### PR TITLE
4.x: Bump required PHP and Laravel versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,8 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 8.2, 8.3, 8.4, 8.5 ]
-        laravel: [ 13,12, 11 ]
+        php: [ 8.3, 8.4, 8.5 ]
+        laravel: [ 12, 13 ]
         dependency-version: [ prefer-stable ]
         os: [ ubuntu-latest ]
         include:
@@ -35,82 +35,9 @@ jobs:
           - laravel: 12
             scout: 10.*
             testbench: 10.*
-          - laravel: 11
-            scout: 10.*
-            testbench: 9.*
         exclude:
           - laravel: 13
-            php: 8.2
-          - laravel: 13
-            php: 8.1
-          - laravel: 13
-            php: 8.0
-          - laravel: 13
-            php: 7.4
-          - laravel: 12
-            php: 8.1
-          - laravel: 11
-            php: 8.5
-          - laravel: 11
-            php: 8.5
-          - laravel: 11
-            php: 8.0
-          - laravel: 11
-            php: 7.4
-          - laravel: 10
-            php: 8.0
-          - laravel: 10
-            php: 7.4
-          - laravel: 10
-            php: 8.4
-          - laravel: 10
-            php: 8.5
-          - laravel: 9
-            php: 7.4
-          - laravel: 9
-            php: 8.4
-          - laravel: 9
-            php: 8.5
-          - laravel: 8
-            php: 8.4
-          - laravel: 8
-            php: 8.5
-          - laravel: 7
-            php: 8.0
-          - laravel: 7
-            php: 8.1
-          - laravel: 7
-            php: 8.2
-          - laravel: 7
             php: 8.3
-          - laravel: 7
-            php: 8.4
-          - laravel: 7
-            php: 8.5
-          - laravel: 6
-            php: 8.0
-          - laravel: 6
-            php: 8.1
-          - laravel: 6
-            php: 8.2
-          - laravel: 6
-            php: 8.3
-          - laravel: 6
-            php: 8.4
-          - laravel: 6
-            php: 8.5
-          - laravel: 5.8
-            php: 8.0
-          - laravel: 5.8
-            php: 8.1
-          - laravel: 5.8
-            php: 8.2
-          - laravel: 5.8
-            php: 8.3
-          - laravel: 5.8
-            php: 8.4
-          - laravel: 5.8
-            php: 8.5
 
     name: PHP${{ matrix.php }} - L${{ matrix.laravel }}
 
@@ -136,10 +63,7 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}.*" "orchestra/testbench:${{ matrix.testbench }}" "laravel/scout:${{ matrix.scout }}"  --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --no-interaction
 
-      - name: Install legacy factories
-        run: |
-          composer require "laravel/legacy-factories" -W --no-interaction
-        if: "matrix.laravel >= 8"
+
 
       - name: Execute tests
         run: vendor/bin/phpunit --testdox --configuration phpunit.xml.dist

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
   ],
   "require": {
     "ext-json": "*",
-    "php": "^8.2",
+    "php": "^8.3",
     "phpoffice/phpspreadsheet": "^5.3",
-    "illuminate/support": "^11.0||^12.0||^13.0",
+    "illuminate/support": "^12.0||^13.0",
     "psr/simple-cache": "^1.0||^2.0||^3.0",
     "composer/semver": "^3.3"
   },
   "require-dev": {
-    "orchestra/testbench": "^9.0||^10.0||^11.0",
+    "orchestra/testbench": "^10.0||^11.0",
     "predis/predis": "^1.1",
     "laravel/scout": "^10.0||^11.0"
   },


### PR DESCRIPTION
Drop support for PHP versions before 8.3 and Laravel before 12

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
