### PR TITLE
4.x: Specify supported PHPUnit versions and modernize phpunit.xml.dist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
   },
   "require-dev": {
     "orchestra/testbench": "^10.0||^11.0",
+    "phpunit/phpunit": "^12.0.1||^13.0.0",
     "predis/predis": "^1.1",
     "laravel/scout": "^10.0||^11.0",
     "rector/rector": "^2.4.2",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
-  <coverage/>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         colors="true"
+         backupGlobals="false"
+         backupStaticProperties="false"
+         processIsolation="false"
+         stopOnFailure="false"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnPhpunitDeprecations="true">
   <php>
     <env name="APP_KEY" value="base64:6igsHe3RYC88h3Wje3VzSNqPwUr7Z5ru+NZw/9qwY5M="/>
     <env name="DB_HOST" value="127.0.0.1"/>


### PR DESCRIPTION
Declare phpunit/phpunit ^12.0.1 || ^13.0.0 in require-dev (PHPUnit 11 went EOL Feb 2026), bump the schema URL to 12.5 (the lowest supported version), and surface deprecations/notices/warnings/errors via displayDetailsOn* attributes.
