### PR TITLE
4.x: Initialize rector, apply targeted rule sets up to minimum currently supported php version (8.3)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -145,3 +145,39 @@ jobs:
         run: vendor/bin/phpunit --testdox --configuration phpunit.xml.dist
         env:
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
+
+  rector:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    runs-on: ubuntu-latest
+    name: Rector
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache/files
+          key: dependency-cache-rector-composer-${{ hashFiles('composer.json') }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction
+
+      - name: Rector Cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/rector
+          key: ${{ runner.os }}-rector-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-rector-
+
+      - run: mkdir -p /tmp/rector
+
+      - name: Rector Dry Run
+        run: php vendor/bin/rector process --dry-run --config=rector.php

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.3
           coverage: none
 
       - name: Install dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -77,10 +77,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.composer/cache/files
           key: dependency-cache-rector-composer-${{ hashFiles('composer.json') }}
@@ -95,7 +95,7 @@ jobs:
         run: composer install --no-interaction
 
       - name: Rector Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/rector
           key: ${{ runner.os }}-rector-${{ github.run_id }}

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
   "require-dev": {
     "orchestra/testbench": "^9.0||^10.0||^11.0",
     "predis/predis": "^1.1",
-    "laravel/scout": "^10.0||^11.0"
+    "laravel/scout": "^10.0||^11.0",
+    "rector/rector": "^2.4.2"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     "orchestra/testbench": "^10.0||^11.0",
     "predis/predis": "^1.1",
     "laravel/scout": "^10.0||^11.0",
-    "rector/rector": "^2.4.2"
+    "rector/rector": "^2.4.2",
+    "driftingly/rector-laravel": "^2.3"
   },
   "autoload": {
     "psr-4": {

--- a/rector.php
+++ b/rector.php
@@ -7,6 +7,7 @@ use Rector\Config\RectorConfig;
 use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector;
+use RectorLaravel\Set\LaravelLevelSetList;
 
 return RectorConfig::configure()
     ->withCache(
@@ -19,6 +20,9 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
     ])
     ->withPhpSets()
+    ->withSets([
+        LaravelLevelSetList::UP_TO_LARAVEL_120,
+    ])
     ->withSkip([
         ReadOnlyPropertyRector::class,
         ReturnNeverTypeRector::class,

--- a/rector.php
+++ b/rector.php
@@ -14,9 +14,9 @@ return RectorConfig::configure()
         cacheClass: FileCacheStorage::class,
     )
     ->withPaths([
-        __DIR__.'/config',
-        __DIR__.'/src',
-        __DIR__.'/tests',
+        __DIR__ . '/config',
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
     ])
     ->withPhpSets()
     ->withSkip([

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Caching\ValueObject\Storage\FileCacheStorage;
+use Rector\Config\RectorConfig;
+use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
+use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector;
+
+return RectorConfig::configure()
+    ->withCache(
+        cacheDirectory: '/tmp/rector',
+        cacheClass: FileCacheStorage::class,
+    )
+    ->withPaths([
+        __DIR__.'/config',
+        __DIR__.'/src',
+        __DIR__.'/tests',
+    ])
+    ->withPhpSets()
+    ->withSkip([
+        ReadOnlyPropertyRector::class,
+        ReturnNeverTypeRector::class,
+        RandomFunctionRector::class,
+    ]);

--- a/src/Cell.php
+++ b/src/Cell.php
@@ -56,7 +56,7 @@ class Cell
             } elseif ($calculateFormulas) {
                 try {
                     $value = $this->cell->getCalculatedValue();
-                } catch (Exception $e) {
+                } catch (Exception) {
                     $value = $this->cell->getOldCalculatedValue();
                 }
             } else {

--- a/src/Cell.php
+++ b/src/Cell.php
@@ -15,16 +15,10 @@ class Cell
     use DelegatedMacroable;
 
     /**
-     * @var SpreadsheetCell
-     */
-    private $cell;
-
-    /**
      * @param  SpreadsheetCell  $cell
      */
-    public function __construct(SpreadsheetCell $cell)
+    public function __construct(private SpreadsheetCell $cell)
     {
-        $this->cell = $cell;
     }
 
     /**

--- a/src/ChunkReader.php
+++ b/src/ChunkReader.php
@@ -113,9 +113,7 @@ class ChunkReader
 
         $jobs->each(function ($job) {
             try {
-                function_exists('dispatch_now')
-                    ? dispatch_now($job)
-                    : $this->dispatchNow($job);
+                $this->dispatchNow($job);
             } catch (Throwable $e) {
                 if (method_exists($job, 'failed')) {
                     $job->failed($e);

--- a/src/Concerns/Exportable.php
+++ b/src/Concerns/Exportable.php
@@ -19,9 +19,9 @@ trait Exportable
      */
     public function download(?string $fileName = null, ?string $writerType = null, ?array $headers = null)
     {
-        $headers    = $headers ?? $this->headers ?? [];
-        $fileName   = $fileName ?? $this->fileName ?? null;
-        $writerType = $writerType ?? $this->writerType ?? null;
+        $headers ??= $this->headers ?? [];
+        $fileName ??= $this->fileName ?? null;
+        $writerType ??= $this->writerType ?? null;
 
         if (null === $fileName) {
             throw new NoFilenameGivenException();
@@ -41,7 +41,7 @@ trait Exportable
      */
     public function store(?string $filePath = null, ?string $disk = null, ?string $writerType = null, $diskOptions = [])
     {
-        $filePath = $filePath ?? $this->filePath ?? null;
+        $filePath ??= $this->filePath ?? null;
 
         if (null === $filePath) {
             throw NoFilePathGivenException::export();
@@ -67,7 +67,7 @@ trait Exportable
      */
     public function queue(?string $filePath = null, ?string $disk = null, ?string $writerType = null, $diskOptions = [])
     {
-        $filePath = $filePath ?? $this->filePath ?? null;
+        $filePath ??= $this->filePath ?? null;
 
         if (null === $filePath) {
             throw NoFilePathGivenException::export();
@@ -88,7 +88,7 @@ trait Exportable
      */
     public function raw($writerType = null)
     {
-        $writerType = $writerType ?? $this->writerType ?? null;
+        $writerType ??= $this->writerType ?? null;
 
         return $this->getExporter()->raw($this, $writerType);
     }

--- a/src/Concerns/Importable.php
+++ b/src/Concerns/Importable.php
@@ -129,7 +129,7 @@ trait Importable
      */
     private function getFilePath($filePath = null)
     {
-        $filePath = $filePath ?? $this->filePath ?? null;
+        $filePath ??= $this->filePath ?? null;
 
         if (null === $filePath) {
             throw NoFilePathGivenException::import();

--- a/src/Concerns/WithConditionalSheets.php
+++ b/src/Concerns/WithConditionalSheets.php
@@ -25,9 +25,7 @@ trait WithConditionalSheets
      */
     public function sheets(): array
     {
-        return \array_filter($this->conditionalSheets(), function ($name) {
-            return \in_array($name, $this->conditionallySelectedSheets, false);
-        }, ARRAY_FILTER_USE_KEY);
+        return \array_filter($this->conditionalSheets(), fn($name) => \in_array($name, $this->conditionallySelectedSheets, false), ARRAY_FILTER_USE_KEY);
     }
 
     /**

--- a/src/Concerns/WithConditionalSheets.php
+++ b/src/Concerns/WithConditionalSheets.php
@@ -25,7 +25,7 @@ trait WithConditionalSheets
      */
     public function sheets(): array
     {
-        return \array_filter($this->conditionalSheets(), fn($name) => \in_array($name, $this->conditionallySelectedSheets, false), ARRAY_FILTER_USE_KEY);
+        return \array_filter($this->conditionalSheets(), fn ($name) => \in_array($name, $this->conditionallySelectedSheets, false), ARRAY_FILTER_USE_KEY);
     }
 
     /**

--- a/src/Console/ExportMakeCommand.php
+++ b/src/Console/ExportMakeCommand.php
@@ -54,6 +54,7 @@ class ExportMakeCommand extends GeneratorCommand
      * @param  string  $rootNamespace
      * @return string
      */
+    #[\Override]
     protected function getDefaultNamespace($rootNamespace)
     {
         return $rootNamespace . '\Exports';
@@ -66,6 +67,7 @@ class ExportMakeCommand extends GeneratorCommand
      * @param  string  $name
      * @return string
      */
+    #[\Override]
     protected function buildClass($name)
     {
         $replace = [];
@@ -83,6 +85,7 @@ class ExportMakeCommand extends GeneratorCommand
      *
      * @return array
      */
+    #[\Override]
     protected function getOptions()
     {
         return [

--- a/src/Console/ImportMakeCommand.php
+++ b/src/Console/ImportMakeCommand.php
@@ -48,6 +48,7 @@ class ImportMakeCommand extends GeneratorCommand
      * @param  string  $rootNamespace
      * @return string
      */
+    #[\Override]
     protected function getDefaultNamespace($rootNamespace)
     {
         return $rootNamespace . '\Imports';
@@ -60,6 +61,7 @@ class ImportMakeCommand extends GeneratorCommand
      * @param  string  $name
      * @return string
      */
+    #[\Override]
     protected function buildClass($name)
     {
         $replace = [];
@@ -77,6 +79,7 @@ class ImportMakeCommand extends GeneratorCommand
      *
      * @return array
      */
+    #[\Override]
     protected function getOptions()
     {
         return [

--- a/src/DefaultValueBinder.php
+++ b/src/DefaultValueBinder.php
@@ -12,6 +12,7 @@ class DefaultValueBinder extends PhpSpreadsheetDefaultValueBinder
      * @param  mixed  $value  Value to bind in cell
      * @return bool
      */
+    #[\Override]
     public function bindValue(Cell $cell, mixed $value): bool
     {
         if (is_array($value)) {

--- a/src/Events/AfterBatch.php
+++ b/src/Events/AfterBatch.php
@@ -12,26 +12,14 @@ class AfterBatch extends Event
     public $manager;
 
     /**
-     * @var int
-     */
-    private $batchSize;
-
-    /**
-     * @var int
-     */
-    private $startRow;
-
-    /**
      * @param  ModelManager  $manager
      * @param  object  $importable
      * @param  int  $batchSize
      * @param  int  $startRow
      */
-    public function __construct(ModelManager $manager, $importable, int $batchSize, int $startRow)
+    public function __construct(ModelManager $manager, $importable, private int $batchSize, private int $startRow)
     {
         $this->manager   = $manager;
-        $this->batchSize = $batchSize;
-        $this->startRow  = $startRow;
         parent::__construct($importable);
     }
 

--- a/src/Events/AfterChunk.php
+++ b/src/Events/AfterChunk.php
@@ -6,20 +6,8 @@ use Maatwebsite\Excel\Sheet;
 
 class AfterChunk extends Event
 {
-    /**
-     * @var Sheet
-     */
-    private $sheet;
-
-    /**
-     * @var int
-     */
-    private $startRow;
-
-    public function __construct(Sheet $sheet, $importable, int $startRow)
+    public function __construct(private Sheet $sheet, $importable, private int $startRow)
     {
-        $this->sheet     = $sheet;
-        $this->startRow  = $startRow;
         parent::__construct($importable);
     }
 

--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -8,16 +8,10 @@ namespace Maatwebsite\Excel\Events;
 abstract class Event
 {
     /**
-     * @var object
-     */
-    protected $concernable;
-
-    /**
      * @param  object  $concernable
      */
-    public function __construct($concernable)
+    public function __construct(protected $concernable)
     {
-        $this->concernable = $concernable;
     }
 
     /**

--- a/src/Excel.php
+++ b/src/Excel.php
@@ -55,11 +55,6 @@ class Excel implements Exporter, Importer
     protected $filesystem;
 
     /**
-     * @var Reader
-     */
-    private $reader;
-
-    /**
      * @param  Writer  $writer
      * @param  QueuedWriter  $queuedWriter
      * @param  Reader  $reader
@@ -68,11 +63,10 @@ class Excel implements Exporter, Importer
     public function __construct(
         Writer $writer,
         QueuedWriter $queuedWriter,
-        Reader $reader,
+        private Reader $reader,
         Filesystem $filesystem
     ) {
         $this->writer       = $writer;
-        $this->reader       = $reader;
         $this->filesystem   = $filesystem;
         $this->queuedWriter = $queuedWriter;
     }

--- a/src/ExcelServiceProvider.php
+++ b/src/ExcelServiceProvider.php
@@ -67,20 +67,20 @@ class ExcelServiceProvider extends ServiceProvider
             'excel'
         );
 
-        $this->app->bind(CacheManager::class, fn($app) => new CacheManager($app));
+        $this->app->bind(CacheManager::class, fn ($app) => new CacheManager($app));
 
-        $this->app->singleton(TransactionManager::class, fn($app) => new TransactionManager($app));
+        $this->app->singleton(TransactionManager::class, fn ($app) => new TransactionManager($app));
 
-        $this->app->bind(TransactionHandler::class, fn($app) => $app->make(TransactionManager::class)->driver());
+        $this->app->bind(TransactionHandler::class, fn ($app) => $app->make(TransactionManager::class)->driver());
 
-        $this->app->bind(TemporaryFileFactory::class, fn() => new TemporaryFileFactory(
+        $this->app->bind(TemporaryFileFactory::class, fn () => new TemporaryFileFactory(
             config('excel.temporary_files.local_path', config('excel.exports.temp_path', storage_path('framework/laravel-excel'))),
             config('excel.temporary_files.remote_disk')
         ));
 
-        $this->app->bind(Filesystem::class, fn($app) => new Filesystem($app->make('filesystem')));
+        $this->app->bind(Filesystem::class, fn ($app) => new Filesystem($app->make('filesystem')));
 
-        $this->app->bind('excel', fn($app) => new Excel(
+        $this->app->bind('excel', fn ($app) => new Excel(
             $app->make(Writer::class),
             $app->make(QueuedWriter::class),
             $app->make(Reader::class),

--- a/src/ExcelServiceProvider.php
+++ b/src/ExcelServiceProvider.php
@@ -60,6 +60,7 @@ class ExcelServiceProvider extends ServiceProvider
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function register()
     {
         $this->mergeConfigFrom(

--- a/src/ExcelServiceProvider.php
+++ b/src/ExcelServiceProvider.php
@@ -67,37 +67,25 @@ class ExcelServiceProvider extends ServiceProvider
             'excel'
         );
 
-        $this->app->bind(CacheManager::class, function ($app) {
-            return new CacheManager($app);
-        });
+        $this->app->bind(CacheManager::class, fn($app) => new CacheManager($app));
 
-        $this->app->singleton(TransactionManager::class, function ($app) {
-            return new TransactionManager($app);
-        });
+        $this->app->singleton(TransactionManager::class, fn($app) => new TransactionManager($app));
 
-        $this->app->bind(TransactionHandler::class, function ($app) {
-            return $app->make(TransactionManager::class)->driver();
-        });
+        $this->app->bind(TransactionHandler::class, fn($app) => $app->make(TransactionManager::class)->driver());
 
-        $this->app->bind(TemporaryFileFactory::class, function () {
-            return new TemporaryFileFactory(
-                config('excel.temporary_files.local_path', config('excel.exports.temp_path', storage_path('framework/laravel-excel'))),
-                config('excel.temporary_files.remote_disk')
-            );
-        });
+        $this->app->bind(TemporaryFileFactory::class, fn() => new TemporaryFileFactory(
+            config('excel.temporary_files.local_path', config('excel.exports.temp_path', storage_path('framework/laravel-excel'))),
+            config('excel.temporary_files.remote_disk')
+        ));
 
-        $this->app->bind(Filesystem::class, function ($app) {
-            return new Filesystem($app->make('filesystem'));
-        });
+        $this->app->bind(Filesystem::class, fn($app) => new Filesystem($app->make('filesystem')));
 
-        $this->app->bind('excel', function ($app) {
-            return new Excel(
-                $app->make(Writer::class),
-                $app->make(QueuedWriter::class),
-                $app->make(Reader::class),
-                $app->make(Filesystem::class)
-            );
-        });
+        $this->app->bind('excel', fn($app) => new Excel(
+            $app->make(Writer::class),
+            $app->make(QueuedWriter::class),
+            $app->make(Reader::class),
+            $app->make(Filesystem::class)
+        ));
 
         $this->app->alias('excel', Excel::class);
         $this->app->alias('excel', Exporter::class);

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -243,7 +243,7 @@ class ExcelFake implements Exporter, Importer
     {
         $fileName = $this->assertArrayHasKey($fileName, $this->downloads, sprintf('%s is not downloaded', $fileName));
 
-        $callback = $callback ?: (fn() => true);
+        $callback = $callback ?: (fn () => true);
 
         Assert::assertTrue(
             $callback($this->downloads[$fileName]),
@@ -272,7 +272,7 @@ class ExcelFake implements Exporter, Importer
             sprintf('%s is not stored on disk %s', $filePath, $disk)
         );
 
-        $callback = $callback ?: (fn() => true);
+        $callback = $callback ?: (fn () => true);
 
         Assert::assertTrue(
             $callback($storedOnDisk[$filePath]),
@@ -301,7 +301,7 @@ class ExcelFake implements Exporter, Importer
             sprintf('%s is not queued for export on disk %s', $filePath, $disk)
         );
 
-        $callback = $callback ?: (fn() => true);
+        $callback = $callback ?: (fn () => true);
 
         Assert::assertTrue(
             $callback($queuedForDisk[$filePath]),
@@ -322,7 +322,7 @@ class ExcelFake implements Exporter, Importer
     {
         Assert::assertArrayHasKey($classname, $this->raws, sprintf('%s is not exported in raw', $classname));
 
-        $callback = $callback ?: (fn() => true);
+        $callback = $callback ?: (fn () => true);
 
         Assert::assertTrue(
             $callback($this->raws[$classname]),
@@ -351,7 +351,7 @@ class ExcelFake implements Exporter, Importer
             sprintf('%s is not stored on disk %s', $filePath, $disk)
         );
 
-        $callback = $callback ?: (fn() => true);
+        $callback = $callback ?: (fn () => true);
 
         Assert::assertTrue(
             $callback($importedOnDisk[$filePath]),

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -120,7 +120,7 @@ class ExcelFake implements Exporter, Importer
      */
     public function raw($export, string $writerType)
     {
-        $this->raws[get_class($export)] = $export;
+        $this->raws[$export::class] = $export;
 
         return 'RAW-CONTENTS';
     }
@@ -311,7 +311,7 @@ class ExcelFake implements Exporter, Importer
 
     public function assertQueuedWithChain($chain): void
     {
-        Queue::assertPushedWithChain(get_class($this->job), $chain);
+        Queue::assertPushedWithChain($this->job::class, $chain);
     }
 
     /**

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -263,7 +263,7 @@ class ExcelFake implements Exporter, Importer
             $disk     = null;
         }
 
-        $disk         = $disk ?? 'default';
+        $disk ??= 'default';
         $storedOnDisk = $this->stored[$disk] ?? [];
 
         $filePath = $this->assertArrayHasKey(
@@ -292,7 +292,7 @@ class ExcelFake implements Exporter, Importer
             $disk     = null;
         }
 
-        $disk          = $disk ?? 'default';
+        $disk ??= 'default';
         $queuedForDisk = $this->queued[$disk] ?? [];
 
         $filePath = $this->assertArrayHasKey(
@@ -342,7 +342,7 @@ class ExcelFake implements Exporter, Importer
             $disk     = null;
         }
 
-        $disk           = $disk ?? 'default';
+        $disk ??= 'default';
         $importedOnDisk = $this->imported[$disk] ?? [];
 
         $filePath = $this->assertArrayHasKey(

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -243,9 +243,7 @@ class ExcelFake implements Exporter, Importer
     {
         $fileName = $this->assertArrayHasKey($fileName, $this->downloads, sprintf('%s is not downloaded', $fileName));
 
-        $callback = $callback ?: function () {
-            return true;
-        };
+        $callback = $callback ?: (fn() => true);
 
         Assert::assertTrue(
             $callback($this->downloads[$fileName]),
@@ -274,9 +272,7 @@ class ExcelFake implements Exporter, Importer
             sprintf('%s is not stored on disk %s', $filePath, $disk)
         );
 
-        $callback = $callback ?: function () {
-            return true;
-        };
+        $callback = $callback ?: (fn() => true);
 
         Assert::assertTrue(
             $callback($storedOnDisk[$filePath]),
@@ -305,9 +301,7 @@ class ExcelFake implements Exporter, Importer
             sprintf('%s is not queued for export on disk %s', $filePath, $disk)
         );
 
-        $callback = $callback ?: function () {
-            return true;
-        };
+        $callback = $callback ?: (fn() => true);
 
         Assert::assertTrue(
             $callback($queuedForDisk[$filePath]),
@@ -328,9 +322,7 @@ class ExcelFake implements Exporter, Importer
     {
         Assert::assertArrayHasKey($classname, $this->raws, sprintf('%s is not exported in raw', $classname));
 
-        $callback = $callback ?: function () {
-            return true;
-        };
+        $callback = $callback ?: (fn() => true);
 
         Assert::assertTrue(
             $callback($this->raws[$classname]),
@@ -359,9 +351,7 @@ class ExcelFake implements Exporter, Importer
             sprintf('%s is not stored on disk %s', $filePath, $disk)
         );
 
-        $callback = $callback ?: function () {
-            return true;
-        };
+        $callback = $callback ?: (fn() => true);
 
         Assert::assertTrue(
             $callback($importedOnDisk[$filePath]),

--- a/src/Files/Filesystem.php
+++ b/src/Files/Filesystem.php
@@ -7,16 +7,10 @@ use Illuminate\Contracts\Filesystem\Factory;
 class Filesystem
 {
     /**
-     * @var Factory
-     */
-    private $filesystem;
-
-    /**
      * @param  Factory  $filesystem
      */
-    public function __construct(Factory $filesystem)
+    public function __construct(private Factory $filesystem)
     {
-        $this->filesystem = $filesystem;
     }
 
     /**

--- a/src/Files/RemoteTemporaryFile.php
+++ b/src/Files/RemoteTemporaryFile.php
@@ -74,6 +74,7 @@ class RemoteTemporaryFile extends TemporaryFile
     /**
      * @return TemporaryFile
      */
+    #[\Override]
     public function sync(bool $copy = true): TemporaryFile
     {
         if (!$this->localTemporaryFile->exists()) {

--- a/src/Files/RemoteTemporaryFile.php
+++ b/src/Files/RemoteTemporaryFile.php
@@ -7,37 +7,18 @@ use Illuminate\Support\Arr;
 class RemoteTemporaryFile extends TemporaryFile
 {
     /**
-     * @var string
-     */
-    private $disk;
-
-    /**
      * @var Disk|null
      */
     private $diskInstance;
-
-    /**
-     * @var string
-     */
-    private $filename;
-
-    /**
-     * @var LocalTemporaryFile
-     */
-    private $localTemporaryFile;
 
     /**
      * @param  string  $disk
      * @param  string  $filename
      * @param  LocalTemporaryFile  $localTemporaryFile
      */
-    public function __construct(string $disk, string $filename, LocalTemporaryFile $localTemporaryFile)
+    public function __construct(private string $disk, private string $filename, private LocalTemporaryFile $localTemporaryFile)
     {
-        $this->disk               = $disk;
-        $this->filename           = $filename;
-        $this->localTemporaryFile = $localTemporaryFile;
-
-        $this->disk()->touch($filename);
+        $this->disk()->touch($this->filename);
     }
 
     public function __sleep()

--- a/src/Files/TemporaryFileFactory.php
+++ b/src/Files/TemporaryFileFactory.php
@@ -7,23 +7,11 @@ use Illuminate\Support\Str;
 class TemporaryFileFactory
 {
     /**
-     * @var string|null
-     */
-    private $temporaryPath;
-
-    /**
-     * @var string|null
-     */
-    private $temporaryDisk;
-
-    /**
      * @param  string|null  $temporaryPath
      * @param  string|null  $temporaryDisk
      */
-    public function __construct(?string $temporaryPath = null, ?string $temporaryDisk = null)
+    public function __construct(private ?string $temporaryPath = null, private ?string $temporaryDisk = null)
     {
-        $this->temporaryPath = $temporaryPath;
-        $this->temporaryDisk = $temporaryDisk;
     }
 
     /**

--- a/src/Filters/ChunkReadFilter.php
+++ b/src/Filters/ChunkReadFilter.php
@@ -9,22 +9,7 @@ class ChunkReadFilter implements IReadFilter
     /**
      * @var int
      */
-    private $headingRow;
-
-    /**
-     * @var int
-     */
-    private $startRow;
-
-    /**
-     * @var int
-     */
     private $endRow;
-
-    /**
-     * @var string
-     */
-    private $worksheetName;
 
     /**
      * @param  int  $headingRow
@@ -32,12 +17,9 @@ class ChunkReadFilter implements IReadFilter
      * @param  int  $chunkSize
      * @param  string  $worksheetName
      */
-    public function __construct(int $headingRow, int $startRow, int $chunkSize, string $worksheetName)
+    public function __construct(private int $headingRow, private int $startRow, int $chunkSize, private string $worksheetName)
     {
-        $this->headingRow    = $headingRow;
-        $this->startRow      = $startRow;
-        $this->endRow        = $startRow + $chunkSize;
-        $this->worksheetName = $worksheetName;
+        $this->endRow        = $this->startRow + $chunkSize;
     }
 
     /**

--- a/src/Filters/LimitFilter.php
+++ b/src/Filters/LimitFilter.php
@@ -9,21 +9,15 @@ class LimitFilter implements IReadFilter
     /**
      * @var int
      */
-    private $startRow;
-
-    /**
-     * @var int
-     */
     private $endRow;
 
     /**
      * @param  int  $startRow
      * @param  int  $limit
      */
-    public function __construct(int $startRow, int $limit)
+    public function __construct(private int $startRow, int $limit)
     {
-        $this->startRow = $startRow;
-        $this->endRow   = $startRow + $limit;
+        $this->endRow   = $this->startRow + $limit;
     }
 
     /**

--- a/src/HasEventBus.php
+++ b/src/HasEventBus.php
@@ -58,7 +58,7 @@ trait HasEventBus
      */
     public function listeners($event): array
     {
-        $name = \get_class($event);
+        $name = $event::class;
 
         $localListeners  = $this->events[$name] ?? [];
         $globalListeners = static::$globalEvents[$name] ?? [];

--- a/src/HeadingRowImport.php
+++ b/src/HeadingRowImport.php
@@ -13,16 +13,10 @@ class HeadingRowImport implements WithStartRow, WithLimit, WithMapping
     use Importable;
 
     /**
-     * @var int
-     */
-    private $headingRow;
-
-    /**
      * @param  int  $headingRow
      */
-    public function __construct(int $headingRow = 1)
+    public function __construct(private int $headingRow = 1)
     {
-        $this->headingRow = $headingRow;
     }
 
     /**

--- a/src/Helpers/ArrayHelper.php
+++ b/src/Helpers/ArrayHelper.php
@@ -26,6 +26,6 @@ class ArrayHelper
      */
     public static function hasMultipleRows(array $array): bool
     {
-        return count($array) === count(array_filter($array, 'is_array'));
+        return count($array) === count(array_filter($array, is_array(...)));
     }
 }

--- a/src/Helpers/FileTypeDetector.php
+++ b/src/Helpers/FileTypeDetector.php
@@ -21,7 +21,7 @@ class FileTypeDetector
         }
 
         if (!$filePath instanceof UploadedFile) {
-            $pathInfo  = pathinfo($filePath);
+            $pathInfo  = pathinfo((string) $filePath);
             $extension = $pathInfo['extension'] ?? '';
         } else {
             $extension = $filePath->getClientOriginalExtension();

--- a/src/Imports/EndRowFinder.php
+++ b/src/Imports/EndRowFinder.php
@@ -26,7 +26,7 @@ class EndRowFinder
 
         // When no start row given,
         // use the first row as start row.
-        $startRow = $startRow ?? 1;
+        $startRow ??= 1;
 
         // Subtract 1 row from the start row, so a limit
         // of 1 row, will have the same start and end row.

--- a/src/Imports/HeadingRowFormatter.php
+++ b/src/Imports/HeadingRowFormatter.php
@@ -80,7 +80,7 @@ class HeadingRowFormatter
      */
     protected static function callFormatter($value, $key=null)
     {
-        static::$formatter = static::$formatter ?? config('excel.imports.heading_row.formatter', self::FORMATTER_SLUG);
+        static::$formatter ??= config('excel.imports.heading_row.formatter', self::FORMATTER_SLUG);
 
         // Call custom formatter
         if (isset(static::$customFormatters[static::$formatter])) {

--- a/src/Imports/HeadingRowFormatter.php
+++ b/src/Imports/HeadingRowFormatter.php
@@ -42,9 +42,7 @@ class HeadingRowFormatter
      */
     public static function format(array $headings): array
     {
-        return (new Collection($headings))->map(function ($value, $key) {
-            return static::callFormatter($value, $key);
-        })->toArray();
+        return (new Collection($headings))->map(fn($value, $key) => static::callFormatter($value, $key))->toArray();
     }
 
     /**

--- a/src/Imports/HeadingRowFormatter.php
+++ b/src/Imports/HeadingRowFormatter.php
@@ -42,7 +42,7 @@ class HeadingRowFormatter
      */
     public static function format(array $headings): array
     {
-        return (new Collection($headings))->map(fn($value, $key) => static::callFormatter($value, $key))->toArray();
+        return (new Collection($headings))->map(fn ($value, $key) => static::callFormatter($value, $key))->toArray();
     }
 
     /**

--- a/src/Imports/ModelImporter.php
+++ b/src/Imports/ModelImporter.php
@@ -22,16 +22,10 @@ class ModelImporter
     use HasEventBus;
 
     /**
-     * @var ModelManager
-     */
-    private $manager;
-
-    /**
      * @param  ModelManager  $manager
      */
-    public function __construct(ModelManager $manager)
+    public function __construct(private ModelManager $manager)
     {
-        $this->manager = $manager;
     }
 
     /**

--- a/src/Imports/ModelManager.php
+++ b/src/Imports/ModelManager.php
@@ -23,28 +23,16 @@ class ModelManager
      * @var array
      */
     private $rows = [];
-
-    /**
-     * @var RowValidator
-     */
-    private $validator;
     /**
      * @var bool
      */
     private $remembersRowNumber = false;
 
     /**
-     * @var CascadePersistManager
-     */
-    private $cascade;
-
-    /**
      * @param  RowValidator  $validator
      */
-    public function __construct(RowValidator $validator, CascadePersistManager $cascade)
+    public function __construct(private RowValidator $validator, private CascadePersistManager $cascade)
     {
-        $this->validator = $validator;
-        $this->cascade   = $cascade;
     }
 
     /**

--- a/src/Imports/ModelManager.php
+++ b/src/Imports/ModelManager.php
@@ -95,7 +95,7 @@ class ModelManager
     {
         $this->rows()
              ->flatMap(fn(array $attributes, $index) => $this->toModels($import, $attributes, $index))
-             ->mapToGroups(fn($model) => [\get_class($model) => $this->prepare($model)->getAttributes()])
+             ->mapToGroups(fn($model) => [$model::class => $this->prepare($model)->getAttributes()])
              ->each(function (Collection $models, string $model) use ($import) {
                  try {
                      /* @var Model $model */

--- a/src/Imports/ModelManager.php
+++ b/src/Imports/ModelManager.php
@@ -94,8 +94,8 @@ class ModelManager
     private function massFlush(ToModel $import)
     {
         $this->rows()
-             ->flatMap(fn(array $attributes, $index) => $this->toModels($import, $attributes, $index))
-             ->mapToGroups(fn($model) => [$model::class => $this->prepare($model)->getAttributes()])
+             ->flatMap(fn (array $attributes, $index) => $this->toModels($import, $attributes, $index))
+             ->mapToGroups(fn ($model) => [$model::class => $this->prepare($model)->getAttributes()])
              ->each(function (Collection $models, string $model) use ($import) {
                  try {
                      /* @var Model $model */

--- a/src/Imports/ModelManager.php
+++ b/src/Imports/ModelManager.php
@@ -94,12 +94,8 @@ class ModelManager
     private function massFlush(ToModel $import)
     {
         $this->rows()
-             ->flatMap(function (array $attributes, $index) use ($import) {
-                 return $this->toModels($import, $attributes, $index);
-             })
-             ->mapToGroups(function ($model) {
-                 return [\get_class($model) => $this->prepare($model)->getAttributes()];
-             })
+             ->flatMap(fn(array $attributes, $index) => $this->toModels($import, $attributes, $index))
+             ->mapToGroups(fn($model) => [\get_class($model) => $this->prepare($model)->getAttributes()])
              ->each(function (Collection $models, string $model) use ($import) {
                  try {
                      /* @var Model $model */

--- a/src/Imports/Persistence/CascadePersistManager.php
+++ b/src/Imports/Persistence/CascadePersistManager.php
@@ -30,7 +30,7 @@ class CascadePersistManager
      */
     public function persist(Model $model): bool
     {
-        return ($this->transaction)(fn() => $this->save($model));
+        return ($this->transaction)(fn () => $this->save($model));
     }
 
     /**

--- a/src/Imports/Persistence/CascadePersistManager.php
+++ b/src/Imports/Persistence/CascadePersistManager.php
@@ -30,9 +30,7 @@ class CascadePersistManager
      */
     public function persist(Model $model): bool
     {
-        return ($this->transaction)(function () use ($model) {
-            return $this->save($model);
-        });
+        return ($this->transaction)(fn() => $this->save($model));
     }
 
     /**

--- a/src/Jobs/AfterImportJob.php
+++ b/src/Jobs/AfterImportJob.php
@@ -40,9 +40,7 @@ class AfterImportJob implements ShouldQueue
 
     public function setDependencies(Collection $jobs)
     {
-        $this->dependencyIds = $jobs->map(function (ReadChunk $job) {
-            return $job->getUniqueId();
-        })->all();
+        $this->dependencyIds = $jobs->map(fn(ReadChunk $job) => $job->getUniqueId())->all();
     }
 
     public function handle()

--- a/src/Jobs/AfterImportJob.php
+++ b/src/Jobs/AfterImportJob.php
@@ -19,16 +19,6 @@ class AfterImportJob implements ShouldQueue
     use Batchable, Dispatchable, HasEventBus, InteractsWithQueue, Queueable;
 
     /**
-     * @var WithEvents
-     */
-    private $import;
-
-    /**
-     * @var Reader
-     */
-    private $reader;
-
-    /**
      * @var iterable
      */
     private $dependencyIds = [];
@@ -39,10 +29,8 @@ class AfterImportJob implements ShouldQueue
      * @param  object  $import
      * @param  Reader  $reader
      */
-    public function __construct($import, Reader $reader)
+    public function __construct(private $import, private Reader $reader)
     {
-        $this->import = $import;
-        $this->reader = $reader;
     }
 
     public function setInterval(int $interval)

--- a/src/Jobs/AfterImportJob.php
+++ b/src/Jobs/AfterImportJob.php
@@ -40,7 +40,7 @@ class AfterImportJob implements ShouldQueue
 
     public function setDependencies(Collection $jobs)
     {
-        $this->dependencyIds = $jobs->map(fn(ReadChunk $job) => $job->getUniqueId())->all();
+        $this->dependencyIds = $jobs->map(fn (ReadChunk $job) => $job->getUniqueId())->all();
     }
 
     public function handle()

--- a/src/Jobs/AppendDataToSheet.php
+++ b/src/Jobs/AppendDataToSheet.php
@@ -36,20 +36,14 @@ class AppendDataToSheet implements ShouldQueue
     public $sheetIndex;
 
     /**
-     * @var object
-     */
-    public $sheetExport;
-
-    /**
      * @param  object  $sheetExport
      * @param  TemporaryFile  $temporaryFile
      * @param  string  $writerType
      * @param  int  $sheetIndex
      * @param  array  $data
      */
-    public function __construct($sheetExport, TemporaryFile $temporaryFile, string $writerType, int $sheetIndex, array $data)
+    public function __construct(public $sheetExport, TemporaryFile $temporaryFile, string $writerType, int $sheetIndex, array $data)
     {
-        $this->sheetExport   = $sheetExport;
         $this->data          = $data;
         $this->temporaryFile = $temporaryFile;
         $this->writerType    = $writerType;

--- a/src/Jobs/CloseSheet.php
+++ b/src/Jobs/CloseSheet.php
@@ -16,37 +16,13 @@ class CloseSheet implements ShouldQueue
     use Batchable, Dispatchable, InteractsWithQueue, ProxyFailures, Queueable;
 
     /**
-     * @var object
-     */
-    private $sheetExport;
-
-    /**
-     * @var string
-     */
-    private $temporaryFile;
-
-    /**
-     * @var string
-     */
-    private $writerType;
-
-    /**
-     * @var int
-     */
-    private $sheetIndex;
-
-    /**
      * @param  object  $sheetExport
      * @param  TemporaryFile  $temporaryFile
      * @param  string  $writerType
      * @param  int  $sheetIndex
      */
-    public function __construct($sheetExport, TemporaryFile $temporaryFile, string $writerType, int $sheetIndex)
+    public function __construct(private $sheetExport, private TemporaryFile $temporaryFile, private string $writerType, private int $sheetIndex)
     {
-        $this->sheetExport   = $sheetExport;
-        $this->temporaryFile = $temporaryFile;
-        $this->writerType    = $writerType;
-        $this->sheetIndex    = $sheetIndex;
     }
 
     /**

--- a/src/Jobs/Middleware/LocalizeJob.php
+++ b/src/Jobs/Middleware/LocalizeJob.php
@@ -36,8 +36,6 @@ class LocalizeJob
             return null;
         });
 
-        return $this->withLocale($locale, function () use ($next, $job) {
-            return $next($job);
-        });
+        return $this->withLocale($locale, fn() => $next($job));
     }
 }

--- a/src/Jobs/Middleware/LocalizeJob.php
+++ b/src/Jobs/Middleware/LocalizeJob.php
@@ -36,6 +36,6 @@ class LocalizeJob
             return null;
         });
 
-        return $this->withLocale($locale, fn() => $next($job));
+        return $this->withLocale($locale, fn () => $next($job));
     }
 }

--- a/src/Jobs/Middleware/LocalizeJob.php
+++ b/src/Jobs/Middleware/LocalizeJob.php
@@ -11,18 +11,12 @@ class LocalizeJob
     use Localizable;
 
     /**
-     * @var object
-     */
-    private $localizable;
-
-    /**
      * LocalizeJob constructor.
      *
      * @param  object  $localizable
      */
-    public function __construct($localizable)
+    public function __construct(private $localizable)
     {
-        $this->localizable = $localizable;
     }
 
     /**

--- a/src/Jobs/QueueExport.php
+++ b/src/Jobs/QueueExport.php
@@ -18,30 +18,12 @@ class QueueExport implements ShouldQueue
     use Batchable, Dispatchable, ExtendedQueueable, InteractsWithQueue;
 
     /**
-     * @var object
-     */
-    public $export;
-
-    /**
-     * @var string
-     */
-    private $writerType;
-
-    /**
-     * @var TemporaryFile
-     */
-    private $temporaryFile;
-
-    /**
      * @param  object  $export
      * @param  TemporaryFile  $temporaryFile
      * @param  string  $writerType
      */
-    public function __construct($export, TemporaryFile $temporaryFile, string $writerType)
+    public function __construct(public $export, private TemporaryFile $temporaryFile, private string $writerType)
     {
-        $this->export        = $export;
-        $this->writerType    = $writerType;
-        $this->temporaryFile = $temporaryFile;
     }
 
     /**

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -58,41 +58,6 @@ class ReadChunk implements ShouldQueue
     public $connection;
 
     /**
-     * @var WithChunkReading
-     */
-    private $import;
-
-    /**
-     * @var IReader
-     */
-    private $reader;
-
-    /**
-     * @var TemporaryFile
-     */
-    private $temporaryFile;
-
-    /**
-     * @var string
-     */
-    private $sheetName;
-
-    /**
-     * @var object
-     */
-    private $sheetImport;
-
-    /**
-     * @var int
-     */
-    private $startRow;
-
-    /**
-     * @var int
-     */
-    private $chunkSize;
-
-    /**
      * @var string
      */
     private $uniqueId;
@@ -106,21 +71,14 @@ class ReadChunk implements ShouldQueue
      * @param  int  $startRow
      * @param  int  $chunkSize
      */
-    public function __construct(WithChunkReading $import, IReader $reader, TemporaryFile $temporaryFile, string $sheetName, $sheetImport, int $startRow, int $chunkSize)
+    public function __construct(private WithChunkReading $import, private IReader $reader, private TemporaryFile $temporaryFile, private string $sheetName, private $sheetImport, private int $startRow, private int $chunkSize)
     {
-        $this->import        = $import;
-        $this->reader        = $reader;
-        $this->temporaryFile = $temporaryFile;
-        $this->sheetName     = $sheetName;
-        $this->sheetImport   = $sheetImport;
-        $this->startRow      = $startRow;
-        $this->chunkSize     = $chunkSize;
-        $this->timeout       = $import->timeout ?? null;
-        $this->tries         = $import->tries ?? null;
-        $this->maxExceptions = $import->maxExceptions ?? null;
-        $this->backoff       = method_exists($import, 'backoff') ? $import->backoff() : ($import->backoff ?? null);
-        $this->connection    = property_exists($import, 'connection') ? $import->connection : null;
-        $this->queue         = property_exists($import, 'queue') ? $import->queue : null;
+        $this->timeout       = $this->import->timeout ?? null;
+        $this->tries         = $this->import->tries ?? null;
+        $this->maxExceptions = $this->import->maxExceptions ?? null;
+        $this->backoff       = method_exists($this->import, 'backoff') ? $this->import->backoff() : ($this->import->backoff ?? null);
+        $this->connection    = property_exists($this->import, 'connection') ? $this->import->connection : null;
+        $this->queue         = property_exists($this->import, 'queue') ? $this->import->queue : null;
     }
 
     public function getUniqueId(): string

--- a/src/Jobs/StoreQueuedExport.php
+++ b/src/Jobs/StoreQueuedExport.php
@@ -15,37 +15,13 @@ class StoreQueuedExport implements ShouldQueue
     use Batchable, Dispatchable, InteractsWithQueue, Queueable;
 
     /**
-     * @var string
-     */
-    private $filePath;
-
-    /**
-     * @var string|null
-     */
-    private $disk;
-
-    /**
-     * @var TemporaryFile
-     */
-    private $temporaryFile;
-
-    /**
-     * @var array|string
-     */
-    private $diskOptions;
-
-    /**
      * @param  TemporaryFile  $temporaryFile
      * @param  string  $filePath
      * @param  string|null  $disk
      * @param  array|string  $diskOptions
      */
-    public function __construct(TemporaryFile $temporaryFile, string $filePath, ?string $disk = null, $diskOptions = [])
+    public function __construct(private TemporaryFile $temporaryFile, private string $filePath, private ?string $disk = null, private $diskOptions = [])
     {
-        $this->disk          = $disk;
-        $this->filePath      = $filePath;
-        $this->temporaryFile = $temporaryFile;
-        $this->diskOptions   = $diskOptions;
     }
 
     /**

--- a/src/Mixins/DownloadCollectionMixin.php
+++ b/src/Mixins/DownloadCollectionMixin.php
@@ -22,23 +22,17 @@ class DownloadCollectionMixin
                 use Exportable;
 
                 /**
-                 * @var bool
-                 */
-                private $withHeadings;
-
-                /**
                  * @var Collection
                  */
                 private $collection;
 
                 /**
                  * @param  Collection  $collection
-                 * @param  bool  $withHeading
+                 * @param bool $withHeadings
                  */
-                public function __construct(Collection $collection, bool $withHeading = false)
+                public function __construct(Collection $collection, private bool $withHeadings = false)
                 {
                     $this->collection   = $collection->toBase();
-                    $this->withHeadings = $withHeading;
                 }
 
                 /**

--- a/src/Mixins/DownloadCollectionMixin.php
+++ b/src/Mixins/DownloadCollectionMixin.php
@@ -28,7 +28,7 @@ class DownloadCollectionMixin
 
                 /**
                  * @param  Collection  $collection
-                 * @param bool $withHeadings
+                 * @param  bool  $withHeadings
                  */
                 public function __construct(Collection $collection, private bool $withHeadings = false)
                 {

--- a/src/Mixins/DownloadQueryMacro.php
+++ b/src/Mixins/DownloadQueryMacro.php
@@ -20,7 +20,7 @@ class DownloadQueryMacro
                 /**
                  * @param  $query
                  * @param  bool  $withHeadings
-                 * @param Builder $query
+                 * @param  Builder  $query
                  */
                 public function __construct(private $query, private bool $withHeadings = false)
                 {

--- a/src/Mixins/DownloadQueryMacro.php
+++ b/src/Mixins/DownloadQueryMacro.php
@@ -18,23 +18,12 @@ class DownloadQueryMacro
                 use Exportable;
 
                 /**
-                 * @var bool
-                 */
-                private $withHeadings;
-
-                /**
-                 * @var Builder
-                 */
-                private $query;
-
-                /**
                  * @param  $query
                  * @param  bool  $withHeadings
+                 * @param Builder $query
                  */
-                public function __construct($query, bool $withHeadings = false)
+                public function __construct(private $query, private bool $withHeadings = false)
                 {
-                    $this->query        = $query;
-                    $this->withHeadings = $withHeadings;
                 }
 
                 /**

--- a/src/Mixins/ImportAsMacro.php
+++ b/src/Mixins/ImportAsMacro.php
@@ -16,11 +16,6 @@ class ImportAsMacro
                 use Importable;
 
                 /**
-                 * @var string
-                 */
-                private $model;
-
-                /**
                  * @var callable
                  */
                 private $mapping;
@@ -29,9 +24,8 @@ class ImportAsMacro
                  * @param  string  $model
                  * @param  callable  $mapping
                  */
-                public function __construct(string $model, callable $mapping)
+                public function __construct(private string $model, callable $mapping)
                 {
-                    $this->model   = $model;
                     $this->mapping = $mapping;
                 }
 

--- a/src/Mixins/ImportAsMacro.php
+++ b/src/Mixins/ImportAsMacro.php
@@ -11,7 +11,7 @@ class ImportAsMacro
     public function __invoke()
     {
         return function (string $filename, callable $mapping, ?string $disk = null, ?string $readerType = null) {
-            $import = new class(get_class($this->getModel()), $mapping) implements ToModel
+            $import = new class($this->getModel()::class, $mapping) implements ToModel
             {
                 use Importable;
 

--- a/src/Mixins/ImportMacro.php
+++ b/src/Mixins/ImportMacro.php
@@ -17,16 +17,10 @@ class ImportMacro
                 use Importable;
 
                 /**
-                 * @var string
-                 */
-                private $model;
-
-                /**
                  * @param  string  $model
                  */
-                public function __construct(string $model)
+                public function __construct(private string $model)
                 {
-                    $this->model = $model;
                 }
 
                 /**

--- a/src/Mixins/ImportMacro.php
+++ b/src/Mixins/ImportMacro.php
@@ -12,7 +12,7 @@ class ImportMacro
     public function __invoke()
     {
         return function (string $filename, ?string $disk = null, ?string $readerType = null) {
-            $import = new class(get_class($this->getModel())) implements ToModel, WithHeadingRow
+            $import = new class($this->getModel()::class) implements ToModel, WithHeadingRow
             {
                 use Importable;
 

--- a/src/Mixins/StoreCollectionMixin.php
+++ b/src/Mixins/StoreCollectionMixin.php
@@ -20,11 +20,6 @@ class StoreCollectionMixin
                 use Exportable;
 
                 /**
-                 * @var bool
-                 */
-                private $withHeadings;
-
-                /**
                  * @var Collection
                  */
                 private $collection;
@@ -33,10 +28,9 @@ class StoreCollectionMixin
                  * @param  Collection  $collection
                  * @param  bool  $withHeadings
                  */
-                public function __construct(Collection $collection, bool $withHeadings = false)
+                public function __construct(Collection $collection, private bool $withHeadings = false)
                 {
                     $this->collection   = $collection->toBase();
-                    $this->withHeadings = $withHeadings;
                 }
 
                 /**

--- a/src/Mixins/StoreQueryMacro.php
+++ b/src/Mixins/StoreQueryMacro.php
@@ -18,23 +18,12 @@ class StoreQueryMacro
                 use Exportable;
 
                 /**
-                 * @var bool
-                 */
-                private $withHeadings;
-
-                /**
-                 * @var Builder
-                 */
-                private $query;
-
-                /**
                  * @param  $query
                  * @param  bool  $withHeadings
+                 * @param Builder $query
                  */
-                public function __construct($query, bool $withHeadings = false)
+                public function __construct(private $query, private bool $withHeadings = false)
                 {
-                    $this->query        = $query;
-                    $this->withHeadings = $withHeadings;
                 }
 
                 /**

--- a/src/Mixins/StoreQueryMacro.php
+++ b/src/Mixins/StoreQueryMacro.php
@@ -20,7 +20,7 @@ class StoreQueryMacro
                 /**
                  * @param  $query
                  * @param  bool  $withHeadings
-                 * @param Builder $query
+                 * @param  Builder  $query
                  */
                 public function __construct(private $query, private bool $withHeadings = false)
                 {

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -398,7 +398,7 @@ class Reader
             // an option to load only the selected sheets.
             if (
                 method_exists($this->reader, 'setLoadSheetsOnly')
-                && count(array_filter(array_keys($sheetImports), 'is_numeric')) === 0
+                && count(array_filter(array_keys($sheetImports), is_numeric(...))) === 0
             ) {
                 $this->reader->setLoadSheetsOnly(array_keys($sheetImports));
             }

--- a/src/SettingsProvider.php
+++ b/src/SettingsProvider.php
@@ -7,14 +7,8 @@ use PhpOffice\PhpSpreadsheet\Settings;
 
 class SettingsProvider
 {
-    /**
-     * @var CacheManager
-     */
-    private $cache;
-
-    public function __construct(CacheManager $cache)
+    public function __construct(private CacheManager $cache)
     {
-        $this->cache = $cache;
     }
 
     /**

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -293,7 +293,7 @@ class Sheet
                         try {
                             app(RowValidator::class)->validate($toValidate, $import);
                             $import->onRow($sheetRow);
-                        } catch (RowSkippedException $e) {
+                        } catch (RowSkippedException) {
                         } catch (Throwable $e) {
                             if ($import instanceof SkipsOnError) {
                                 $import->onError($e);

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -759,7 +759,7 @@ class Sheet
         /**
          * @callable(string): string $increment
          */
-        $increment = function_exists('str_increment') ? fn($cell) => str_increment($cell) : (fn($cell) => ++$cell);
+        $increment = function_exists('str_increment') ? str_increment(...) : (fn($cell) => ++$cell);
 
         $upper = $increment($upper);
         for ($i = $lower; $i !== $upper; $i = $increment($i)) {

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -82,16 +82,10 @@ class Sheet
     protected $exportable;
 
     /**
-     * @var Worksheet
-     */
-    private $worksheet;
-
-    /**
      * @param  Worksheet  $worksheet
      */
-    public function __construct(Worksheet $worksheet)
+    public function __construct(private Worksheet $worksheet)
     {
-        $this->worksheet            = $worksheet;
         $this->chunkSize            = config('excel.exports.chunk_size', 100);
         $this->temporaryFileFactory = app(TemporaryFileFactory::class);
     }

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -390,9 +390,7 @@ class Sheet
     {
         $rows = $this->toArray($import, $startRow, $nullValue, $calculateFormulas, $formatData);
 
-        return new Collection(array_map(function (array $row) {
-            return new Collection($row);
-        }, $rows));
+        return new Collection(array_map(fn(array $row) => new Collection($row), $rows));
     }
 
     /**
@@ -738,9 +736,7 @@ class Sheet
      */
     protected function validated(WithValidation $import, int $startRow, $rows)
     {
-        $toValidate = (new Collection($rows))->mapWithKeys(function ($row, $index) use ($startRow) {
-            return [($startRow + $index) => $row];
-        });
+        $toValidate = (new Collection($rows))->mapWithKeys(fn($row, $index) => [($startRow + $index) => $row]);
 
         try {
             app(RowValidator::class)->validate($toValidate->toArray(), $import);
@@ -763,11 +759,7 @@ class Sheet
         /**
          * @callable(string): string $increment
          */
-        $increment = function_exists('str_increment') ? function ($cell) {
-            return str_increment($cell);
-        } : function ($cell) {
-            return ++$cell;
-        };
+        $increment = function_exists('str_increment') ? fn($cell) => str_increment($cell) : (fn($cell) => ++$cell);
 
         $upper = $increment($upper);
         for ($i = $lower; $i !== $upper; $i = $increment($i)) {
@@ -824,8 +816,6 @@ class Sheet
             return null;
         }
 
-        return function (array $data, int $index) use ($import) {
-            return $import->prepareForValidation($data, $index);
-        };
+        return fn(array $data, int $index) => $import->prepareForValidation($data, $index);
     }
 }

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -390,7 +390,7 @@ class Sheet
     {
         $rows = $this->toArray($import, $startRow, $nullValue, $calculateFormulas, $formatData);
 
-        return new Collection(array_map(fn(array $row) => new Collection($row), $rows));
+        return new Collection(array_map(fn (array $row) => new Collection($row), $rows));
     }
 
     /**
@@ -736,7 +736,7 @@ class Sheet
      */
     protected function validated(WithValidation $import, int $startRow, $rows)
     {
-        $toValidate = (new Collection($rows))->mapWithKeys(fn($row, $index) => [($startRow + $index) => $row]);
+        $toValidate = (new Collection($rows))->mapWithKeys(fn ($row, $index) => [($startRow + $index) => $row]);
 
         try {
             app(RowValidator::class)->validate($toValidate->toArray(), $import);
@@ -759,7 +759,7 @@ class Sheet
         /**
          * @callable(string): string $increment
          */
-        $increment = function_exists('str_increment') ? str_increment(...) : (fn($cell) => ++$cell);
+        $increment = function_exists('str_increment') ? str_increment(...) : (fn ($cell) => ++$cell);
 
         $upper = $increment($upper);
         for ($i = $lower; $i !== $upper; $i = $increment($i)) {
@@ -816,6 +816,6 @@ class Sheet
             return null;
         }
 
-        return fn(array $data, int $index) => $import->prepareForValidation($data, $index);
+        return fn (array $data, int $index) => $import->prepareForValidation($data, $index);
     }
 }

--- a/src/Transactions/DbTransactionHandler.php
+++ b/src/Transactions/DbTransactionHandler.php
@@ -7,16 +7,10 @@ use Illuminate\Database\ConnectionInterface;
 class DbTransactionHandler implements TransactionHandler
 {
     /**
-     * @var ConnectionInterface
-     */
-    private $connection;
-
-    /**
      * @param  ConnectionInterface  $connection
      */
-    public function __construct(ConnectionInterface $connection)
+    public function __construct(private ConnectionInterface $connection)
     {
-        $this->connection = $connection;
     }
 
     /**

--- a/src/Validators/Failure.php
+++ b/src/Validators/Failure.php
@@ -72,9 +72,7 @@ class Failure implements Arrayable, JsonSerializable
      */
     public function toArray()
     {
-        return collect($this->errors)->map(function ($message) {
-            return __('There was an error on row :row. :message', ['row' => $this->row, 'message' => $message]);
-        })->all();
+        return collect($this->errors)->map(fn($message) => __('There was an error on row :row. :message', ['row' => $this->row, 'message' => $message]))->all();
     }
 
     /**

--- a/src/Validators/Failure.php
+++ b/src/Validators/Failure.php
@@ -72,7 +72,7 @@ class Failure implements Arrayable, JsonSerializable
      */
     public function toArray()
     {
-        return collect($this->errors)->map(fn($message) => __('There was an error on row :row. :message', ['row' => $this->row, 'message' => $message]))->all();
+        return collect($this->errors)->map(fn ($message) => __('There was an error on row :row. :message', ['row' => $this->row, 'message' => $message]))->all();
     }
 
     /**

--- a/src/Validators/Failure.php
+++ b/src/Validators/Failure.php
@@ -23,22 +23,16 @@ class Failure implements Arrayable, JsonSerializable
     protected $errors;
 
     /**
-     * @var array
-     */
-    private $values;
-
-    /**
      * @param  int  $row
      * @param  string  $attribute
      * @param  array  $errors
      * @param  array  $values
      */
-    public function __construct(int $row, string $attribute, array $errors, array $values = [])
+    public function __construct(int $row, string $attribute, array $errors, private array $values = [])
     {
         $this->row       = $row;
         $this->attribute = $attribute;
         $this->errors    = $errors;
-        $this->values    = $values;
     }
 
     /**

--- a/src/Validators/RowValidator.php
+++ b/src/Validators/RowValidator.php
@@ -129,7 +129,7 @@ class RowValidator
         }
 
         if (Str::contains($rules, 'required_without') && preg_match('/(.*?):(.*)/', $rules, $matches)) {
-            $column = array_map(fn($match) => Str::startsWith($match, '*.') ? $match : '*.' . $match, explode(',', $matches[2]));
+            $column = array_map(fn ($match) => Str::startsWith($match, '*.') ? $match : '*.' . $match, explode(',', $matches[2]));
 
             return $matches[1] . ':' . implode(',', $column);
         }

--- a/src/Validators/RowValidator.php
+++ b/src/Validators/RowValidator.php
@@ -129,9 +129,7 @@ class RowValidator
         }
 
         if (Str::contains($rules, 'required_without') && preg_match('/(.*?):(.*)/', $rules, $matches)) {
-            $column = array_map(function ($match) {
-                return Str::startsWith($match, '*.') ? $match : '*.' . $match;
-            }, explode(',', $matches[2]));
+            $column = array_map(fn($match) => Str::startsWith($match, '*.') ? $match : '*.' . $match, explode(',', $matches[2]));
 
             return $matches[1] . ':' . implode(',', $column);
         }

--- a/src/Validators/RowValidator.php
+++ b/src/Validators/RowValidator.php
@@ -12,16 +12,10 @@ use Maatwebsite\Excel\Exceptions\RowSkippedException;
 class RowValidator
 {
     /**
-     * @var Factory
-     */
-    private $validator;
-
-    /**
      * @param  Factory  $validator
      */
-    public function __construct(Factory $validator)
+    public function __construct(private Factory $validator)
     {
-        $this->validator = $validator;
     }
 
     /**

--- a/src/Validators/ValidationException.php
+++ b/src/Validators/ValidationException.php
@@ -24,6 +24,7 @@ class ValidationException extends IlluminateValidationException
     /**
      * @return string[]
      */
+    #[\Override]
     public function errors(): array
     {
         return collect($this->failures)->map->toArray()->all();

--- a/tests/Cache/BatchCacheTest.php
+++ b/tests/Cache/BatchCacheTest.php
@@ -178,7 +178,7 @@ class BatchCacheTest extends TestCase
 
         $dispatchedCollection = Event::dispatched(
             KeyWritten::class,
-            fn(KeyWritten $event) => $event->seconds === $expectedTTL);
+            fn (KeyWritten $event) => $event->seconds === $expectedTTL);
 
         $this->assertCount(2, $dispatchedCollection);
     }
@@ -194,7 +194,7 @@ class BatchCacheTest extends TestCase
 
         $dispatchedCollection = Event::dispatched(
             KeyWritten::class,
-            fn(KeyWritten $event) => $event->seconds >= 59 && $event->seconds <= 60);
+            fn (KeyWritten $event) => $event->seconds >= 59 && $event->seconds <= 60);
 
         $this->assertCount(2, $dispatchedCollection);
     }
@@ -209,7 +209,7 @@ class BatchCacheTest extends TestCase
 
         $dispatchedCollection = Event::dispatched(
             KeyWritten::class,
-            fn(KeyWritten $event) => $event->seconds === null);
+            fn (KeyWritten $event) => $event->seconds === null);
 
         $this->assertCount(2, $dispatchedCollection);
     }
@@ -219,7 +219,7 @@ class BatchCacheTest extends TestCase
         return [
             'null (forever)' => [null, null],
             'int value'      => [$value = rand(1, 100), $value],
-            'callable'       => [$closure = (fn() => 199), $closure],
+            'callable'       => [$closure = (fn () => 199), $closure],
         ];
     }
 

--- a/tests/Cache/BatchCacheTest.php
+++ b/tests/Cache/BatchCacheTest.php
@@ -178,9 +178,7 @@ class BatchCacheTest extends TestCase
 
         $dispatchedCollection = Event::dispatched(
             KeyWritten::class,
-            function (KeyWritten $event) use ($expectedTTL) {
-                return $event->seconds === $expectedTTL;
-            });
+            fn(KeyWritten $event) => $event->seconds === $expectedTTL);
 
         $this->assertCount(2, $dispatchedCollection);
     }
@@ -196,9 +194,7 @@ class BatchCacheTest extends TestCase
 
         $dispatchedCollection = Event::dispatched(
             KeyWritten::class,
-            function (KeyWritten $event) {
-                return $event->seconds >= 59 && $event->seconds <= 60;
-            });
+            fn(KeyWritten $event) => $event->seconds >= 59 && $event->seconds <= 60);
 
         $this->assertCount(2, $dispatchedCollection);
     }
@@ -213,9 +209,7 @@ class BatchCacheTest extends TestCase
 
         $dispatchedCollection = Event::dispatched(
             KeyWritten::class,
-            function (KeyWritten $event) {
-                return $event->seconds === null;
-            });
+            fn(KeyWritten $event) => $event->seconds === null);
 
         $this->assertCount(2, $dispatchedCollection);
     }
@@ -225,9 +219,7 @@ class BatchCacheTest extends TestCase
         return [
             'null (forever)' => [null, null],
             'int value'      => [$value = rand(1, 100), $value],
-            'callable'       => [$closure = function () {
-                return 199;
-            }, $closure],
+            'callable'       => [$closure = (fn() => 199), $closure],
         ];
     }
 

--- a/tests/Concerns/FromCollectionTest.php
+++ b/tests/Concerns/FromCollectionTest.php
@@ -47,7 +47,7 @@ class FromCollectionTest extends TestCase
 
     public function test_can_export_from_lazy_collection()
     {
-        if (!class_exists('\Illuminate\Support\LazyCollection')) {
+        if (!class_exists(\Illuminate\Support\LazyCollection::class)) {
             $this->markTestSkipped('Skipping test because LazyCollection is not supported');
 
             return;
@@ -69,7 +69,7 @@ class FromCollectionTest extends TestCase
 
     public function test_can_export_from_lazy_collection_with_queue()
     {
-        if (!class_exists('\Illuminate\Support\LazyCollection')) {
+        if (!class_exists(\Illuminate\Support\LazyCollection::class)) {
             $this->markTestSkipped('Skipping test because LazyCollection is not supported');
 
             return;

--- a/tests/Concerns/FromCollectionTest.php
+++ b/tests/Concerns/FromCollectionTest.php
@@ -61,9 +61,7 @@ class FromCollectionTest extends TestCase
 
         $this->assertEquals(
             $export->collection()->map(
-                function (array $item) {
-                    return array_values($item);
-                }
+                fn(array $item) => array_values($item)
             )->toArray(),
             $contents
         );
@@ -90,9 +88,7 @@ class FromCollectionTest extends TestCase
 
         $this->assertEquals(
             $export->collection()->map(
-                function (array $item) {
-                    return array_values($item);
-                }
+                fn(array $item) => array_values($item)
             )->toArray(),
             $contents
         );

--- a/tests/Concerns/FromCollectionTest.php
+++ b/tests/Concerns/FromCollectionTest.php
@@ -61,7 +61,7 @@ class FromCollectionTest extends TestCase
 
         $this->assertEquals(
             $export->collection()->map(
-                fn(array $item) => array_values($item)
+                fn (array $item) => array_values($item)
             )->toArray(),
             $contents
         );
@@ -88,7 +88,7 @@ class FromCollectionTest extends TestCase
 
         $this->assertEquals(
             $export->collection()->map(
-                fn(array $item) => array_values($item)
+                fn (array $item) => array_values($item)
             )->toArray(),
             $contents
         );

--- a/tests/Concerns/FromQueryTest.php
+++ b/tests/Concerns/FromQueryTest.php
@@ -209,7 +209,7 @@ class FromQueryTest extends TestCase
 
     public function test_can_export_from_scout()
     {
-        if (!class_exists('\Laravel\Scout\Engines\DatabaseEngine')) {
+        if (!class_exists(\Laravel\Scout\Engines\DatabaseEngine::class)) {
             $this->markTestSkipped('Laravel Scout is too old');
 
             return;

--- a/tests/Concerns/FromQueryTest.php
+++ b/tests/Concerns/FromQueryTest.php
@@ -41,9 +41,7 @@ class FromQueryTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-store.xlsx', 'Xlsx');
 
-        $allUsers = $export->query()->get()->map(function (User $user) {
-            return array_values($user->toArray());
-        })->toArray();
+        $allUsers = $export->query()->get()->map(fn(User $user) => array_values($user->toArray()))->toArray();
 
         $this->assertEquals($allUsers, $contents);
     }
@@ -58,9 +56,7 @@ class FromQueryTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-store.xlsx', 'Xlsx');
 
-        $allUsers = $export->query->get()->map(function (User $user) {
-            return array_values($user->toArray());
-        })->toArray();
+        $allUsers = $export->query->get()->map(fn(User $user) => array_values($user->toArray()))->toArray();
 
         $this->assertEquals($allUsers, $contents);
     }
@@ -73,9 +69,7 @@ class FromQueryTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-store.xlsx', 'Xlsx');
 
-        $allUsers = $export->query()->get()->map(function ($row) use ($export) {
-            return $export->map($row);
-        })->toArray();
+        $allUsers = $export->query()->get()->map(fn($row) => $export->map($row))->toArray();
 
         $this->assertEquals($allUsers, $contents);
     }
@@ -97,9 +91,7 @@ class FromQueryTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-with-eager-loads.xlsx', 'Xlsx');
 
-        $allUsers = $export->query()->get()->map(function (User $user) use ($export) {
-            return $export->map($user);
-        })->toArray();
+        $allUsers = $export->query()->get()->map(fn(User $user) => $export->map($user))->toArray();
 
         $this->assertEquals($allUsers, $contents);
     }
@@ -120,9 +112,7 @@ class FromQueryTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-with-eager-loads.xlsx', 'Xlsx');
 
-        $allUsers = $export->query()->get()->map(function (User $user) use ($export) {
-            return $export->map($user);
-        })->toArray();
+        $allUsers = $export->query()->get()->map(fn(User $user) => $export->map($user))->toArray();
 
         $this->assertEquals($allUsers, $contents);
     }
@@ -137,9 +127,7 @@ class FromQueryTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-without-eloquent.xlsx', 'Xlsx');
 
-        $allUsers = $export->query()->get()->map(function ($row) {
-            return array_values((array) $row);
-        })->all();
+        $allUsers = $export->query()->get()->map(fn($row) => array_values((array) $row))->all();
 
         $this->assertEquals($allUsers, $contents);
     }
@@ -152,9 +140,7 @@ class FromQueryTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-without-eloquent.xlsx', 'Xlsx');
 
-        $allUsers = $export->query()->get()->map(function ($row) {
-            return array_values((array) $row);
-        })->all();
+        $allUsers = $export->query()->get()->map(fn($row) => array_values((array) $row))->all();
 
         $this->assertEquals($allUsers, $contents);
     }
@@ -195,9 +181,7 @@ class FromQueryTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-store.xlsx', 'Xlsx');
 
-        $allUsers = $export->query()->get()->map(function (User $user) {
-            return array_values($user->toArray());
-        })->toArray();
+        $allUsers = $export->query()->get()->map(fn(User $user) => array_values($user->toArray()))->toArray();
 
         $this->assertEquals($allUsers, $contents);
     }
@@ -239,9 +223,7 @@ class FromQueryTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-scout-store.xlsx', 'Xlsx');
 
-        $allUsers = $export->query()->get()->map(function (User $user) {
-            return array_values($user->toArray());
-        })->toArray();
+        $allUsers = $export->query()->get()->map(fn(User $user) => array_values($user->toArray()))->toArray();
 
         $this->assertEquals($allUsers, $contents);
     }

--- a/tests/Concerns/FromQueryTest.php
+++ b/tests/Concerns/FromQueryTest.php
@@ -41,7 +41,7 @@ class FromQueryTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-store.xlsx', 'Xlsx');
 
-        $allUsers = $export->query()->get()->map(fn(User $user) => array_values($user->toArray()))->toArray();
+        $allUsers = $export->query()->get()->map(fn (User $user) => array_values($user->toArray()))->toArray();
 
         $this->assertEquals($allUsers, $contents);
     }
@@ -56,7 +56,7 @@ class FromQueryTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-store.xlsx', 'Xlsx');
 
-        $allUsers = $export->query->get()->map(fn(User $user) => array_values($user->toArray()))->toArray();
+        $allUsers = $export->query->get()->map(fn (User $user) => array_values($user->toArray()))->toArray();
 
         $this->assertEquals($allUsers, $contents);
     }
@@ -69,7 +69,7 @@ class FromQueryTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-store.xlsx', 'Xlsx');
 
-        $allUsers = $export->query()->get()->map(fn($row) => $export->map($row))->toArray();
+        $allUsers = $export->query()->get()->map(fn ($row) => $export->map($row))->toArray();
 
         $this->assertEquals($allUsers, $contents);
     }
@@ -91,7 +91,7 @@ class FromQueryTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-with-eager-loads.xlsx', 'Xlsx');
 
-        $allUsers = $export->query()->get()->map(fn(User $user) => $export->map($user))->toArray();
+        $allUsers = $export->query()->get()->map(fn (User $user) => $export->map($user))->toArray();
 
         $this->assertEquals($allUsers, $contents);
     }
@@ -112,7 +112,7 @@ class FromQueryTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-with-eager-loads.xlsx', 'Xlsx');
 
-        $allUsers = $export->query()->get()->map(fn(User $user) => $export->map($user))->toArray();
+        $allUsers = $export->query()->get()->map(fn (User $user) => $export->map($user))->toArray();
 
         $this->assertEquals($allUsers, $contents);
     }
@@ -127,7 +127,7 @@ class FromQueryTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-without-eloquent.xlsx', 'Xlsx');
 
-        $allUsers = $export->query()->get()->map(fn($row) => array_values((array) $row))->all();
+        $allUsers = $export->query()->get()->map(fn ($row) => array_values((array) $row))->all();
 
         $this->assertEquals($allUsers, $contents);
     }
@@ -140,7 +140,7 @@ class FromQueryTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-without-eloquent.xlsx', 'Xlsx');
 
-        $allUsers = $export->query()->get()->map(fn($row) => array_values((array) $row))->all();
+        $allUsers = $export->query()->get()->map(fn ($row) => array_values((array) $row))->all();
 
         $this->assertEquals($allUsers, $contents);
     }
@@ -181,7 +181,7 @@ class FromQueryTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-query-store.xlsx', 'Xlsx');
 
-        $allUsers = $export->query()->get()->map(fn(User $user) => array_values($user->toArray()))->toArray();
+        $allUsers = $export->query()->get()->map(fn (User $user) => array_values($user->toArray()))->toArray();
 
         $this->assertEquals($allUsers, $contents);
     }
@@ -223,7 +223,7 @@ class FromQueryTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-scout-store.xlsx', 'Xlsx');
 
-        $allUsers = $export->query()->get()->map(fn(User $user) => array_values($user->toArray()))->toArray();
+        $allUsers = $export->query()->get()->map(fn (User $user) => array_values($user->toArray()))->toArray();
 
         $this->assertEquals($allUsers, $contents);
     }

--- a/tests/Concerns/FromViewTest.php
+++ b/tests/Concerns/FromViewTest.php
@@ -59,7 +59,7 @@ class FromViewTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-view.xlsx', 'Xlsx');
 
-        $expected = $users->map(fn(User $user) => [
+        $expected = $users->map(fn (User $user) => [
             $user->name,
             $user->email,
         ])->prepend(['Name', 'Email'])->toArray();
@@ -108,7 +108,7 @@ class FromViewTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-multiple-view.xlsx', 'Xlsx', 0);
 
-        $expected = $users->forPage(1, 100)->map(fn(User $user) => [
+        $expected = $users->forPage(1, 100)->map(fn (User $user) => [
             $user->name,
             $user->email,
         ])->prepend(['Name', 'Email'])->toArray();
@@ -118,7 +118,7 @@ class FromViewTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-multiple-view.xlsx', 'Xlsx', 2);
 
-        $expected = $users->forPage(3, 100)->map(fn(User $user) => [
+        $expected = $users->forPage(3, 100)->map(fn (User $user) => [
             $user->name,
             $user->email,
         ])->prepend(['Name', 'Email'])->toArray();

--- a/tests/Concerns/FromViewTest.php
+++ b/tests/Concerns/FromViewTest.php
@@ -59,12 +59,10 @@ class FromViewTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-view.xlsx', 'Xlsx');
 
-        $expected = $users->map(function (User $user) {
-            return [
-                $user->name,
-                $user->email,
-            ];
-        })->prepend(['Name', 'Email'])->toArray();
+        $expected = $users->map(fn(User $user) => [
+            $user->name,
+            $user->email,
+        ])->prepend(['Name', 'Email'])->toArray();
 
         $this->assertEquals($expected, $contents);
     }
@@ -110,24 +108,20 @@ class FromViewTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-multiple-view.xlsx', 'Xlsx', 0);
 
-        $expected = $users->forPage(1, 100)->map(function (User $user) {
-            return [
-                $user->name,
-                $user->email,
-            ];
-        })->prepend(['Name', 'Email'])->toArray();
+        $expected = $users->forPage(1, 100)->map(fn(User $user) => [
+            $user->name,
+            $user->email,
+        ])->prepend(['Name', 'Email'])->toArray();
 
         $this->assertEquals(101, sizeof($contents));
         $this->assertEquals($expected, $contents);
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-multiple-view.xlsx', 'Xlsx', 2);
 
-        $expected = $users->forPage(3, 100)->map(function (User $user) {
-            return [
-                $user->name,
-                $user->email,
-            ];
-        })->prepend(['Name', 'Email'])->toArray();
+        $expected = $users->forPage(3, 100)->map(fn(User $user) => [
+            $user->name,
+            $user->email,
+        ])->prepend(['Name', 'Email'])->toArray();
 
         $this->assertEquals(101, sizeof($contents));
         $this->assertEquals($expected, $contents);

--- a/tests/Concerns/ShouldQueueWithoutChainTest.php
+++ b/tests/Concerns/ShouldQueueWithoutChainTest.php
@@ -43,9 +43,7 @@ class ShouldQueueWithoutChainTest extends TestCase
 
         Queue::assertPushed(ReadChunk::class, 2);
         Queue::assertPushed(AfterImportJob::class, 1);
-        Queue::assertPushed(AfterImportJob::class, function ($import) {
-            return !is_null($import->delay);
-        });
+        Queue::assertPushed(AfterImportJob::class, fn($import) => !is_null($import->delay));
         Queue::assertNotPushed(QueueImport::class);
     }
 

--- a/tests/Concerns/ShouldQueueWithoutChainTest.php
+++ b/tests/Concerns/ShouldQueueWithoutChainTest.php
@@ -43,7 +43,7 @@ class ShouldQueueWithoutChainTest extends TestCase
 
         Queue::assertPushed(ReadChunk::class, 2);
         Queue::assertPushed(AfterImportJob::class, 1);
-        Queue::assertPushed(AfterImportJob::class, fn($import) => !is_null($import->delay));
+        Queue::assertPushed(AfterImportJob::class, fn ($import) => !is_null($import->delay));
         Queue::assertNotPushed(QueueImport::class);
     }
 

--- a/tests/Concerns/SkipsOnFailureTest.php
+++ b/tests/Concerns/SkipsOnFailureTest.php
@@ -278,13 +278,11 @@ class SkipsOnFailureTest extends TestCase
              */
             public function collection(Collection $rows)
             {
-                $rows = $rows->each(function ($row) {
-                    return User::create([
-                        'name'     => $row[0],
-                        'email'    => $row[1],
-                        'password' => 'secret',
-                    ]);
-                });
+                $rows = $rows->each(fn($row) => User::create([
+                    'name'     => $row[0],
+                    'email'    => $row[1],
+                    'password' => 'secret',
+                ]));
             }
 
             /**

--- a/tests/Concerns/SkipsOnFailureTest.php
+++ b/tests/Concerns/SkipsOnFailureTest.php
@@ -278,7 +278,7 @@ class SkipsOnFailureTest extends TestCase
              */
             public function collection(Collection $rows)
             {
-                $rows = $rows->each(fn($row) => User::create([
+                $rows = $rows->each(fn ($row) => User::create([
                     'name'     => $row[0],
                     'email'    => $row[1],
                     'password' => 'secret',

--- a/tests/Concerns/WithColumnFormattingTest.php
+++ b/tests/Concerns/WithColumnFormattingTest.php
@@ -41,7 +41,7 @@ class WithColumnFormattingTest extends TestCase
             {
                 return [
                     Date::dateTimeToExcel($row[0]),
-                    isset($row[1]) ? $row[1] : null,
+                    $row[1] ?? null,
                 ];
             }
 

--- a/tests/Concerns/WithCustomValueBinderTest.php
+++ b/tests/Concerns/WithCustomValueBinderTest.php
@@ -40,7 +40,7 @@ class WithCustomValueBinderTest extends TestCase
             public function bindValue(Cell $cell, mixed $value): bool
             {
                 // Handle percentage
-                if (preg_match('/^\-?\d*\.?\d*\s?\%$/', $value)) {
+                if (preg_match('/^\-?\d*\.?\d*\s?\%$/', (string) $value)) {
                     $cell->setValueExplicit(
                         (float) str_replace('%', '', $value) / 100,
                         DataType::TYPE_NUMERIC

--- a/tests/Concerns/WithValidationTest.php
+++ b/tests/Concerns/WithValidationTest.php
@@ -771,9 +771,7 @@ class WithValidationTest extends TestCase
              */
             public function withValidator($validator)
             {
-                $validator->sometimes('*.1', Rule::in(['patrick@maatwebsite.nl']), function () {
-                    return true;
-                });
+                $validator->sometimes('*.1', Rule::in(['patrick@maatwebsite.nl']), fn() => true);
             }
         };
 

--- a/tests/Concerns/WithValidationTest.php
+++ b/tests/Concerns/WithValidationTest.php
@@ -771,7 +771,7 @@ class WithValidationTest extends TestCase
              */
             public function withValidator($validator)
             {
-                $validator->sometimes('*.1', Rule::in(['patrick@maatwebsite.nl']), fn() => true);
+                $validator->sometimes('*.1', Rule::in(['patrick@maatwebsite.nl']), fn () => true);
             }
         };
 

--- a/tests/Data/Stubs/AfterQueueExportJob.php
+++ b/tests/Data/Stubs/AfterQueueExportJob.php
@@ -11,16 +11,10 @@ class AfterQueueExportJob implements ShouldQueue
     use Queueable;
 
     /**
-     * @var string
-     */
-    private $filePath;
-
-    /**
      * @param  string  $filePath
      */
-    public function __construct(string $filePath)
+    public function __construct(private string $filePath)
     {
-        $this->filePath = $filePath;
     }
 
     public function handle()

--- a/tests/Data/Stubs/AfterQueueImportJob.php
+++ b/tests/Data/Stubs/AfterQueueImportJob.php
@@ -12,16 +12,10 @@ class AfterQueueImportJob implements ShouldQueue
     use Queueable;
 
     /**
-     * @var int
-     */
-    private $totalRows;
-
-    /**
      * @param  int  $totalRows
      */
-    public function __construct(int $totalRows)
+    public function __construct(private int $totalRows)
     {
-        $this->totalRows = $totalRows;
     }
 
     public function handle()

--- a/tests/Data/Stubs/Database/Factories/GroupFactory.php
+++ b/tests/Data/Stubs/Database/Factories/GroupFactory.php
@@ -15,7 +15,7 @@ class GroupFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => $this->faker->word,
+            'name' => fake()->word,
         ];
     }
 }

--- a/tests/Data/Stubs/Database/Factories/UserFactory.php
+++ b/tests/Data/Stubs/Database/Factories/UserFactory.php
@@ -16,8 +16,8 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'name'           => $this->faker->name,
-            'email'          => $this->faker->unique()->safeEmail,
+            'name'           => fake()->name,
+            'email'          => fake()->unique()->safeEmail,
             'password'       => '$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm', // secret
             'remember_token' => Str::random(10),
         ];

--- a/tests/Data/Stubs/Database/User.php
+++ b/tests/Data/Stubs/Database/User.php
@@ -60,7 +60,7 @@ class User extends Model
      */
     public function searchableUsing(): Engine
     {
-        return class_exists('\Laravel\Scout\Engines\DatabaseEngine') ? new DatabaseEngine() : new NullEngine();
+        return class_exists(\Laravel\Scout\Engines\DatabaseEngine::class) ? new DatabaseEngine() : new NullEngine();
     }
 
     protected static function newFactory(): UserFactory

--- a/tests/Data/Stubs/Database/User.php
+++ b/tests/Data/Stubs/Database/User.php
@@ -60,6 +60,7 @@ class User extends Model
     {
         return UserFactory::new();
     }
+
     /**
      * @return array
      */

--- a/tests/Data/Stubs/Database/User.php
+++ b/tests/Data/Stubs/Database/User.php
@@ -27,13 +27,6 @@ class User extends Model
     /**
      * @var array
      */
-    protected $casts = [
-        'options' => 'array',
-    ];
-
-    /**
-     * @var array
-     */
     protected $hidden = ['password', 'email_verified_at', 'options', 'group_id'];
 
     public function groups(): BelongsToMany
@@ -66,5 +59,15 @@ class User extends Model
     protected static function newFactory(): UserFactory
     {
         return UserFactory::new();
+    }
+    /**
+     * @return array
+     */
+    #[\Override]
+    protected function casts(): array
+    {
+        return [
+            'options' => 'array',
+        ];
     }
 }

--- a/tests/Data/Stubs/ImportWithEventsChunksAndBatches.php
+++ b/tests/Data/Stubs/ImportWithEventsChunksAndBatches.php
@@ -23,6 +23,7 @@ class ImportWithEventsChunksAndBatches extends ImportWithEvents implements WithB
     /**
      * @return array
      */
+    #[\Override]
     public function registerEvents(): array
     {
         return parent::registerEvents() + [

--- a/tests/Data/Stubs/QueuedExportWithFailedEvents.php
+++ b/tests/Data/Stubs/QueuedExportWithFailedEvents.php
@@ -33,9 +33,7 @@ class QueuedExportWithFailedEvents implements WithMultipleSheets, WithEvents
     {
         Assert::assertEquals('catch exception from QueueExport job', $exception->getMessage());
 
-        app()->bind('queue-has-failed-from-queue-export-job', function () {
-            return true;
-        });
+        app()->bind('queue-has-failed-from-queue-export-job', fn() => true);
     }
 
     /**

--- a/tests/Data/Stubs/QueuedExportWithFailedEvents.php
+++ b/tests/Data/Stubs/QueuedExportWithFailedEvents.php
@@ -33,7 +33,7 @@ class QueuedExportWithFailedEvents implements WithMultipleSheets, WithEvents
     {
         Assert::assertEquals('catch exception from QueueExport job', $exception->getMessage());
 
-        app()->bind('queue-has-failed-from-queue-export-job', fn() => true);
+        app()->bind('queue-has-failed-from-queue-export-job', fn () => true);
     }
 
     /**

--- a/tests/Data/Stubs/QueuedExportWithFailedHook.php
+++ b/tests/Data/Stubs/QueuedExportWithFailedHook.php
@@ -48,6 +48,6 @@ class QueuedExportWithFailedHook implements FromCollection, WithMapping
     {
         Assert::assertEquals('we expect this', $exception->getMessage());
 
-        app()->bind('queue-has-failed', fn() => true);
+        app()->bind('queue-has-failed', fn () => true);
     }
 }

--- a/tests/Data/Stubs/QueuedExportWithFailedHook.php
+++ b/tests/Data/Stubs/QueuedExportWithFailedHook.php
@@ -48,8 +48,6 @@ class QueuedExportWithFailedHook implements FromCollection, WithMapping
     {
         Assert::assertEquals('we expect this', $exception->getMessage());
 
-        app()->bind('queue-has-failed', function () {
-            return true;
-        });
+        app()->bind('queue-has-failed', fn() => true);
     }
 }

--- a/tests/Data/Stubs/QueuedExportWithLocalePreferences.php
+++ b/tests/Data/Stubs/QueuedExportWithLocalePreferences.php
@@ -57,9 +57,7 @@ class QueuedExportWithLocalePreferences implements FromCollection, HasLocalePref
     {
         Assert::assertEquals('ru', app()->getLocale());
 
-        app()->bind('queue-has-correct-locale', function () {
-            return true;
-        });
+        app()->bind('queue-has-correct-locale', fn() => true);
 
         return $rows;
     }

--- a/tests/Data/Stubs/QueuedExportWithLocalePreferences.php
+++ b/tests/Data/Stubs/QueuedExportWithLocalePreferences.php
@@ -57,7 +57,7 @@ class QueuedExportWithLocalePreferences implements FromCollection, HasLocalePref
     {
         Assert::assertEquals('ru', app()->getLocale());
 
-        app()->bind('queue-has-correct-locale', fn() => true);
+        app()->bind('queue-has-correct-locale', fn () => true);
 
         return $rows;
     }

--- a/tests/Data/Stubs/SheetWith100Rows.php
+++ b/tests/Data/Stubs/SheetWith100Rows.php
@@ -18,16 +18,10 @@ class SheetWith100Rows implements FromCollection, WithTitle, ShouldAutoSize, Wit
     use Exportable, RegistersEventListeners;
 
     /**
-     * @var string
-     */
-    private $title;
-
-    /**
      * @param  string  $title
      */
-    public function __construct(string $title)
+    public function __construct(private string $title)
     {
-        $this->title = $title;
     }
 
     /**

--- a/tests/ExcelFakeTest.php
+++ b/tests/ExcelFakeTest.php
@@ -33,9 +33,7 @@ class ExcelFakeTest extends TestCase
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
 
         ExcelFacade::assertDownloaded('downloaded-filename.csv');
-        ExcelFacade::assertDownloaded('downloaded-filename.csv', function (FromCollection $export) {
-            return $export->collection()->contains('foo');
-        });
+        ExcelFacade::assertDownloaded('downloaded-filename.csv', fn(FromCollection $export) => $export->collection()->contains('foo'));
         ExcelFacade::matchByRegex();
         ExcelFacade::assertDownloaded('/\w{10}-\w{8}\.csv/');
     }
@@ -49,9 +47,7 @@ class ExcelFakeTest extends TestCase
         $this->assertTrue($response);
 
         ExcelFacade::assertStored('stored-filename.csv', 's3');
-        ExcelFacade::assertStored('stored-filename.csv', 's3', function (FromCollection $export) {
-            return $export->collection()->contains('foo');
-        });
+        ExcelFacade::assertStored('stored-filename.csv', 's3', fn(FromCollection $export) => $export->collection()->contains('foo'));
         ExcelFacade::matchByRegex();
         ExcelFacade::assertStored('/\w{6}-\w{8}\.csv/', 's3');
     }
@@ -82,9 +78,7 @@ class ExcelFakeTest extends TestCase
         $this->assertTrue($response);
 
         ExcelFacade::assertStored('stored-filename.csv');
-        ExcelFacade::assertStored('stored-filename.csv', function (FromCollection $export) {
-            return $export->collection()->contains('foo');
-        });
+        ExcelFacade::assertStored('stored-filename.csv', fn(FromCollection $export) => $export->collection()->contains('foo'));
         ExcelFacade::matchByRegex();
         ExcelFacade::assertStored('/\w{6}-\w{8}\.csv/');
     }
@@ -98,9 +92,7 @@ class ExcelFakeTest extends TestCase
         $this->assertInstanceOf(PendingDispatch::class, $response);
 
         ExcelFacade::assertQueued('queued-filename.csv', 's3');
-        ExcelFacade::assertQueued('queued-filename.csv', 's3', function (FromCollection $export) {
-            return $export->collection()->contains('foo');
-        });
+        ExcelFacade::assertQueued('queued-filename.csv', 's3', fn(FromCollection $export) => $export->collection()->contains('foo'));
         ExcelFacade::matchByRegex();
         ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/', 's3');
     }
@@ -115,9 +107,7 @@ class ExcelFakeTest extends TestCase
 
         ExcelFacade::assertStored('queued-filename.csv', 's3');
         ExcelFacade::assertQueued('queued-filename.csv', 's3');
-        ExcelFacade::assertQueued('queued-filename.csv', 's3', function (FromCollection $export) {
-            return $export->collection()->contains('foo');
-        });
+        ExcelFacade::assertQueued('queued-filename.csv', 's3', fn(FromCollection $export) => $export->collection()->contains('foo'));
         ExcelFacade::matchByRegex();
         ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/', 's3');
     }
@@ -146,9 +136,7 @@ class ExcelFakeTest extends TestCase
         $this->assertIsString($response);
 
         ExcelFacade::assertExportedInRaw(get_class($this->givenExport()));
-        ExcelFacade::assertExportedInRaw(get_class($this->givenExport()), function (FromCollection $export) {
-            return $export->collection()->contains('foo');
-        });
+        ExcelFacade::assertExportedInRaw(get_class($this->givenExport()), fn(FromCollection $export) => $export->collection()->contains('foo'));
     }
 
     public function test_can_assert_against_a_fake_import()
@@ -158,9 +146,7 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::import($this->givenImport(), 'stored-filename.csv', 's3');
 
         ExcelFacade::assertImported('stored-filename.csv', 's3');
-        ExcelFacade::assertImported('stored-filename.csv', 's3', function (ToModel $import) {
-            return $import->model([]) instanceof User;
-        });
+        ExcelFacade::assertImported('stored-filename.csv', 's3', fn(ToModel $import) => $import->model([]) instanceof User);
         ExcelFacade::matchByRegex();
         ExcelFacade::assertImported('/\w{6}-\w{8}\.csv/', 's3');
     }
@@ -172,9 +158,7 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::import($this->givenImport(), $this->givenUploadedFile(__DIR__ . '/Data/Disks/Local/import.xlsx'));
 
         ExcelFacade::assertImported('import.xlsx');
-        ExcelFacade::assertImported('import.xlsx', function (ToModel $import) {
-            return $import->model([]) instanceof User;
-        });
+        ExcelFacade::assertImported('import.xlsx', fn(ToModel $import) => $import->model([]) instanceof User);
         ExcelFacade::matchByRegex();
         ExcelFacade::assertImported('/\w{6}\.xlsx/');
     }
@@ -189,9 +173,7 @@ class ExcelFakeTest extends TestCase
 
         ExcelFacade::assertImported('queued-filename.csv', 's3');
         ExcelFacade::assertQueued('queued-filename.csv', 's3');
-        ExcelFacade::assertQueued('queued-filename.csv', 's3', function (ToModel $import) {
-            return $import->model([]) instanceof User;
-        });
+        ExcelFacade::assertQueued('queued-filename.csv', 's3', fn(ToModel $import) => $import->model([]) instanceof User);
         ExcelFacade::matchByRegex();
         ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/', 's3');
     }
@@ -206,9 +188,7 @@ class ExcelFakeTest extends TestCase
 
         ExcelFacade::assertImported('queued-filename.csv', 's3');
         ExcelFacade::assertQueued('queued-filename.csv', 's3');
-        ExcelFacade::assertQueued('queued-filename.csv', 's3', function (ToModel $import) {
-            return $import->model([]) instanceof User;
-        });
+        ExcelFacade::assertQueued('queued-filename.csv', 's3', fn(ToModel $import) => $import->model([]) instanceof User);
         ExcelFacade::matchByRegex();
         ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/', 's3');
     }
@@ -237,9 +217,7 @@ class ExcelFakeTest extends TestCase
         $this->assertInstanceOf(PendingDispatch::class, $response);
 
         ExcelFacade::assertQueued('queued-filename.csv');
-        ExcelFacade::assertQueued('queued-filename.csv', function (FromCollection $export) {
-            return $export->collection()->contains('foo');
-        });
+        ExcelFacade::assertQueued('queued-filename.csv', fn(FromCollection $export) => $export->collection()->contains('foo'));
         ExcelFacade::matchByRegex();
         ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/');
     }

--- a/tests/ExcelFakeTest.php
+++ b/tests/ExcelFakeTest.php
@@ -33,7 +33,7 @@ class ExcelFakeTest extends TestCase
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
 
         ExcelFacade::assertDownloaded('downloaded-filename.csv');
-        ExcelFacade::assertDownloaded('downloaded-filename.csv', fn(FromCollection $export) => $export->collection()->contains('foo'));
+        ExcelFacade::assertDownloaded('downloaded-filename.csv', fn (FromCollection $export) => $export->collection()->contains('foo'));
         ExcelFacade::matchByRegex();
         ExcelFacade::assertDownloaded('/\w{10}-\w{8}\.csv/');
     }
@@ -47,7 +47,7 @@ class ExcelFakeTest extends TestCase
         $this->assertTrue($response);
 
         ExcelFacade::assertStored('stored-filename.csv', 's3');
-        ExcelFacade::assertStored('stored-filename.csv', 's3', fn(FromCollection $export) => $export->collection()->contains('foo'));
+        ExcelFacade::assertStored('stored-filename.csv', 's3', fn (FromCollection $export) => $export->collection()->contains('foo'));
         ExcelFacade::matchByRegex();
         ExcelFacade::assertStored('/\w{6}-\w{8}\.csv/', 's3');
     }
@@ -78,7 +78,7 @@ class ExcelFakeTest extends TestCase
         $this->assertTrue($response);
 
         ExcelFacade::assertStored('stored-filename.csv');
-        ExcelFacade::assertStored('stored-filename.csv', fn(FromCollection $export) => $export->collection()->contains('foo'));
+        ExcelFacade::assertStored('stored-filename.csv', fn (FromCollection $export) => $export->collection()->contains('foo'));
         ExcelFacade::matchByRegex();
         ExcelFacade::assertStored('/\w{6}-\w{8}\.csv/');
     }
@@ -92,7 +92,7 @@ class ExcelFakeTest extends TestCase
         $this->assertInstanceOf(PendingDispatch::class, $response);
 
         ExcelFacade::assertQueued('queued-filename.csv', 's3');
-        ExcelFacade::assertQueued('queued-filename.csv', 's3', fn(FromCollection $export) => $export->collection()->contains('foo'));
+        ExcelFacade::assertQueued('queued-filename.csv', 's3', fn (FromCollection $export) => $export->collection()->contains('foo'));
         ExcelFacade::matchByRegex();
         ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/', 's3');
     }
@@ -107,7 +107,7 @@ class ExcelFakeTest extends TestCase
 
         ExcelFacade::assertStored('queued-filename.csv', 's3');
         ExcelFacade::assertQueued('queued-filename.csv', 's3');
-        ExcelFacade::assertQueued('queued-filename.csv', 's3', fn(FromCollection $export) => $export->collection()->contains('foo'));
+        ExcelFacade::assertQueued('queued-filename.csv', 's3', fn (FromCollection $export) => $export->collection()->contains('foo'));
         ExcelFacade::matchByRegex();
         ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/', 's3');
     }
@@ -136,7 +136,7 @@ class ExcelFakeTest extends TestCase
         $this->assertIsString($response);
 
         ExcelFacade::assertExportedInRaw($this->givenExport()::class);
-        ExcelFacade::assertExportedInRaw($this->givenExport()::class, fn(FromCollection $export) => $export->collection()->contains('foo'));
+        ExcelFacade::assertExportedInRaw($this->givenExport()::class, fn (FromCollection $export) => $export->collection()->contains('foo'));
     }
 
     public function test_can_assert_against_a_fake_import()
@@ -146,7 +146,7 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::import($this->givenImport(), 'stored-filename.csv', 's3');
 
         ExcelFacade::assertImported('stored-filename.csv', 's3');
-        ExcelFacade::assertImported('stored-filename.csv', 's3', fn(ToModel $import) => $import->model([]) instanceof User);
+        ExcelFacade::assertImported('stored-filename.csv', 's3', fn (ToModel $import) => $import->model([]) instanceof User);
         ExcelFacade::matchByRegex();
         ExcelFacade::assertImported('/\w{6}-\w{8}\.csv/', 's3');
     }
@@ -158,7 +158,7 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::import($this->givenImport(), $this->givenUploadedFile(__DIR__ . '/Data/Disks/Local/import.xlsx'));
 
         ExcelFacade::assertImported('import.xlsx');
-        ExcelFacade::assertImported('import.xlsx', fn(ToModel $import) => $import->model([]) instanceof User);
+        ExcelFacade::assertImported('import.xlsx', fn (ToModel $import) => $import->model([]) instanceof User);
         ExcelFacade::matchByRegex();
         ExcelFacade::assertImported('/\w{6}\.xlsx/');
     }
@@ -173,7 +173,7 @@ class ExcelFakeTest extends TestCase
 
         ExcelFacade::assertImported('queued-filename.csv', 's3');
         ExcelFacade::assertQueued('queued-filename.csv', 's3');
-        ExcelFacade::assertQueued('queued-filename.csv', 's3', fn(ToModel $import) => $import->model([]) instanceof User);
+        ExcelFacade::assertQueued('queued-filename.csv', 's3', fn (ToModel $import) => $import->model([]) instanceof User);
         ExcelFacade::matchByRegex();
         ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/', 's3');
     }
@@ -188,7 +188,7 @@ class ExcelFakeTest extends TestCase
 
         ExcelFacade::assertImported('queued-filename.csv', 's3');
         ExcelFacade::assertQueued('queued-filename.csv', 's3');
-        ExcelFacade::assertQueued('queued-filename.csv', 's3', fn(ToModel $import) => $import->model([]) instanceof User);
+        ExcelFacade::assertQueued('queued-filename.csv', 's3', fn (ToModel $import) => $import->model([]) instanceof User);
         ExcelFacade::matchByRegex();
         ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/', 's3');
     }
@@ -217,7 +217,7 @@ class ExcelFakeTest extends TestCase
         $this->assertInstanceOf(PendingDispatch::class, $response);
 
         ExcelFacade::assertQueued('queued-filename.csv');
-        ExcelFacade::assertQueued('queued-filename.csv', fn(FromCollection $export) => $export->collection()->contains('foo'));
+        ExcelFacade::assertQueued('queued-filename.csv', fn (FromCollection $export) => $export->collection()->contains('foo'));
         ExcelFacade::matchByRegex();
         ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/');
     }

--- a/tests/ExcelFakeTest.php
+++ b/tests/ExcelFakeTest.php
@@ -135,8 +135,8 @@ class ExcelFakeTest extends TestCase
 
         $this->assertIsString($response);
 
-        ExcelFacade::assertExportedInRaw(get_class($this->givenExport()));
-        ExcelFacade::assertExportedInRaw(get_class($this->givenExport()), fn(FromCollection $export) => $export->collection()->contains('foo'));
+        ExcelFacade::assertExportedInRaw($this->givenExport()::class);
+        ExcelFacade::assertExportedInRaw($this->givenExport()::class, fn(FromCollection $export) => $export->collection()->contains('foo'));
     }
 
     public function test_can_assert_against_a_fake_import()

--- a/tests/ExcelServiceProviderTest.php
+++ b/tests/ExcelServiceProviderTest.php
@@ -16,7 +16,7 @@ class ExcelServiceProviderTest extends TestCase
 {
     public function test_custom_transaction_handler_is_bound()
     {
-        $this->app->make(TransactionManager::class)->extend('handler', fn() => new CustomTransactionHandler);
+        $this->app->make(TransactionManager::class)->extend('handler', fn () => new CustomTransactionHandler);
 
         $this->assertInstanceOf(CustomTransactionHandler::class, $this->app->make(TransactionManager::class)->driver('handler'));
     }

--- a/tests/ExcelServiceProviderTest.php
+++ b/tests/ExcelServiceProviderTest.php
@@ -16,9 +16,7 @@ class ExcelServiceProviderTest extends TestCase
 {
     public function test_custom_transaction_handler_is_bound()
     {
-        $this->app->make(TransactionManager::class)->extend('handler', function () {
-            return new CustomTransactionHandler;
-        });
+        $this->app->make(TransactionManager::class)->extend('handler', fn() => new CustomTransactionHandler);
 
         $this->assertInstanceOf(CustomTransactionHandler::class, $this->app->make(TransactionManager::class)->driver('handler'));
     }

--- a/tests/HeadingRowImportTest.php
+++ b/tests/HeadingRowImportTest.php
@@ -28,9 +28,7 @@ class HeadingRowImportTest extends TestCase
 
     public function test_can_import_only_heading_row_with_custom_heading_row_formatter()
     {
-        HeadingRowFormatter::extend('custom', function ($value) {
-            return 'custom-' . $value;
-        });
+        HeadingRowFormatter::extend('custom', fn($value) => 'custom-' . $value);
 
         HeadingRowFormatter::default('custom');
 
@@ -47,9 +45,7 @@ class HeadingRowImportTest extends TestCase
 
     public function test_can_import_only_heading_row_with_custom_heading_row_formatter_with_key()
     {
-        HeadingRowFormatter::extend('custom', function ($value, $key) {
-            return $key;
-        });
+        HeadingRowFormatter::extend('custom', fn($value, $key) => $key);
 
         HeadingRowFormatter::default('custom');
 
@@ -95,9 +91,7 @@ class HeadingRowImportTest extends TestCase
 
     public function test_can_import_only_heading_row_for_multiple_sheets_with_key()
     {
-        HeadingRowFormatter::extend('custom', function ($value, $key) {
-            return $key;
-        });
+        HeadingRowFormatter::extend('custom', fn($value, $key) => $key);
 
         HeadingRowFormatter::default('custom');
         $import = new HeadingRowImport();
@@ -132,9 +126,7 @@ class HeadingRowImportTest extends TestCase
 
     public function test_can_import_heading_row_with_custom_formatter_defined_in_config()
     {
-        HeadingRowFormatter::extend('custom2', function ($value) {
-            return 'custom2-' . $value;
-        });
+        HeadingRowFormatter::extend('custom2', fn($value) => 'custom2-' . $value);
 
         config()->set('excel.imports.heading_row.formatter', 'custom2');
 

--- a/tests/HeadingRowImportTest.php
+++ b/tests/HeadingRowImportTest.php
@@ -28,7 +28,7 @@ class HeadingRowImportTest extends TestCase
 
     public function test_can_import_only_heading_row_with_custom_heading_row_formatter()
     {
-        HeadingRowFormatter::extend('custom', fn($value) => 'custom-' . $value);
+        HeadingRowFormatter::extend('custom', fn ($value) => 'custom-' . $value);
 
         HeadingRowFormatter::default('custom');
 
@@ -45,7 +45,7 @@ class HeadingRowImportTest extends TestCase
 
     public function test_can_import_only_heading_row_with_custom_heading_row_formatter_with_key()
     {
-        HeadingRowFormatter::extend('custom', fn($value, $key) => $key);
+        HeadingRowFormatter::extend('custom', fn ($value, $key) => $key);
 
         HeadingRowFormatter::default('custom');
 
@@ -91,7 +91,7 @@ class HeadingRowImportTest extends TestCase
 
     public function test_can_import_only_heading_row_for_multiple_sheets_with_key()
     {
-        HeadingRowFormatter::extend('custom', fn($value, $key) => $key);
+        HeadingRowFormatter::extend('custom', fn ($value, $key) => $key);
 
         HeadingRowFormatter::default('custom');
         $import = new HeadingRowImport();
@@ -126,7 +126,7 @@ class HeadingRowImportTest extends TestCase
 
     public function test_can_import_heading_row_with_custom_formatter_defined_in_config()
     {
-        HeadingRowFormatter::extend('custom2', fn($value) => 'custom2-' . $value);
+        HeadingRowFormatter::extend('custom2', fn ($value) => 'custom2-' . $value);
 
         config()->set('excel.imports.heading_row.formatter', 'custom2');
 

--- a/tests/Helpers/FileHelper.php
+++ b/tests/Helpers/FileHelper.php
@@ -16,7 +16,7 @@ class FileHelper
         }
 
         if (is_dir($fileName)) {
-            $scan = glob(rtrim($fileName, '/') . '/*');
+            $scan = glob(rtrim((string) $fileName, '/') . '/*');
             foreach ($scan as $path) {
                 self::recursiveDelete($path);
             }

--- a/tests/Mixins/ImportAsMacroTest.php
+++ b/tests/Mixins/ImportAsMacroTest.php
@@ -21,7 +21,7 @@ class ImportAsMacroTest extends TestCase
     {
         User::query()->truncate();
 
-        User::importAs('import-users.xlsx', fn(array $row) => [
+        User::importAs('import-users.xlsx', fn (array $row) => [
             'name'     => $row[0],
             'email'    => $row[1],
             'password' => 'secret',

--- a/tests/Mixins/ImportAsMacroTest.php
+++ b/tests/Mixins/ImportAsMacroTest.php
@@ -21,13 +21,11 @@ class ImportAsMacroTest extends TestCase
     {
         User::query()->truncate();
 
-        User::importAs('import-users.xlsx', function (array $row) {
-            return [
-                'name'     => $row[0],
-                'email'    => $row[1],
-                'password' => 'secret',
-            ];
-        });
+        User::importAs('import-users.xlsx', fn(array $row) => [
+            'name'     => $row[0],
+            'email'    => $row[1],
+            'password' => 'secret',
+        ]);
 
         $this->assertCount(2, User::all());
         $this->assertEquals([

--- a/tests/QueuedExportTest.php
+++ b/tests/QueuedExportTest.php
@@ -133,7 +133,7 @@ class QueuedExportTest extends TestCase
         $export = new QueuedExportWithFailedHook();
         try {
             $export->queue('queued-export.xlsx');
-        } catch (Throwable $e) {
+        } catch (Throwable) {
         }
 
         $this->assertTrue(app('queue-has-failed'));
@@ -145,7 +145,7 @@ class QueuedExportTest extends TestCase
 
         try {
             $export->queue('queued-export.xlsx');
-        } catch (Throwable $e) {
+        } catch (Throwable) {
         }
 
         $this->assertTrue(app('queue-has-failed-from-queue-export-job'));

--- a/tests/QueuedQueryExportTest.php
+++ b/tests/QueuedQueryExportTest.php
@@ -79,7 +79,7 @@ class QueuedQueryExportTest extends TestCase
 
     public function test_can_queue_scout_export()
     {
-        if (!class_exists('\Laravel\Scout\Engines\DatabaseEngine')) {
+        if (!class_exists(\Laravel\Scout\Engines\DatabaseEngine::class)) {
             $this->markTestSkipped('Laravel Scout is too old');
 
             return;

--- a/tests/QueuedViewExportTest.php
+++ b/tests/QueuedViewExportTest.php
@@ -47,7 +47,7 @@ class QueuedViewExportTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/Data/Disks/Local/queued-multiple-view-export.xlsx', 'Xlsx', 0);
 
-        $expected = $users->forPage(1, 100)->map(fn(User $user) => [
+        $expected = $users->forPage(1, 100)->map(fn (User $user) => [
             $user->name,
             $user->email,
         ])->prepend(['Name', 'Email'])->toArray();
@@ -57,7 +57,7 @@ class QueuedViewExportTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/Data/Disks/Local/queued-multiple-view-export.xlsx', 'Xlsx', 2);
 
-        $expected = $users->forPage(3, 100)->map(fn(User $user) => [
+        $expected = $users->forPage(3, 100)->map(fn (User $user) => [
             $user->name,
             $user->email,
         ])->prepend(['Name', 'Email'])->toArray();

--- a/tests/QueuedViewExportTest.php
+++ b/tests/QueuedViewExportTest.php
@@ -47,24 +47,20 @@ class QueuedViewExportTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/Data/Disks/Local/queued-multiple-view-export.xlsx', 'Xlsx', 0);
 
-        $expected = $users->forPage(1, 100)->map(function (User $user) {
-            return [
-                $user->name,
-                $user->email,
-            ];
-        })->prepend(['Name', 'Email'])->toArray();
+        $expected = $users->forPage(1, 100)->map(fn(User $user) => [
+            $user->name,
+            $user->email,
+        ])->prepend(['Name', 'Email'])->toArray();
 
         $this->assertEquals(101, sizeof($contents));
         $this->assertEquals($expected, $contents);
 
         $contents = $this->readAsArray(__DIR__ . '/Data/Disks/Local/queued-multiple-view-export.xlsx', 'Xlsx', 2);
 
-        $expected = $users->forPage(3, 100)->map(function (User $user) {
-            return [
-                $user->name,
-                $user->email,
-            ];
-        })->prepend(['Name', 'Email'])->toArray();
+        $expected = $users->forPage(3, 100)->map(fn(User $user) => [
+            $user->name,
+            $user->email,
+        ])->prepend(['Name', 'Email'])->toArray();
 
         $this->assertEquals(101, sizeof($contents));
         $this->assertEquals($expected, $contents);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -32,7 +32,7 @@ class TestCase extends OrchestraTestCase
      */
     public function givenUploadedFile(string $filePath, ?string $filename = null): File
     {
-        $filename = $filename ?? basename($filePath);
+        $filename ??= basename($filePath);
 
         // Create temporary file.
         $newFilePath = tempnam(sys_get_temp_dir(), 'import-');

--- a/tests/Validators/RowValidatorTest.php
+++ b/tests/Validators/RowValidatorTest.php
@@ -43,7 +43,7 @@ class RowValidatorTest extends TestCase
 
     public function test_format_rule_with_callable_input()
     {
-        $rule = (fn() => 'callable');
+        $rule = (fn () => 'callable');
 
         $result = $this->callPrivateMethod('formatRule', [$rule]);
 

--- a/tests/Validators/RowValidatorTest.php
+++ b/tests/Validators/RowValidatorTest.php
@@ -43,9 +43,7 @@ class RowValidatorTest extends TestCase
 
     public function test_format_rule_with_callable_input()
     {
-        $rule = function () {
-            return 'callable';
-        };
+        $rule = (fn() => 'callable');
 
         $result = $this->callPrivateMethod('formatRule', [$rule]);
 

--- a/tests/Validators/RowValidatorTest.php
+++ b/tests/Validators/RowValidatorTest.php
@@ -87,7 +87,6 @@ class RowValidatorTest extends TestCase
     public function callPrivateMethod(string $name, array $args)
     {
         $method = new \ReflectionMethod(RowValidator::class, $name);
-        $method->setAccessible(true);
 
         return $method->invokeArgs($this->validator, $args);
     }


### PR DESCRIPTION
## Motivation
- Initialize Rector and apply targeted refactoring to bring the codebase
  up to the new PHP 8.3 minimum (raised from 8.2 by upstream's drop of
  PHP 8.2 / Laravel 11 support, merged in here).
- Layer in `driftingly/rector-laravel` so the project can track
  Laravel-version migrations alongside the PHP ones, bound to the
  package's *minimum* supported Laravel rather than whatever happens to
  be installed in the dev's vendor dir.
- Atomic commits (one rule per commit) so individual rules can be
  reviewed, accepted, or reverted independently. If splitting further
  into multiple PRs would help review, happy to do that.

## Summary
- Add Rector configuration with PHP sets auto-detected from the composer
  PHP constraint, plus a `withCache(...)` block backed by `/tmp/rector`.
- Add `driftingly/rector-laravel` as a dev dep and wire
  `LaravelLevelSetList::UP_TO_LARAVEL_120` into the config (cumulative
  level set keyed off the minimum Laravel version we support).
- Add a single-shot CI job (`rector`) that runs `--dry-run` per workflow
  with the cache persisted between runs (separate from the test matrix
  to avoid running per PHP/Laravel combo). The job uses PHP 8.3 to match
  the new floor.
- Apply 14 modernization rules across atomic commits: 11 PHP rules from
  `withPhpSets()` plus 3 Laravel-aware rules from the level set.
- One manual cleanup in `ChunkReader::read()`: collapse the
  `function_exists('dispatch_now') ? dispatch_now($job) : $this->dispatchNow($job)`
  ternary to just `$this->dispatchNow($job)`. The `dispatch_now()`
  global helper was removed in Laravel 8+, so on every supported
  framework version `function_exists()` already returns false and the
  fallback branch is the only one ever taken — the ternary is dead
  code. Runtime behavior is unchanged.

## Skipped rules
Three rules are explicitly skipped via `withSkip([...])` in `rector.php`:

- **`ReadOnlyPropertyRector`** — would mark 12 properties `readonly`,
  including on event objects (`AfterBatch`, `AfterChunk`) and other
  public-API-adjacent classes (`Failure`, `RowValidator`, etc.). BC break
  for any consumer that subclasses or mutates these.
- **`ReturnNeverTypeRector`** — would add `: never` to a single test
  method; narrows the contract relative to the docblocked
  `Model|null` return. Easier to apply by hand if desired.
- **`RandomFunctionRector`** — would rewrite `rand()` calls in tests to
  `random_int()`. Different RNG source; out of scope for a mechanical
  pass.

## Rules applied (one commit per rule, in order of impact)
| Files | Rule |
|------:|------|
| 34 | Constructor property promotion |
| 27 | Closure → arrow function |
|  8 | `#[\Override]` attribute on overridden methods (12 methods) |
|  6 | Null coalescing assignment (`??=`) |
|  6 | `get_class($o)` → `$o::class` |
|  4 | String class name → `::class` |
|  3 | Strict string func arg null guards (PHP 8.1) |
|  3 | Remove unused catch variable |
|  2 | First-class callable syntax for function calls |
|  2 | `$this->faker->X` → `fake()->X` (test factories) |
|  1 | Remove redundant `Reflection::setAccessible(true)` |
|  1 | Ternary → null coalescing operator |
|  1 | Delegating arrow function → first-class callable |
|  1 | `$casts` property → `casts()` method (test stub) |
