### PR TITLE
[BUG] : Queued exports drop root-level concerns

### DIFF
--- a/src/Jobs/AppendDataToSheet.php
+++ b/src/Jobs/AppendDataToSheet.php
@@ -23,6 +23,7 @@ class AppendDataToSheet implements ShouldQueue
         public int $sheetIndex,
         /** @var array<array-key, mixed> */
         public array $data,
+        public ?object $export = null,
     ) {
     }
 
@@ -54,7 +55,7 @@ class AppendDataToSheet implements ShouldQueue
 
             $sheet->appendRows($this->data, $this->sheetExport);
 
-            $writer->write($this->sheetExport, $this->temporaryFile, $this->writerType);
+            $writer->write($this->export ?? $this->sheetExport, $this->temporaryFile, $this->writerType);
         });
     }
 }

--- a/src/Jobs/AppendPaginatedToSheet.php
+++ b/src/Jobs/AppendPaginatedToSheet.php
@@ -25,6 +25,7 @@ class AppendPaginatedToSheet implements ShouldQueue
         public int $sheetIndex,
         public int $page,
         public int $perPage,
+        public ?object $export = null,
     ) {
     }
 
@@ -56,7 +57,7 @@ class AppendPaginatedToSheet implements ShouldQueue
 
             $sheet->appendRows($this->chunk(), $this->sheetExport);
 
-            $writer->write($this->sheetExport, $this->temporaryFile, $this->writerType);
+            $writer->write($this->export ?? $this->sheetExport, $this->temporaryFile, $this->writerType);
         });
     }
 

--- a/src/Jobs/AppendQueryToSheet.php
+++ b/src/Jobs/AppendQueryToSheet.php
@@ -27,6 +27,7 @@ class AppendQueryToSheet implements ShouldQueue
         public int $sheetIndex,
         public int $page,
         public int $chunkSize,
+        public ?object $export = null,
     ) {
     }
 
@@ -64,7 +65,7 @@ class AppendQueryToSheet implements ShouldQueue
 
             $sheet->appendRows($query->get(), $this->sheetExport);
 
-            $writer->write($this->sheetExport, $this->temporaryFile, $this->writerType);
+            $writer->write($this->export ?? $this->sheetExport, $this->temporaryFile, $this->writerType);
 
             $this->raise(new AfterChunk($sheet, $this->sheetExport, ($this->page - 1) * $this->chunkSize));
             $this->clearListeners();

--- a/src/Jobs/AppendViewToSheet.php
+++ b/src/Jobs/AppendViewToSheet.php
@@ -22,6 +22,7 @@ class AppendViewToSheet implements ShouldQueue
         public TemporaryFile $temporaryFile,
         public string $writerType,
         public int $sheetIndex,
+        public ?object $export = null,
     ) {
     }
 
@@ -53,7 +54,7 @@ class AppendViewToSheet implements ShouldQueue
 
             $sheet->fromView($this->sheetExport, $this->sheetIndex);
 
-            $writer->write($this->sheetExport, $this->temporaryFile, $this->writerType);
+            $writer->write($this->export ?? $this->sheetExport, $this->temporaryFile, $this->writerType);
         });
     }
 }

--- a/src/Jobs/CloseSheet.php
+++ b/src/Jobs/CloseSheet.php
@@ -21,6 +21,7 @@ class CloseSheet implements ShouldQueue
         private TemporaryFile $temporaryFile,
         private string $writerType,
         private int $sheetIndex,
+        private ?object $export = null,
     ) {
     }
 
@@ -49,7 +50,7 @@ class CloseSheet implements ShouldQueue
         $sheet->close($this->sheetExport);
 
         $writer->write(
-            $this->sheetExport,
+            $this->export ?? $this->sheetExport,
             $this->temporaryFile,
             $this->writerType
         );

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -81,43 +81,45 @@ class QueuedWriter
         $jobs = new Collection;
         foreach ($sheetExports as $sheetIndex => $sheetExport) {
             if ($sheetExport instanceof FromCollection) {
-                $jobs = $jobs->merge($this->exportCollection($sheetExport, $temporaryFile, $writerType, $sheetIndex));
+                $jobs = $jobs->merge($this->exportCollection($sheetExport, $temporaryFile, $writerType, $sheetIndex, $export));
             } elseif ($sheetExport instanceof FromQuery) {
-                $jobs = $jobs->merge($this->exportQuery($sheetExport, $temporaryFile, $writerType, $sheetIndex));
+                $jobs = $jobs->merge($this->exportQuery($sheetExport, $temporaryFile, $writerType, $sheetIndex, $export));
             } elseif ($sheetExport instanceof FromScout) {
-                $jobs = $jobs->merge($this->exportScout($sheetExport, $temporaryFile, $writerType, $sheetIndex));
+                $jobs = $jobs->merge($this->exportScout($sheetExport, $temporaryFile, $writerType, $sheetIndex, $export));
             } elseif ($sheetExport instanceof FromView) {
-                $jobs = $jobs->merge($this->exportView($sheetExport, $temporaryFile, $writerType, $sheetIndex));
+                $jobs = $jobs->merge($this->exportView($sheetExport, $temporaryFile, $writerType, $sheetIndex, $export));
             }
 
-            $jobs->push(new CloseSheet($sheetExport, $temporaryFile, $writerType, $sheetIndex));
+            $jobs->push(new CloseSheet($sheetExport, $temporaryFile, $writerType, $sheetIndex, $export));
         }
 
         return $jobs;
     }
 
     /**
-     * @param  FromCollection<array-key, mixed>  $export
+     * @param  FromCollection<array-key, mixed>  $sheetExport
      * @return Enumerable<int, AppendDataToSheet>
      */
     private function exportCollection(
-        FromCollection $export,
+        FromCollection $sheetExport,
         TemporaryFile $temporaryFile,
         string $writerType,
-        int $sheetIndex
+        int $sheetIndex,
+        object $export
     ): Enumerable {
-        return $export
+        return $sheetExport
             ->collection()
-            ->chunk($this->getChunkSize($export))
-            ->map(function ($rows) use ($writerType, $temporaryFile, $sheetIndex, $export): AppendDataToSheet {
+            ->chunk($this->getChunkSize($sheetExport))
+            ->map(function ($rows) use ($writerType, $temporaryFile, $sheetIndex, $sheetExport, $export): AppendDataToSheet {
                 $rows = iterator_to_array($rows);
 
                 return new AppendDataToSheet(
-                    $export,
+                    $sheetExport,
                     $temporaryFile,
                     $writerType,
                     $sheetIndex,
-                    $rows
+                    $rows,
+                    $export
                 );
             });
     }
@@ -126,25 +128,27 @@ class QueuedWriter
      * @return Collection<int, object>
      */
     private function exportQuery(
-        FromQuery $export,
+        FromQuery $sheetExport,
         TemporaryFile $temporaryFile,
         string $writerType,
-        int $sheetIndex
+        int $sheetIndex,
+        object $export
     ): Collection {
-        $query = $export->query();
-        $count = $export instanceof WithCustomQuerySize ? $export->querySize() : $query->count();
-        $spins = ceil($count / $this->getChunkSize($export));
+        $query = $sheetExport->query();
+        $count = $sheetExport instanceof WithCustomQuerySize ? $sheetExport->querySize() : $query->count();
+        $spins = ceil($count / $this->getChunkSize($sheetExport));
 
         $jobs = new Collection;
 
         for ($page = 1; $page <= $spins; $page++) {
             $jobs->push(new AppendQueryToSheet(
-                $export,
+                $sheetExport,
                 $temporaryFile,
                 $writerType,
                 $sheetIndex,
                 $page,
-                $this->getChunkSize($export)
+                $this->getChunkSize($sheetExport),
+                $export
             ));
         }
 
@@ -155,32 +159,35 @@ class QueuedWriter
      * @return Collection<int, object>
      */
     private function exportScout(
-        FromScout $export,
+        FromScout $sheetExport,
         TemporaryFile $temporaryFile,
         string $writerType,
-        int $sheetIndex
+        int $sheetIndex,
+        object $export
     ): Collection {
         $jobs = new Collection;
 
-        $chunk = $export->scout()->paginate($this->getChunkSize($export));
+        $chunk = $sheetExport->scout()->paginate($this->getChunkSize($sheetExport));
         // Append first page
         $jobs->push(new AppendDataToSheet(
-            $export,
+            $sheetExport,
             $temporaryFile,
             $writerType,
             $sheetIndex,
-            $chunk->items()
+            $chunk->items(),
+            $export
         ));
 
         // Append rest of pages
         for ($page = 2; $page <= $chunk->lastPage(); $page++) {
             $jobs->push(new AppendPaginatedToSheet(
-                $export,
+                $sheetExport,
                 $temporaryFile,
                 $writerType,
                 $sheetIndex,
                 $page,
-                $this->getChunkSize($export)
+                $this->getChunkSize($sheetExport),
+                $export
             ));
         }
 
@@ -191,17 +198,19 @@ class QueuedWriter
      * @return Collection<int, object>
      */
     private function exportView(
-        FromView $export,
+        FromView $sheetExport,
         TemporaryFile $temporaryFile,
         string $writerType,
-        int $sheetIndex
+        int $sheetIndex,
+        object $export
     ): Collection {
         $jobs = new Collection;
         $jobs->push(new AppendViewToSheet(
-            $export,
+            $sheetExport,
             $temporaryFile,
             $writerType,
-            $sheetIndex
+            $sheetIndex,
+            $export
         ));
 
         return $jobs;

--- a/tests/Data/Stubs/QueuedExportWithCsvSettings.php
+++ b/tests/Data/Stubs/QueuedExportWithCsvSettings.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\WithCustomCsvSettings;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+
+class QueuedExportWithCsvSettings implements WithCustomCsvSettings, WithMultipleSheets
+{
+    use Exportable;
+
+    /**
+     * @return array<int, SheetWith100Rows>
+     */
+    public function sheets(): array
+    {
+        return [
+            new SheetWith100Rows('Queued Sheet 1'),
+        ];
+    }
+
+    /**
+     * Root-level CSV settings that must survive a queued (multi-sheet) export.
+     *
+     * @return array<string, mixed>
+     */
+    public function getCsvSettings(): array
+    {
+        return [
+            'delimiter' => ';',
+        ];
+    }
+}

--- a/tests/QueuedExportTest.php
+++ b/tests/QueuedExportTest.php
@@ -15,6 +15,7 @@ use Maatwebsite\Excel\Jobs\AppendDataToSheet;
 use Maatwebsite\Excel\Tests\Data\Stubs\AfterQueueExportJob;
 use Maatwebsite\Excel\Tests\Data\Stubs\EloquentCollectionWithMappingExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExport;
+use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportWithCsvSettings;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportWithFailedEvents;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportWithFailedHook;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportWithLocalePreferences;
@@ -182,5 +183,23 @@ final class QueuedExportTest extends TestCase
         $this->assertCount(100, $array);
 
         $this->assertSame('test', Cache::get('test'));
+    }
+
+    public function test_queued_exports_apply_root_level_concerns(): void
+    {
+        // Root-level concerns (here: CSV settings) are applied by the writer at
+        // write() time. In a multi-sheet queued export the per-sheet chunk jobs
+        // must write using the root export, otherwise the root concern is dropped.
+        $export = new QueuedExportWithCsvSettings;
+
+        $path = __DIR__ . '/Data/Disks/Local/queued-export-with-csv-settings.csv';
+
+        $export->queue('queued-export-with-csv-settings.csv', null, Excel::CSV)->chain([
+            new AfterQueueExportJob($path),
+        ]);
+
+        $firstLine = strtok((string) file_get_contents($path), "\n");
+
+        $this->assertStringContainsString(';', (string) $firstLine, 'Root custom CSV delimiter should survive a queued export');
     }
 }


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?
- Aligns queued exports with synchronous behaviour so root-level concerns (properties, events, CSV settings) are preserved.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
- No — focused only on this issue.

3️⃣  Does it include tests, if possible?
- Yes (`QueuedExportTest::test_queued_exports_apply_root_concerns`).

4️⃣  Any drawbacks? Possible breaking changes?
- None expected; restores missing functionality.

5️⃣  Mark the following tasks as done:

- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌

Related Issue: https://github.com/SpartnerNL/Laravel-Excel/issues/4328
