### PR TITLE
Docs: warn that FromQuery requires a unique ORDER BY

### DIFF
--- a/src/Concerns/FromQuery.php
+++ b/src/Concerns/FromQuery.php
@@ -10,6 +10,34 @@ use Laravel\Scout\Builder as ScoutBuilder;
 interface FromQuery
 {
     /**
+     * Return the builder whose rows should be exported.
+     *
+     * The export walks this query in chunks via Laravel's `Builder::chunk()`,
+     * which paginates with `LIMIT/OFFSET`. For chunked pagination to be safe
+     * the query MUST have a deterministic, unique `ORDER BY`. If multiple
+     * rows share the primary sort value, the database engine is free to
+     * return tied rows in a different order between paginated queries —
+     * which causes some rows to appear in two chunks and others to be
+     * skipped entirely, with no error raised.
+     *
+     * Always append a unique tie-breaker — typically the primary key:
+     *
+     *     return Person::query()
+     *         ->orderBy('created_at', 'desc')
+     *         ->orderBy('id', 'asc');   // stable tie-breaker
+     *
+     * UUID primary keys make this pitfall noticeably more likely to bite.
+     * With auto-incrementing integer keys, InnoDB stores rows in PK order,
+     * which often happens to match insertion order — so ties in
+     * `created_at` resolve "naturally" in a stable way and the bug stays
+     * latent. With random (v4) UUIDs the storage layout is decorrelated
+     * from insertion time and the filesort no longer hides ties; the same
+     * code that ran fine for years on integer PKs starts dropping and
+     * duplicating rows the day it's deployed against a UUID table. UUIDs
+     * have a deterministic lexicographic total order, so `orderBy('id')`
+     * still works as a tie-breaker — there's no special handling needed,
+     * just always set one.
+     *
      * @return Builder|EloquentBuilder|Relation|ScoutBuilder
      */
     public function query();


### PR DESCRIPTION
## Why

`FromQuery` exports walk the supplied builder through Laravel's
`Builder::chunk()`, which paginates with `LIMIT/OFFSET`. If the source
query lacks a *unique* `ORDER BY`, the database engine is free to
reorder tied rows between subsequent paginated queries. The result: at
every chunk boundary one row can appear in two chunks while another
slips out, with no warning raised.

Laravel's chunking docs do warn about a related (but different)
problem — modifying the chunked column while iterating — and recommend
`chunkById` there. The simpler case where a non-unique `ORDER BY`
alone causes the same drop-or-duplicate symptom isn't explicitly
called out, so every consumer of `FromQuery` ends up re-discovering
it. A recent example in our codebase: a Nova-driven Excel export of
~4,600 rows, ordered only by `created_at` because that felt
sufficient. Bulk-imported records shared the same timestamp second
(33 rows per second in places). The export silently produced
duplicates and gaps that took several support hours to diagnose.

This PR adds nothing more than a docblock on `FromQuery::query()`
explaining the requirement and showing the typical fix (append
`orderBy('id', 'asc')` as a tie-breaker). It also calls out that UUID
primary keys make the bug noticeably more likely to surface — a useful
nudge as more codebases move to UUID PKs and stumble into this for the
first time on data that used to "just work" on integer PKs.

## What

- `src/Concerns/FromQuery.php` — docblock added to `query()`.

No behaviour change. No new dependencies.

## Why a docs-only change?

Detecting the condition at runtime (sniffing the builder for a unique
`ORDER BY`) would be invasive and prone to false positives — the
caller knows whether their sort columns are unique, the package
doesn't. A clear warning at the point developers read the contract
seems like the lowest-cost, highest-leverage fix.

---

Diagnosed and drafted together with Claude Opus 4.7 — it traced the
chunk-boundary symptom back to the missing tie-breaker, helped frame
the UUID-vs-integer-PK angle, and wrote the docblock. Posting under my
own review and responsibility.