### PR TITLE
4.x: Queued multi-sheet exports fail with PhpSpreadsheet 5 because active sheet index becomes invalid

### DIFF
--- a/src/Jobs/QueueExport.php
+++ b/src/Jobs/QueueExport.php
@@ -59,7 +59,7 @@ class QueueExport implements ShouldQueue
 
             // Pre-create the worksheets
             foreach ($sheetExports as $sheetIndex => $sheetExport) {
-                $sheet = $writer->addNewSheet($sheetIndex);
+                $sheet = $writer->addNewSheet();
                 $sheet->open($sheetExport);
             }
 

--- a/tests/Concerns/WithMultipleSheetsTest.php
+++ b/tests/Concerns/WithMultipleSheetsTest.php
@@ -95,7 +95,8 @@ class WithMultipleSheetsTest extends TestCase
             public function sheets(): array
             {
                 return [
-                    9999 => new class {
+                    9999 => new class
+                    {
                     },
                 ];
             }
@@ -116,7 +117,8 @@ class WithMultipleSheetsTest extends TestCase
             public function sheets(): array
             {
                 return [
-                    'Some Random Sheet Name' => new class {
+                    'Some Random Sheet Name' => new class
+                    {
                     },
                 ];
             }
@@ -136,7 +138,8 @@ class WithMultipleSheetsTest extends TestCase
             public function sheets(): array
             {
                 return [
-                    'Some Random Sheet Name' => new class {
+                    'Some Random Sheet Name' => new class
+                    {
                     },
                 ];
             }
@@ -192,7 +195,8 @@ class WithMultipleSheetsTest extends TestCase
             public function sheets(): array
             {
                 return [
-                    99999 => new class {
+                    99999 => new class
+                    {
                     },
                 ];
             }

--- a/tests/Data/Stubs/QueuedMultiSheetExport.php
+++ b/tests/Data/Stubs/QueuedMultiSheetExport.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+
+class QueuedMultiSheetExport implements ShouldQueue, WithMultipleSheets
+{
+    use Exportable;
+
+    public function sheets(): array
+    {
+        return [
+            new SheetWithHeadings('First sheet'),
+            new SheetWithHeadings('Second sheet'),
+        ];
+    }
+}

--- a/tests/Data/Stubs/SheetWithHeadings.php
+++ b/tests/Data/Stubs/SheetWithHeadings.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithTitle;
+
+class SheetWithHeadings implements FromCollection, WithHeadings, WithTitle
+{
+    public function __construct(private string $title)
+    {
+    }
+
+    public function title(): string
+    {
+        return $this->title;
+    }
+
+    public function headings(): array
+    {
+        return ['id', 'name'];
+    }
+
+    public function collection(): Collection
+    {
+        return collect();
+    }
+}

--- a/tests/PhpSpreadsheetV5CompatibilityTest.php
+++ b/tests/PhpSpreadsheetV5CompatibilityTest.php
@@ -309,13 +309,17 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
             public function sheets(): array
             {
                 return [
-                    'Sheet1' => new class {
+                    'Sheet1' => new class
+                    {
                     },
-                    'NonExistent1' => new class {
+                    'NonExistent1' => new class
+                    {
                     },
-                    'Sheet2' => new class {
+                    'Sheet2' => new class
+                    {
                     },
-                    'NonExistent2' => new class {
+                    'NonExistent2' => new class
+                    {
                     },
                 ];
             }

--- a/tests/QueuedExportTest.php
+++ b/tests/QueuedExportTest.php
@@ -16,6 +16,7 @@ use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportWithFailedEvents;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportWithFailedHook;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportWithLocalePreferences;
+use Maatwebsite\Excel\Tests\Data\Stubs\QueuedMultiSheetExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\ShouldBatchExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\ShouldQueueExport;
 use Throwable;
@@ -162,6 +163,21 @@ class QueuedExportTest extends TestCase
         $this->assertTrue(app('queue-has-correct-locale'));
 
         $this->assertEquals($currentLocale, app()->getLocale());
+    }
+
+    public function test_queued_multi_sheet_export_with_headings()
+    {
+        $export = new QueuedMultiSheetExport;
+
+        $export->store('queued-multi-sheet-export.xlsx', 'test');
+
+        $spreadsheet = $this->read(__DIR__ . '/Data/Disks/Test/queued-multi-sheet-export.xlsx', 'Xlsx');
+
+        $this->assertCount(2, $spreadsheet->getAllSheets());
+        $this->assertEquals('First sheet', $spreadsheet->getSheet(0)->getTitle());
+        $this->assertEquals('Second sheet', $spreadsheet->getSheet(1)->getTitle());
+        $this->assertEquals(['id', 'name'], $spreadsheet->getSheet(0)->toArray()[0]);
+        $this->assertEquals(['id', 'name'], $spreadsheet->getSheet(1)->toArray()[0]);
     }
 
     public function test_can_queue_export_not_flushing_the_cache()


### PR DESCRIPTION
Fixes #4365 