### PR TITLE
Handle concurrent temporary directory creation

### DIFF
--- a/src/Files/TemporaryFileFactory.php
+++ b/src/Files/TemporaryFileFactory.php
@@ -46,7 +46,7 @@ class TemporaryFileFactory
      */
     public function makeLocal(?string $fileName = null, ?string $fileExtension = null): LocalTemporaryFile
     {
-        if (!file_exists($this->temporaryPath) && !mkdir($concurrentDirectory = $this->temporaryPath, config('excel.temporary_files.local_permissions.dir', 0777), true) && !is_dir($concurrentDirectory)) {
+        if (!is_dir($this->temporaryPath) && !@mkdir($concurrentDirectory = $this->temporaryPath, config('excel.temporary_files.local_permissions.dir', 0777), true) && !is_dir($concurrentDirectory)) {
             throw new \RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
         }
 

--- a/tests/TemporaryFileTest.php
+++ b/tests/TemporaryFileTest.php
@@ -4,6 +4,7 @@ namespace Maatwebsite\Excel\Tests;
 
 use Maatwebsite\Excel\Files\TemporaryFileFactory;
 use Maatwebsite\Excel\Tests\Helpers\FileHelper;
+use RuntimeException;
 
 class TemporaryFileTest extends TestCase
 {
@@ -80,5 +81,24 @@ class TemporaryFileTest extends TestCase
         $this->assertFileExists($temporaryFile->getLocalPath());
         $this->assertEquals($this->defaultDirectoryPermissions, substr(sprintf('%o', fileperms(dirname($temporaryFile->getLocalPath()))), -4));
         $this->assertEquals('0600', substr(sprintf('%o', fileperms($temporaryFile->getLocalPath())), -4));
+    }
+
+    public function test_cannot_use_file_as_temporary_directory()
+    {
+        $path = FileHelper::absolutePath('temporary-directory-file', 'local');
+        FileHelper::recursiveDelete($path);
+
+        touch($path);
+        config()->set('excel.temporary_files.local_path', $path);
+
+        try {
+            app(TemporaryFileFactory::class)->makeLocal(null, 'txt');
+
+            $this->fail('Expected temporary file creation to fail.');
+        } catch (RuntimeException $e) {
+            $this->assertEquals(sprintf('Directory "%s" was not created', $path), $e->getMessage());
+        } finally {
+            @unlink($path);
+        }
     }
 }


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?
I am seeing errors in our CI that look like this:

```php
ErrorException: mkdir(): File exists in /builds/myapp/applications/my-app/api/vendor/maatwebsite/excel/src/Files/TemporaryFileFactory.php:49
Stack trace:
#0 /builds/myapp/applications/my-app/api/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(258): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError()
#1 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->{closure:Illuminate\Foundation\Bootstrap\HandleExceptions::forwardsTo():257}()
#2 /builds/myapp/applications/my-app/api/vendor/maatwebsite/excel/src/Files/TemporaryFileFactory.php(49): mkdir()
#3 /builds/myapp/applications/my-app/api/vendor/maatwebsite/excel/src/Reader.php(438): Maatwebsite\Excel\Files\TemporaryFileFactory->makeLocal()
#4 /builds/myapp/applications/my-app/api/vendor/maatwebsite/excel/src/Reader.php(200): Maatwebsite\Excel\Reader->getReader()
#5 /builds/myapp/applications/my-app/api/vendor/maatwebsite/excel/src/Excel.php(181): Maatwebsite\Excel\Reader->toCollection()
```

My understanding is that it's a race condition caused by parallelized tests attempting to create the same directory.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣  Does it include tests, if possible?
Yes

4️⃣  Any drawbacks? Possible breaking changes?
I don't think this is a breaking change.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
