### PR TITLE
fix: add export array method to queue writer

### DIFF
--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -132,7 +132,6 @@ class QueuedWriter
             if ($rows instanceof Traversable) {
                 $rows = iterator_to_array($rows);
             }
-
             return new AppendDataToSheet(
                 $export,
                 $temporaryFile,

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -111,11 +111,11 @@ class QueuedWriter
 
     /**
      * 
-     * @param FromArray $export 
-     * @param TemporaryFile $temporaryFile 
-     * @param string $writerType 
-     * @param int $sheetIndex 
-     * @return array 
+     * @param  FromArray  $export
+     * @param  TemporaryFile  $temporaryFile
+     * @param  string  $writerType
+     * @param  int  $sheetIndex
+     * @return array
      */
     private function exportArray(
         FromArray $export,

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -5,6 +5,7 @@ namespace Maatwebsite\Excel;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
+use Maatwebsite\Excel\Concerns\FromArray;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\FromQuery;
 use Maatwebsite\Excel\Concerns\FromView;
@@ -98,12 +99,48 @@ class QueuedWriter
                 $jobs = $jobs->merge($this->exportQuery($sheetExport, $temporaryFile, $writerType, $sheetIndex));
             } elseif ($sheetExport instanceof FromView) {
                 $jobs = $jobs->merge($this->exportView($sheetExport, $temporaryFile, $writerType, $sheetIndex));
+            } elseif ($sheetExport instanceof FromArray) {
+                $jobs = $jobs->merge($this->exportArray($sheetExport, $temporaryFile, $writerType, $sheetIndex));
             }
 
             $jobs->push(new CloseSheet($sheetExport, $temporaryFile, $writerType, $sheetIndex));
         }
 
         return $jobs;
+    }
+
+    /**
+     * 
+     * @param FromArray $export 
+     * @param TemporaryFile $temporaryFile 
+     * @param string $writerType 
+     * @param int $sheetIndex 
+     * @return array 
+     */
+    private function exportArray(
+        FromArray $export,
+        TemporaryFile $temporaryFile,
+        string $writerType,
+        int $sheetIndex
+    ): array {
+        $payload =  array_chunk(
+            $export->array(),
+            $this->getChunkSize($export)
+        );
+
+        return array_map(function ($rows) use ($export, $temporaryFile, $writerType, $sheetIndex) {
+            if ($rows instanceof Traversable) {
+                $rows = iterator_to_array($rows);
+            }
+
+            return new AppendDataToSheet(
+                $export,
+                $temporaryFile,
+                $writerType,
+                $sheetIndex,
+                $rows
+            );
+        }, $payload);
     }
 
     /**

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -110,7 +110,6 @@ class QueuedWriter
     }
 
     /**
-     * 
      * @param  FromArray  $export
      * @param  TemporaryFile  $temporaryFile
      * @param  string  $writerType
@@ -132,6 +131,7 @@ class QueuedWriter
             if ($rows instanceof Traversable) {
                 $rows = iterator_to_array($rows);
             }
+
             return new AppendDataToSheet(
                 $export,
                 $temporaryFile,

--- a/tests/Data/Stubs/FromArrayQueuedExport.php
+++ b/tests/Data/Stubs/FromArrayQueuedExport.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+
+class FromArrayQueuedExport implements WithMultipleSheets
+{
+    use Exportable;
+
+    /**
+     * @return SheetWith100RowsFromArray[]
+     */
+    public function sheets(): array
+    {
+        return [
+            new SheetWith100RowsFromArray('A'),
+            new SheetWith100RowsFromArray('B'),
+            new SheetWith100RowsFromArray('C'),
+        ];
+    }
+}

--- a/tests/Data/Stubs/FromArrayQueuedExport.php
+++ b/tests/Data/Stubs/FromArrayQueuedExport.php
@@ -2,7 +2,6 @@
 
 namespace Maatwebsite\Excel\Tests\Data\Stubs;
 
-
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 

--- a/tests/Data/Stubs/SheetWith100RowsFromArray.php
+++ b/tests/Data/Stubs/SheetWith100RowsFromArray.php
@@ -43,6 +43,7 @@ class SheetWith100RowsFromArray implements FromArray, WithTitle, ShouldAutoSize,
 
             array_push($array, $row);
         }
+
         return $array;
     }
 

--- a/tests/Data/Stubs/SheetWith100RowsFromArray.php
+++ b/tests/Data/Stubs/SheetWith100RowsFromArray.php
@@ -43,9 +43,8 @@ class SheetWith100RowsFromArray implements FromArray, WithTitle, ShouldAutoSize,
                 $row[] = $this->title() . '-' . $i . '-' . $j;
             }
 
-            array_push($row, $array);
+            array_push($array, $row);
         }
-
         return $array;
     }
 

--- a/tests/Data/Stubs/SheetWith100RowsFromArray.php
+++ b/tests/Data/Stubs/SheetWith100RowsFromArray.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\RegistersEventListeners;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Concerns\WithTitle;
+use Maatwebsite\Excel\Events\BeforeWriting;
+use Maatwebsite\Excel\Tests\TestCase;
+use Maatwebsite\Excel\Writer;
+
+class SheetWith100RowsFromArray implements FromArray, WithTitle, ShouldAutoSize, WithEvents
+{
+    use Exportable, RegistersEventListeners;
+
+    /**
+     * @var string
+     */
+    private $title;
+
+    /**
+     * @param  string  $title
+     */
+    public function __construct(string $title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * @return array
+     */
+    public function array(): array
+    {
+        $array = [];
+        for ($i = 0; $i < 100; $i++) {
+            $row = [];
+            for ($j = 0; $j < 5; $j++) {
+                $row[] = $this->title() . '-' . $i . '-' . $j;
+            }
+
+            array_push($row, $array);
+        }
+
+        return $array;
+    }
+
+    /**
+     * @return string
+     */
+    public function title(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param  BeforeWriting  $event
+     */
+    public static function beforeWriting(BeforeWriting $event)
+    {
+        TestCase::assertInstanceOf(Writer::class, $event->writer);
+    }
+}

--- a/tests/Data/Stubs/SheetWith100RowsFromArray.php
+++ b/tests/Data/Stubs/SheetWith100RowsFromArray.php
@@ -2,10 +2,8 @@
 
 namespace Maatwebsite\Excel\Tests\Data\Stubs;
 
-use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromArray;
-use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\RegistersEventListeners;
 use Maatwebsite\Excel\Concerns\ShouldAutoSize;
 use Maatwebsite\Excel\Concerns\WithEvents;

--- a/tests/Data/Stubs/ShouldQueuedArrayExport.php
+++ b/tests/Data/Stubs/ShouldQueuedArrayExport.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+
+class ShouldQueuedArrayExport implements WithMultipleSheets, ShouldQueue
+{
+    use Exportable;
+
+    /**
+     * @return SheetWith100RowsFromArray[]
+     */
+    public function sheets(): array
+    {
+        return [
+            new SheetWith100RowsFromArray('A'),
+            new SheetWith100RowsFromArray('B'),
+            new SheetWith100RowsFromArray('C'),
+        ];
+    }
+}

--- a/tests/QueuedExportTest.php
+++ b/tests/QueuedExportTest.php
@@ -11,15 +11,28 @@ use Maatwebsite\Excel\Files\TemporaryFile;
 use Maatwebsite\Excel\Jobs\AppendDataToSheet;
 use Maatwebsite\Excel\Tests\Data\Stubs\AfterQueueExportJob;
 use Maatwebsite\Excel\Tests\Data\Stubs\EloquentCollectionWithMappingExport;
+use Maatwebsite\Excel\Tests\Data\Stubs\FromArrayQueuedExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExport;
+use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportFromArray;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportWithFailedEvents;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportWithFailedHook;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportWithLocalePreferences;
+use Maatwebsite\Excel\Tests\Data\Stubs\ShouldQueuedArrayExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\ShouldQueueExport;
 use Throwable;
 
 class QueuedExportTest extends TestCase
 {
+
+    public function test_can_queue_an_export_using_from_array()
+    {
+        $export = new FromArrayQueuedExport();
+
+        $export->queue('queued-export.xlsx')->chain([
+            new AfterQueueExportJob(__DIR__ . '/Data/Disks/Local/queued-export.xlsx'),
+        ]);
+    }
+
     public function test_can_queue_an_export()
     {
         $export = new QueuedExport();
@@ -94,6 +107,15 @@ class QueuedExportTest extends TestCase
     public function test_can_implicitly_queue_an_export()
     {
         $export = new ShouldQueueExport();
+
+        $export->store('queued-export.xlsx', 'test')->chain([
+            new AfterQueueExportJob(__DIR__ . '/Data/Disks/Test/queued-export.xlsx'),
+        ]);
+    }
+
+    public function test_can_implicitly_queue_an_export_using_from_array()
+    {
+        $export = new ShouldQueuedArrayExport();
 
         $export->store('queued-export.xlsx', 'test')->chain([
             new AfterQueueExportJob(__DIR__ . '/Data/Disks/Test/queued-export.xlsx'),

--- a/tests/QueuedExportTest.php
+++ b/tests/QueuedExportTest.php
@@ -22,7 +22,6 @@ use Throwable;
 
 class QueuedExportTest extends TestCase
 {
-
     public function test_can_queue_an_export_using_from_array()
     {
         $export = new FromArrayQueuedExport();

--- a/tests/QueuedExportTest.php
+++ b/tests/QueuedExportTest.php
@@ -13,7 +13,6 @@ use Maatwebsite\Excel\Tests\Data\Stubs\AfterQueueExportJob;
 use Maatwebsite\Excel\Tests\Data\Stubs\EloquentCollectionWithMappingExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromArrayQueuedExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExport;
-use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportFromArray;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportWithFailedEvents;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportWithFailedHook;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportWithLocalePreferences;


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?
  It resolves the issue #4317. It allows the export do be queued when using the FromArray interface.
2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No, it's a single change.
3️⃣  Does it include tests, if possible?
Yes
4️⃣  Any drawbacks? Possible breaking changes?
No
5️⃣  Mark the following tasks as done:

- [ x ] Checked the codebase to ensure that your feature doesn't already exist.
- [ x ] Take note of the contributing guidelines.
- [ x ] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ x ] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
