### PR TITLE
Modernise (PHP 8.3) using PHP-cs-fixer

### DIFF
--- a/src/Cache/BatchCache.php
+++ b/src/Cache/BatchCache.php
@@ -37,7 +37,7 @@ class BatchCache implements CacheInterface
         return ['memory'];
     }
 
-    public function __wakeup()
+    public function __wakeup(): void
     {
         $this->cache = Cache::driver(
             config('excel.cache.illuminate.store')

--- a/src/Cache/BatchCacheDeprecated.php
+++ b/src/Cache/BatchCacheDeprecated.php
@@ -40,7 +40,7 @@ class BatchCacheDeprecated implements CacheInterface
         return ['memory'];
     }
 
-    public function __wakeup()
+    public function __wakeup(): void
     {
         $this->cache = Cache::driver(
             config('excel.cache.illuminate.store')

--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -76,7 +76,7 @@ class CacheManager extends Manager
         );
     }
 
-    public function flush()
+    public function flush(): void
     {
         $this->driver()->clear();
     }

--- a/src/ChunkReader.php
+++ b/src/ChunkReader.php
@@ -87,7 +87,7 @@ class ChunkReader
             $afterImportJob->setDependencies($jobs);
             $jobs->push($afterImportJob->delay($delayCleanup));
 
-            return $jobs->each(function ($job) use ($queue) {
+            return $jobs->each(function ($job) use ($queue): void {
                 dispatch($job->onQueue($queue));
             });
         }
@@ -108,7 +108,7 @@ class ChunkReader
             );
         }
 
-        $jobs->each(function ($job) {
+        $jobs->each(function ($job): void {
             try {
                 $this->dispatchNow($job);
             } catch (Throwable $e) {

--- a/src/Concerns/MapsCsvSettings.php
+++ b/src/Concerns/MapsCsvSettings.php
@@ -61,7 +61,7 @@ trait MapsCsvSettings
      */
     protected static $testAutoDetect = true;
 
-    public static function applyCsvSettings(array $config)
+    public static function applyCsvSettings(array $config): void
     {
         static::$delimiter            = Arr::get($config, 'delimiter', static::$delimiter);
         static::$enclosure            = Arr::get($config, 'enclosure', static::$enclosure);

--- a/src/Concerns/RemembersChunkOffset.php
+++ b/src/Concerns/RemembersChunkOffset.php
@@ -9,7 +9,7 @@ trait RemembersChunkOffset
      */
     protected $chunkOffset;
 
-    public function setChunkOffset(int $chunkOffset)
+    public function setChunkOffset(int $chunkOffset): void
     {
         $this->chunkOffset = $chunkOffset;
     }

--- a/src/Concerns/RemembersRowNumber.php
+++ b/src/Concerns/RemembersRowNumber.php
@@ -9,7 +9,7 @@ trait RemembersRowNumber
      */
     protected $rowNumber;
 
-    public function rememberRowNumber(int $rowNumber)
+    public function rememberRowNumber(int $rowNumber): void
     {
         $this->rowNumber = $rowNumber;
     }

--- a/src/Concerns/SkipsErrors.php
+++ b/src/Concerns/SkipsErrors.php
@@ -12,7 +12,7 @@ trait SkipsErrors
      */
     protected $errors = [];
 
-    public function onError(Throwable $e)
+    public function onError(Throwable $e): void
     {
         $this->errors[] = $e;
     }

--- a/src/Concerns/SkipsFailures.php
+++ b/src/Concerns/SkipsFailures.php
@@ -12,7 +12,7 @@ trait SkipsFailures
      */
     protected $failures = [];
 
-    public function onFailure(Failure ...$failures)
+    public function onFailure(Failure ...$failures): void
     {
         $this->failures = array_merge($this->failures, $failures);
     }

--- a/src/Console/ExportMakeCommand.php
+++ b/src/Console/ExportMakeCommand.php
@@ -76,7 +76,9 @@ class ExportMakeCommand extends GeneratorCommand
         }
 
         return str_replace(
-            array_keys($replace), array_values($replace), parent::buildClass($name)
+            array_keys($replace),
+            array_values($replace),
+            parent::buildClass($name)
         );
     }
 

--- a/src/Console/ImportMakeCommand.php
+++ b/src/Console/ImportMakeCommand.php
@@ -70,7 +70,9 @@ class ImportMakeCommand extends GeneratorCommand
         }
 
         return str_replace(
-            array_keys($replace), array_values($replace), parent::buildClass($name)
+            array_keys($replace),
+            array_values($replace),
+            parent::buildClass($name)
         );
     }
 

--- a/src/Excel.php
+++ b/src/Excel.php
@@ -16,29 +16,29 @@ class Excel implements Exporter, Importer
 {
     use Macroable, RegistersCustomConcerns;
 
-    const XLSX = 'Xlsx';
+    public const XLSX = 'Xlsx';
 
-    const CSV = 'Csv';
+    public const CSV = 'Csv';
 
-    const TSV = 'Csv';
+    public const TSV = 'Csv';
 
-    const ODS = 'Ods';
+    public const ODS = 'Ods';
 
-    const XLS = 'Xls';
+    public const XLS = 'Xls';
 
-    const SLK = 'Slk';
+    public const SLK = 'Slk';
 
-    const XML = 'Xml';
+    public const XML = 'Xml';
 
-    const GNUMERIC = 'Gnumeric';
+    public const GNUMERIC = 'Gnumeric';
 
-    const HTML = 'Html';
+    public const HTML = 'Html';
 
-    const MPDF = 'Mpdf';
+    public const MPDF = 'Mpdf';
 
-    const DOMPDF = 'Dompdf';
+    public const DOMPDF = 'Dompdf';
 
-    const TCPDF = 'Tcpdf';
+    public const TCPDF = 'Tcpdf';
 
     /**
      * @var Writer

--- a/src/ExcelServiceProvider.php
+++ b/src/ExcelServiceProvider.php
@@ -26,7 +26,7 @@ class ExcelServiceProvider extends ServiceProvider
     /**
      * {@inheritdoc}
      */
-    public function boot()
+    public function boot(): void
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
@@ -49,7 +49,7 @@ class ExcelServiceProvider extends ServiceProvider
 
         if ($this->app instanceof Application) {
             // Laravel
-            $this->app->booted(function ($app) {
+            $this->app->booted(function ($app): void {
                 $app->make(SettingsProvider::class)->provide();
             });
         } else {
@@ -62,7 +62,7 @@ class ExcelServiceProvider extends ServiceProvider
      * {@inheritdoc}
      */
     #[\Override]
-    public function register()
+    public function register(): void
     {
         $this->mergeConfigFrom(
             $this->getConfigFile(),

--- a/src/Facades/Excel.php
+++ b/src/Facades/Excel.php
@@ -32,10 +32,8 @@ class Excel extends Facade
 {
     /**
      * Replace the bound instance with a fake.
-     *
-     * @return void
      */
-    public static function fake()
+    public static function fake(): void
     {
         static::swap(new ExcelFake);
     }

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -98,7 +98,7 @@ class ExcelFake implements Exporter, Importer
         {
             use Queueable;
 
-            public function handle()
+            public function handle(): void
             {
                 //
             }
@@ -186,7 +186,7 @@ class ExcelFake implements Exporter, Importer
         {
             use Queueable;
 
-            public function handle()
+            public function handle(): void
             {
                 //
             }
@@ -205,10 +205,8 @@ class ExcelFake implements Exporter, Importer
     /**
      * When asserting downloaded, stored, queued or imported, use regular expression
      * to look for a matching file path.
-     *
-     * @return void
      */
-    public function matchByRegex()
+    public function matchByRegex(): void
     {
         $this->matchByRegex = true;
     }
@@ -216,10 +214,8 @@ class ExcelFake implements Exporter, Importer
     /**
      * When asserting downloaded, stored, queued or imported, use regular string
      * comparison for matching file path.
-     *
-     * @return void
      */
-    public function doNotMatchByRegex()
+    public function doNotMatchByRegex(): void
     {
         $this->matchByRegex = false;
     }
@@ -227,7 +223,7 @@ class ExcelFake implements Exporter, Importer
     /**
      * @param  callable|null  $callback
      */
-    public function assertDownloaded(string $fileName, $callback = null)
+    public function assertDownloaded(string $fileName, $callback = null): void
     {
         $fileName = $this->assertArrayHasKey($fileName, $this->downloads, sprintf('%s is not downloaded', $fileName));
 
@@ -243,7 +239,7 @@ class ExcelFake implements Exporter, Importer
      * @param  string|callable|null  $disk
      * @param  callable|null  $callback
      */
-    public function assertStored(string $filePath, $disk = null, $callback = null)
+    public function assertStored(string $filePath, $disk = null, $callback = null): void
     {
         if (is_callable($disk)) {
             $callback = $disk;
@@ -271,7 +267,7 @@ class ExcelFake implements Exporter, Importer
      * @param  string|callable|null  $disk
      * @param  callable|null  $callback
      */
-    public function assertQueued(string $filePath, $disk = null, $callback = null)
+    public function assertQueued(string $filePath, $disk = null, $callback = null): void
     {
         if (is_callable($disk)) {
             $callback = $disk;
@@ -303,7 +299,7 @@ class ExcelFake implements Exporter, Importer
     /**
      * @param  callable|null  $callback
      */
-    public function assertExportedInRaw(string $classname, $callback = null)
+    public function assertExportedInRaw(string $classname, $callback = null): void
     {
         Assert::assertArrayHasKey($classname, $this->raws, sprintf('%s is not exported in raw', $classname));
 
@@ -319,7 +315,7 @@ class ExcelFake implements Exporter, Importer
      * @param  string|callable|null  $disk
      * @param  callable|null  $callback
      */
-    public function assertImported(string $filePath, $disk = null, $callback = null)
+    public function assertImported(string $filePath, $disk = null, $callback = null): void
     {
         if (is_callable($disk)) {
             $callback = $disk;

--- a/src/Files/Disk.php
+++ b/src/Files/Disk.php
@@ -78,7 +78,7 @@ class Disk
         return $success;
     }
 
-    public function touch(string $filename)
+    public function touch(string $filename): void
     {
         $this->disk->put($filename, '', $this->diskOptions);
     }

--- a/src/Files/LocalTemporaryFile.php
+++ b/src/Files/LocalTemporaryFile.php
@@ -54,7 +54,7 @@ class LocalTemporaryFile extends TemporaryFile
     /**
      * @param @param string|resource $contents
      */
-    public function put($contents)
+    public function put($contents): void
     {
         file_put_contents($this->filePath, $contents);
     }

--- a/src/Files/RemoteTemporaryFile.php
+++ b/src/Files/RemoteTemporaryFile.php
@@ -70,7 +70,7 @@ class RemoteTemporaryFile extends TemporaryFile
     /**
      * Store on remote disk.
      */
-    public function updateRemote()
+    public function updateRemote(): void
     {
         $this->disk()->copy(
             $this->localTemporaryFile,
@@ -94,7 +94,7 @@ class RemoteTemporaryFile extends TemporaryFile
     /**
      * @param  string|resource  $contents
      */
-    public function put($contents)
+    public function put($contents): void
     {
         $this->disk()->put($this->filename, $contents);
     }

--- a/src/Files/TemporaryFileFactory.php
+++ b/src/Files/TemporaryFileFactory.php
@@ -21,7 +21,7 @@ class TemporaryFileFactory
 
     public function makeLocal(?string $fileName = null, ?string $fileExtension = null): LocalTemporaryFile
     {
-        if (!file_exists($this->temporaryPath) && !mkdir($concurrentDirectory = $this->temporaryPath, config('excel.temporary_files.local_permissions.dir', 0777), true) && !is_dir($concurrentDirectory)) {
+        if (!file_exists($this->temporaryPath) && !mkdir($concurrentDirectory = $this->temporaryPath, config('excel.temporary_files.local_permissions.dir', 0o777), true) && !is_dir($concurrentDirectory)) {
             throw new \RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
         }
 

--- a/src/HasEventBus.php
+++ b/src/HasEventBus.php
@@ -17,14 +17,14 @@ trait HasEventBus
     /**
      * Register local event listeners.
      */
-    public function registerListeners(array $listeners)
+    public function registerListeners(array $listeners): void
     {
         foreach ($listeners as $event => $listener) {
             $this->events[$event][] = $listener;
         }
     }
 
-    public function clearListeners()
+    public function clearListeners(): void
     {
         $this->events = [];
     }
@@ -32,7 +32,7 @@ trait HasEventBus
     /**
      * Register a global event listener.
      */
-    public static function listen(string $event, callable $listener)
+    public static function listen(string $event, callable $listener): void
     {
         static::$globalEvents[$event][] = $listener;
     }
@@ -40,7 +40,7 @@ trait HasEventBus
     /**
      * @param  object  $event
      */
-    public function raise($event)
+    public function raise($event): void
     {
         foreach ($this->listeners($event) as $listener) {
             $listener($event);

--- a/src/Imports/HeadingRowExtractor.php
+++ b/src/Imports/HeadingRowExtractor.php
@@ -14,7 +14,7 @@ class HeadingRowExtractor
     /**
      * @const int
      */
-    const DEFAULT_HEADING_ROW = 1;
+    public const DEFAULT_HEADING_ROW = 1;
 
     /**
      * @param  WithHeadingRow|mixed  $importable
@@ -71,7 +71,7 @@ class HeadingRowExtractor
             return $headerIsGrouped;
         }
 
-        array_walk($headerIsGrouped, function (&$value, $key) use ($headingRow) {
+        array_walk($headerIsGrouped, function (&$value, $key) use ($headingRow): void {
             if (array_count_values($headingRow)[$headingRow[$key]] > 1) {
                 $value = true;
             }

--- a/src/Imports/HeadingRowFormatter.php
+++ b/src/Imports/HeadingRowFormatter.php
@@ -11,12 +11,12 @@ class HeadingRowFormatter
     /**
      * @const string
      */
-    const FORMATTER_NONE = 'none';
+    public const FORMATTER_NONE = 'none';
 
     /**
      * @const string
      */
-    const FORMATTER_SLUG = 'slug';
+    public const FORMATTER_SLUG = 'slug';
 
     /**
      * @var string
@@ -41,7 +41,7 @@ class HeadingRowFormatter
         return (new Collection($headings))->map(fn ($value, $key) => static::callFormatter($value, $key))->toArray();
     }
 
-    public static function default(?string $name = null)
+    public static function default(?string $name = null): void
     {
         if ($name !== null && !isset(static::$customFormatters[$name]) && !in_array($name, static::$defaultFormatters, true)) {
             throw new InvalidArgumentException(sprintf('Formatter "%s" does not exist', $name));
@@ -50,7 +50,7 @@ class HeadingRowFormatter
         static::$formatter = $name;
     }
 
-    public static function extend(string $name, callable $formatter)
+    public static function extend(string $name, callable $formatter): void
     {
         static::$customFormatters[$name] = $formatter;
     }
@@ -58,7 +58,7 @@ class HeadingRowFormatter
     /**
      * Reset the formatter.
      */
-    public static function reset()
+    public static function reset(): void
     {
         static::default();
     }

--- a/src/Imports/ModelImporter.php
+++ b/src/Imports/ModelImporter.php
@@ -32,7 +32,7 @@ class ModelImporter
      *
      * @throws ValidationException
      */
-    public function import(Worksheet $worksheet, ToModel $import, int $startRow = 1)
+    public function import(Worksheet $worksheet, ToModel $import, int $startRow = 1): void
     {
         if ($startRow > $worksheet->getHighestRow()) {
             return;
@@ -99,7 +99,7 @@ class ModelImporter
         }
     }
 
-    private function flush(ToModel $import, int $batchSize, int $startRow)
+    private function flush(ToModel $import, int $batchSize, int $startRow): void
     {
         $this->manager->flush($import, $batchSize > 1);
         $this->raise(new AfterBatch($this->manager, $import, $batchSize, $startRow));

--- a/src/Imports/ModelManager.php
+++ b/src/Imports/ModelManager.php
@@ -33,12 +33,12 @@ class ModelManager
     {
     }
 
-    public function add(int $row, array $attributes)
+    public function add(int $row, array $attributes): void
     {
         $this->rows[$row] = $attributes;
     }
 
-    public function setRemembersRowNumber(bool $remembersRowNumber)
+    public function setRemembersRowNumber(bool $remembersRowNumber): void
     {
         $this->remembersRowNumber = $remembersRowNumber;
     }
@@ -46,7 +46,7 @@ class ModelManager
     /**
      * @throws ValidationException
      */
-    public function flush(ToModel $import, bool $massInsert = false)
+    public function flush(ToModel $import, bool $massInsert = false): void
     {
         if ($import instanceof WithValidation) {
             $this->validateRows($import);
@@ -74,12 +74,12 @@ class ModelManager
         return Collection::wrap($import->model($attributes));
     }
 
-    private function massFlush(ToModel $import)
+    private function massFlush(ToModel $import): void
     {
         $this->rows()
             ->flatMap(fn (array $attributes, $index) => $this->toModels($import, $attributes, $index))
             ->mapToGroups(fn ($model) => [$model::class => $this->prepare($model)->getAttributes()])
-            ->each(function (Collection $models, string $model) use ($import) {
+            ->each(function (Collection $models, string $model) use ($import): void {
                 try {
                     /* @var Model $model */
 
@@ -104,12 +104,12 @@ class ModelManager
             });
     }
 
-    private function singleFlush(ToModel $import)
+    private function singleFlush(ToModel $import): void
     {
         $this
             ->rows()
-            ->each(function (array $attributes, $index) use ($import) {
-                $this->toModels($import, $attributes, $index)->each(function (Model $model) use ($import) {
+            ->each(function (array $attributes, $index) use ($import): void {
+                $this->toModels($import, $attributes, $index)->each(function (Model $model) use ($import): void {
                     try {
                         if ($import instanceof WithUpserts) {
                             $model->upsert(
@@ -163,7 +163,7 @@ class ModelManager
     /**
      * @throws ValidationException
      */
-    private function validateRows(WithValidation $import)
+    private function validateRows(WithValidation $import): void
     {
         try {
             $this->validator->validate($this->rows, $import);

--- a/src/Jobs/AfterImportJob.php
+++ b/src/Jobs/AfterImportJob.php
@@ -32,17 +32,17 @@ class AfterImportJob implements ShouldQueue
     {
     }
 
-    public function setInterval(int $interval)
+    public function setInterval(int $interval): void
     {
         $this->interval = $interval;
     }
 
-    public function setDependencies(Collection $jobs)
+    public function setDependencies(Collection $jobs): void
     {
         $this->dependencyIds = $jobs->map(fn (ReadChunk $job) => $job->getUniqueId())->all();
     }
 
-    public function handle()
+    public function handle(): void
     {
         // Determine if the batch has been cancelled...
         if ($this->batch()?->cancelled()) {
@@ -67,7 +67,7 @@ class AfterImportJob implements ShouldQueue
         $this->reader->afterImport($this->import);
     }
 
-    public function failed(Throwable $e)
+    public function failed(Throwable $e): void
     {
         if ($this->import instanceof WithEvents) {
             $this->registerListeners($this->import->registerEvents());

--- a/src/Jobs/AppendDataToSheet.php
+++ b/src/Jobs/AppendDataToSheet.php
@@ -61,14 +61,14 @@ class AppendDataToSheet implements ShouldQueue
      * @throws Exception
      * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception
      */
-    public function handle(Writer $writer)
+    public function handle(Writer $writer): void
     {
         // Determine if the batch has been cancelled...
         if ($this->batch()?->cancelled()) {
             return;
         }
 
-        (new LocalizeJob($this->sheetExport))->handle($this, function () use ($writer) {
+        (new LocalizeJob($this->sheetExport))->handle($this, function () use ($writer): void {
             $writer = $writer->reopen($this->temporaryFile, $this->writerType);
 
             $sheet = $writer->getSheetByIndex($this->sheetIndex);

--- a/src/Jobs/AppendPaginatedToSheet.php
+++ b/src/Jobs/AppendPaginatedToSheet.php
@@ -81,14 +81,14 @@ class AppendPaginatedToSheet implements ShouldQueue
      * @throws Exception
      * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception
      */
-    public function handle(Writer $writer)
+    public function handle(Writer $writer): void
     {
         // Determine if the batch has been cancelled...
         if ($this->batch()?->cancelled()) {
             return;
         }
 
-        (new LocalizeJob($this->sheetExport))->handle($this, function () use ($writer) {
+        (new LocalizeJob($this->sheetExport))->handle($this, function () use ($writer): void {
             $writer = $writer->reopen($this->temporaryFile, $this->writerType);
 
             $sheet = $writer->getSheetByIndex($this->sheetIndex);

--- a/src/Jobs/AppendQueryToSheet.php
+++ b/src/Jobs/AppendQueryToSheet.php
@@ -80,14 +80,14 @@ class AppendQueryToSheet implements ShouldQueue
      * @throws Exception
      * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception
      */
-    public function handle(Writer $writer)
+    public function handle(Writer $writer): void
     {
         // Determine if the batch has been cancelled...
         if ($this->batch()?->cancelled()) {
             return;
         }
 
-        (new LocalizeJob($this->sheetExport))->handle($this, function () use ($writer) {
+        (new LocalizeJob($this->sheetExport))->handle($this, function () use ($writer): void {
             if ($this->sheetExport instanceof WithEvents) {
                 $this->registerListeners($this->sheetExport->registerEvents());
             }

--- a/src/Jobs/AppendViewToSheet.php
+++ b/src/Jobs/AppendViewToSheet.php
@@ -62,14 +62,14 @@ class AppendViewToSheet implements ShouldQueue
      * @throws Exception
      * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception
      */
-    public function handle(Writer $writer)
+    public function handle(Writer $writer): void
     {
         // Determine if the batch has been cancelled...
         if ($this->batch()?->cancelled()) {
             return;
         }
 
-        (new LocalizeJob($this->sheetExport))->handle($this, function () use ($writer) {
+        (new LocalizeJob($this->sheetExport))->handle($this, function () use ($writer): void {
             $writer = $writer->reopen($this->temporaryFile, $this->writerType);
 
             $sheet = $writer->getSheetByIndex($this->sheetIndex);

--- a/src/Jobs/CloseSheet.php
+++ b/src/Jobs/CloseSheet.php
@@ -27,7 +27,7 @@ class CloseSheet implements ShouldQueue
      * @throws Exception
      * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception
      */
-    public function handle(Writer $writer)
+    public function handle(Writer $writer): void
     {
         // Determine if the batch has been cancelled...
         if ($this->batch()?->cancelled()) {

--- a/src/Jobs/ExtendedQueueable.php
+++ b/src/Jobs/ExtendedQueueable.php
@@ -15,7 +15,7 @@ trait ExtendedQueueable
      */
     public function chain($chain)
     {
-        collect($chain)->each(function ($job) {
+        collect($chain)->each(function ($job): void {
             $serialized      = method_exists($this, 'serializeJob') ? $this->serializeJob($job) : serialize($job);
             $this->chained[] = $serialized;
         });

--- a/src/Jobs/ProxyFailures.php
+++ b/src/Jobs/ProxyFailures.php
@@ -6,7 +6,7 @@ use Throwable;
 
 trait ProxyFailures
 {
-    public function failed(Throwable $e)
+    public function failed(Throwable $e): void
     {
         if (method_exists($this->sheetExport, 'failed')) {
             $this->sheetExport->failed($e);

--- a/src/Jobs/QueueExport.php
+++ b/src/Jobs/QueueExport.php
@@ -38,14 +38,14 @@ class QueueExport implements ShouldQueue
     /**
      * @throws Exception
      */
-    public function handle(Writer $writer)
+    public function handle(Writer $writer): void
     {
         // Determine if the batch has been cancelled...
         if ($this->batch()?->cancelled()) {
             return;
         }
 
-        (new LocalizeJob($this->export))->handle($this, function () use ($writer) {
+        (new LocalizeJob($this->export))->handle($this, function () use ($writer): void {
             $writer->open($this->export);
 
             $sheetExports = [$this->export];
@@ -68,7 +68,7 @@ class QueueExport implements ShouldQueue
         });
     }
 
-    public function failed(Throwable $e)
+    public function failed(Throwable $e): void
     {
         if (method_exists($this->export, 'failed')) {
             $this->export->failed($e);

--- a/src/Jobs/QueueImport.php
+++ b/src/Jobs/QueueImport.php
@@ -27,7 +27,7 @@ class QueueImport implements ShouldQueue
         }
     }
 
-    public function handle()
+    public function handle(): void
     {
         //
     }

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -116,7 +116,7 @@ class ReadChunk implements ShouldQueue
      * @throws SheetNotFoundException
      * @throws Exception
      */
-    public function handle(TransactionHandler $transaction)
+    public function handle(TransactionHandler $transaction): void
     {
         // Determine if the batch has been cancelled...
         if ($this->batch()?->cancelled()) {
@@ -165,7 +165,7 @@ class ReadChunk implements ShouldQueue
             return;
         }
 
-        $transaction(function () use ($sheet) {
+        $transaction(function () use ($sheet): void {
             $sheet->import(
                 $this->sheetImport,
                 $this->startRow
@@ -179,7 +179,7 @@ class ReadChunk implements ShouldQueue
         });
     }
 
-    public function failed(Throwable $e)
+    public function failed(Throwable $e): void
     {
         $this->cleanUpTempFile(true);
 

--- a/src/Jobs/StoreQueuedExport.php
+++ b/src/Jobs/StoreQueuedExport.php
@@ -21,7 +21,7 @@ class StoreQueuedExport implements ShouldQueue
     {
     }
 
-    public function handle(Filesystem $filesystem)
+    public function handle(Filesystem $filesystem): void
     {
         // Determine if the batch has been cancelled...
         if ($this->batch()?->cancelled()) {

--- a/src/MappedReader.php
+++ b/src/MappedReader.php
@@ -17,10 +17,10 @@ class MappedReader
     /**
      * @throws Exception
      */
-    public function map(WithMappedCells $import, Worksheet $worksheet)
+    public function map(WithMappedCells $import, Worksheet $worksheet): void
     {
         $mapped = $import->mapping();
-        array_walk_recursive($mapped, function (&$coordinate) use ($import, $worksheet) {
+        array_walk_recursive($mapped, function (&$coordinate) use ($import, $worksheet): void {
             $cell = Cell::make($worksheet, $coordinate);
 
             $coordinate = $cell->getValue(

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -79,7 +79,7 @@ class Reader
         return ['spreadsheet', 'sheetImports', 'currentFile', 'temporaryFileFactory', 'reader'];
     }
 
-    public function __wakeup()
+    public function __wakeup(): void
     {
         $this->transaction = app(TransactionHandler::class);
     }
@@ -104,7 +104,7 @@ class Reader
         try {
             $this->loadSpreadsheet($import);
 
-            ($this->transaction)(function () use ($import) {
+            ($this->transaction)(function () use ($import): void {
                 $sheetsToDisconnect = [];
 
                 foreach ($this->sheetImports as $index => $sheetImport) {
@@ -239,7 +239,7 @@ class Reader
     /**
      * @param  object  $import
      */
-    public function loadSpreadsheet($import)
+    public function loadSpreadsheet($import): void
     {
         $this->sheetImports = $this->buildSheetImports($import);
 
@@ -254,7 +254,7 @@ class Reader
         $this->beforeImport($import);
     }
 
-    public function readSpreadsheet()
+    public function readSpreadsheet(): void
     {
         $this->spreadsheet = $this->reader->load(
             $this->currentFile->getLocalPath()
@@ -264,7 +264,7 @@ class Reader
     /**
      * @param  object  $import
      */
-    public function beforeImport($import)
+    public function beforeImport($import): void
     {
         $this->raise(new BeforeImport($this, $import));
     }
@@ -272,7 +272,7 @@ class Reader
     /**
      * @param  object  $import
      */
-    public function afterImport($import)
+    public function afterImport($import): void
     {
         $this->raise(new AfterImport($this, $import));
 
@@ -431,7 +431,7 @@ class Reader
     /**
      * Garbage collect.
      */
-    private function garbageCollect()
+    private function garbageCollect(): void
     {
         $this->clearListeners();
         $this->setDefaultValueBinder();

--- a/src/RegistersCustomConcerns.php
+++ b/src/RegistersCustomConcerns.php
@@ -20,12 +20,12 @@ trait RegistersCustomConcerns
         AfterSheet::class    => Sheet::class,
     ];
 
-    public static function extend(string $concern, callable $handler, string $event = BeforeWriting::class)
+    public static function extend(string $concern, callable $handler, string $event = BeforeWriting::class): void
     {
         /** @var HasEventBus $delegate */
         $delegate = static::$eventMap[$event] ?? BeforeWriting::class;
 
-        $delegate::listen($event, function (Event $event) use ($concern, $handler) {
+        $delegate::listen($event, function (Event $event) use ($concern, $handler): void {
             if ($event->appliesToConcern($concern)) {
                 $handler($event->getConcernable(), $event->getDelegate());
             }

--- a/src/Row.php
+++ b/src/Row.php
@@ -137,13 +137,13 @@ class Row implements ArrayAccess
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         //
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         //
     }
@@ -151,7 +151,7 @@ class Row implements ArrayAccess
     /**
      * @internal
      */
-    public function setPreparationCallback(?Closure $preparationCallback = null)
+    public function setPreparationCallback(?Closure $preparationCallback = null): void
     {
         $this->preparationCallback = $preparationCallback;
     }

--- a/src/SettingsProvider.php
+++ b/src/SettingsProvider.php
@@ -14,12 +14,12 @@ class SettingsProvider
     /**
      * Provide PhpSpreadsheet settings.
      */
-    public function provide()
+    public function provide(): void
     {
         $this->configureCellCaching();
     }
 
-    protected function configureCellCaching()
+    protected function configureCellCaching(): void
     {
         Settings::setCache(
             $this->cache->driver()

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -135,7 +135,7 @@ class Sheet
      *
      * @throws Exception
      */
-    public function open($sheetExport)
+    public function open($sheetExport): void
     {
         $this->exportable = $sheetExport;
 
@@ -183,7 +183,7 @@ class Sheet
      * @throws Exception
      * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception
      */
-    public function export($sheetExport)
+    public function export($sheetExport): void
     {
         $this->open($sheetExport);
 
@@ -217,7 +217,7 @@ class Sheet
     /**
      * @param  object  $import
      */
-    public function import($import, int $startRow = 1)
+    public function import($import, int $startRow = 1): void
     {
         if ($import instanceof WithEvents) {
             $this->registerListeners($import->registerEvents());
@@ -384,7 +384,7 @@ class Sheet
      *
      * @throws Exception
      */
-    public function close($sheetExport)
+    public function close($sheetExport): void
     {
         if ($sheetExport instanceof WithCharts) {
             $this->addCharts($sheetExport->charts());
@@ -435,7 +435,7 @@ class Sheet
      *
      * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception
      */
-    public function fromView(FromView $sheetExport, $sheetIndex = null)
+    public function fromView(FromView $sheetExport, $sheetIndex = null): void
     {
         $temporaryFile = $this->temporaryFileFactory->makeLocal(null, 'html');
         $temporaryFile->put($sheetExport->view()->render());
@@ -452,7 +452,7 @@ class Sheet
         $temporaryFile->delete();
     }
 
-    public function fromQuery(FromQuery $sheetExport, Worksheet $worksheet)
+    public function fromQuery(FromQuery $sheetExport, Worksheet $worksheet): void
     {
         $query = $sheetExport->query();
         if ($query instanceof Builder) {
@@ -465,12 +465,12 @@ class Sheet
         // and use the clone operator directly to support old versions of Laravel
         // that don't have a clone method in eloquent
         $clonedQuery = clone $query;
-        $clonedQuery->chunk($this->getChunkSize($sheetExport), function ($chunk) use ($sheetExport) {
+        $clonedQuery->chunk($this->getChunkSize($sheetExport), function ($chunk) use ($sheetExport): void {
             $this->appendRows($chunk, $sheetExport);
         });
     }
 
-    public function fromScout(FromQuery $sheetExport, Worksheet $worksheet)
+    public function fromScout(FromQuery $sheetExport, Worksheet $worksheet): void
     {
         $scout     = $sheetExport->query();
         $chunkSize = $this->getChunkSize($sheetExport);
@@ -485,17 +485,17 @@ class Sheet
         }
     }
 
-    public function fromCollection(FromCollection $sheetExport)
+    public function fromCollection(FromCollection $sheetExport): void
     {
         $this->appendRows($sheetExport->collection()->all(), $sheetExport);
     }
 
-    public function fromArray(FromArray $sheetExport)
+    public function fromArray(FromArray $sheetExport): void
     {
         $this->appendRows($sheetExport->array(), $sheetExport);
     }
 
-    public function fromIterator(FromIterator $sheetExport)
+    public function fromIterator(FromIterator $sheetExport): void
     {
         $iterator = class_exists(LazyCollection::class) ? new LazyCollection(function () use ($sheetExport) {
             foreach ($sheetExport->iterator() as $row) {
@@ -506,7 +506,7 @@ class Sheet
         $this->appendRows($iterator, $sheetExport);
     }
 
-    public function fromGenerator(FromGenerator $sheetExport)
+    public function fromGenerator(FromGenerator $sheetExport): void
     {
         $generator = class_exists(LazyCollection::class) ? new LazyCollection(function () use ($sheetExport) {
             foreach ($sheetExport->generator() as $row) {
@@ -517,7 +517,7 @@ class Sheet
         $this->appendRows($generator, $sheetExport);
     }
 
-    public function append(array $rows, ?string $startCell = null, bool $strictNullComparison = false)
+    public function append(array $rows, ?string $startCell = null, bool $strictNullComparison = false): void
     {
         if (!$startCell) {
             $startCell = 'A1';
@@ -530,7 +530,7 @@ class Sheet
         $this->worksheet->fromArray($rows, null, $startCell, $strictNullComparison);
     }
 
-    public function autoSize()
+    public function autoSize(): void
     {
         foreach ($this->buildColumnRange('A', $this->worksheet->getHighestDataColumn()) as $col) {
             $dimension = $this->worksheet->getColumnDimension($col);
@@ -545,7 +545,7 @@ class Sheet
     /**
      * @throws Exception
      */
-    public function formatColumn(string $column, string $format)
+    public function formatColumn(string $column, string $format): void
     {
         // If the column is a range, we wouldn't need to calculate the range.
         if (stripos($column, ':') !== false) {
@@ -582,7 +582,7 @@ class Sheet
     /**
      * @param  Chart|Chart[]  $charts
      */
-    public function addCharts($charts)
+    public function addCharts($charts): void
     {
         $charts = \is_array($charts) ? $charts : [$charts];
 
@@ -594,7 +594,7 @@ class Sheet
     /**
      * @param  BaseDrawing|BaseDrawing[]  $drawings
      */
-    public function addDrawings($drawings)
+    public function addDrawings($drawings): void
     {
         $drawings = \is_array($drawings) ? $drawings : [$drawings];
 
@@ -612,7 +612,7 @@ class Sheet
      * @param  iterable  $rows
      * @param  object  $sheetExport
      */
-    public function appendRows($rows, $sheetExport)
+    public function appendRows($rows, $sheetExport): void
     {
         if (method_exists($sheetExport, 'prepareRows')) {
             $rows = $sheetExport->prepareRows($rows);
@@ -632,7 +632,7 @@ class Sheet
             return ArrayHelper::ensureMultipleRows(
                 static::mapArraybleRow($row)
             );
-        })->chunk(1000)->each(function ($rows) use ($sheetExport) {
+        })->chunk(1000)->each(function ($rows) use ($sheetExport): void {
             $this->append(
                 $rows->toArray(),
                 $sheetExport instanceof WithCustomStartCell ? $sheetExport->startCell() : null,
@@ -672,7 +672,7 @@ class Sheet
     /**
      * Disconnect the sheet.
      */
-    public function disconnect()
+    public function disconnect(): void
     {
         $this->worksheet->disconnectCells();
         unset($this->worksheet);

--- a/src/Validators/RowValidator.php
+++ b/src/Validators/RowValidator.php
@@ -19,7 +19,7 @@ class RowValidator
      * @throws ValidationException
      * @throws RowSkippedException
      */
-    public function validate(array $rows, WithValidation $import)
+    public function validate(array $rows, WithValidation $import): void
     {
         $rules      = $this->rules($import);
         $messages   = $this->messages($import);

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -238,7 +238,7 @@ class Writer
     /**
      * @param  object  $export
      */
-    protected function handleDocumentProperties($export)
+    protected function handleDocumentProperties($export): void
     {
         $properties = config('excel.exports.properties', []);
 

--- a/tests/Cache/BatchCacheTest.php
+++ b/tests/Cache/BatchCacheTest.php
@@ -29,7 +29,7 @@ class BatchCacheTest extends TestCase
      */
     private $memory;
 
-    public function test_will_get_multiple_from_memory_if_cells_hold_in_memory()
+    public function test_will_get_multiple_from_memory_if_cells_hold_in_memory(): void
     {
         $inMemory = [
             'A1' => 'A1-value',
@@ -47,7 +47,7 @@ class BatchCacheTest extends TestCase
         $this->assertEquals('A3-value', $cache->get('A3'));
     }
 
-    public function test_will_get_multiple_from_cache_if_cells_are_persisted()
+    public function test_will_get_multiple_from_cache_if_cells_are_persisted(): void
     {
         $inMemory  = [];
         $persisted = [
@@ -66,7 +66,7 @@ class BatchCacheTest extends TestCase
         $this->assertEquals('A3-value', $cache->get('A3'));
     }
 
-    public function test_will_get_multiple_from_cache_and_persisted()
+    public function test_will_get_multiple_from_cache_and_persisted(): void
     {
         $inMemory = [
             'A1' => 'A1-value',
@@ -90,7 +90,7 @@ class BatchCacheTest extends TestCase
         $this->assertEquals('A6-value', $cache->get('A6'));
     }
 
-    public function test_it_persists_to_cache_when_memory_limit_reached_on_setting_a_value()
+    public function test_it_persists_to_cache_when_memory_limit_reached_on_setting_a_value(): void
     {
         $memoryLimit = 3;
         $persisted   = [];
@@ -125,7 +125,7 @@ class BatchCacheTest extends TestCase
         ], $cache->getMultiple(['A1', 'A2', 'A3', 'A4']));
     }
 
-    public function test_it_persists_to_cache_when_memory_limit_reached_on_setting_multiple_values()
+    public function test_it_persists_to_cache_when_memory_limit_reached_on_setting_multiple_values(): void
     {
         $memoryLimit = 3;
         $persisted   = [];
@@ -166,7 +166,7 @@ class BatchCacheTest extends TestCase
     }
 
     #[DataProvider('defaultTTLDataProvider')]
-    public function test_it_writes_to_cache_with_default_ttl($defaultTTL, $receivedAs)
+    public function test_it_writes_to_cache_with_default_ttl($defaultTTL, $receivedAs): void
     {
         config()->set('excel.cache.default_ttl', $defaultTTL);
 
@@ -178,12 +178,13 @@ class BatchCacheTest extends TestCase
 
         $dispatchedCollection = Event::dispatched(
             KeyWritten::class,
-            fn (KeyWritten $event) => $event->seconds === $expectedTTL);
+            fn (KeyWritten $event) => $event->seconds === $expectedTTL
+        );
 
         $this->assertCount(2, $dispatchedCollection);
     }
 
-    public function test_it_writes_to_cache_with_a_dateinterval_ttl()
+    public function test_it_writes_to_cache_with_a_dateinterval_ttl(): void
     {
         // DateInterval is 1 minute
         config()->set('excel.cache.default_ttl', new DateInterval('PT1M'));
@@ -194,12 +195,13 @@ class BatchCacheTest extends TestCase
 
         $dispatchedCollection = Event::dispatched(
             KeyWritten::class,
-            fn (KeyWritten $event) => $event->seconds >= 59 && $event->seconds <= 60);
+            fn (KeyWritten $event) => $event->seconds >= 59 && $event->seconds <= 60
+        );
 
         $this->assertCount(2, $dispatchedCollection);
     }
 
-    public function test_it_can_override_default_ttl()
+    public function test_it_can_override_default_ttl(): void
     {
         config()->set('excel.cache.default_ttl', 1);
 
@@ -209,7 +211,8 @@ class BatchCacheTest extends TestCase
 
         $dispatchedCollection = Event::dispatched(
             KeyWritten::class,
-            fn (KeyWritten $event) => $event->seconds === null);
+            fn (KeyWritten $event) => $event->seconds === null
+        );
 
         $this->assertCount(2, $dispatchedCollection);
     }
@@ -218,7 +221,7 @@ class BatchCacheTest extends TestCase
     {
         return [
             'null (forever)' => [null, null],
-            'int value'      => [$value = rand(1, 100), $value],
+            'int value'      => [$value = random_int(1, 100), $value],
             'callable'       => [$closure = (fn () => 199), $closure],
         ];
     }

--- a/tests/CellTest.php
+++ b/tests/CellTest.php
@@ -8,7 +8,7 @@ use Maatwebsite\Excel\Middleware\TrimCellValue;
 
 class CellTest extends TestCase
 {
-    public function test_can_get_cell_value()
+    public function test_can_get_cell_value(): void
     {
         config()->set('excel.imports.cells.middleware', []);
 
@@ -20,7 +20,7 @@ class CellTest extends TestCase
         $this->assertEquals('       ', Cell::make($worksheet->getActiveSheet(), 'A2')->getValue());
     }
 
-    public function test_can_trim_empty_cells()
+    public function test_can_trim_empty_cells(): void
     {
         config()->set('excel.imports.cells.middleware', [
             TrimCellValue::class,
@@ -33,7 +33,7 @@ class CellTest extends TestCase
         config()->set('excel.imports.cells.middleware', []);
     }
 
-    public function test_convert_empty_cells_to_null()
+    public function test_convert_empty_cells_to_null(): void
     {
         config()->set('excel.imports.cells.middleware', [
             TrimCellValue::class,

--- a/tests/Concerns/ExportableTest.php
+++ b/tests/Concerns/ExportableTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class ExportableTest extends TestCase
 {
-    public function test_needs_to_have_a_file_name_when_downloading()
+    public function test_needs_to_have_a_file_name_when_downloading(): void
     {
         $this->expectException(NoFilenameGivenException::class);
         $this->expectExceptionMessage('A filename needs to be passed in order to download the export');
@@ -28,7 +28,7 @@ class ExportableTest extends TestCase
         $export->download();
     }
 
-    public function test_needs_to_have_a_file_name_when_storing()
+    public function test_needs_to_have_a_file_name_when_storing(): void
     {
         $this->expectException(NoFilePathGivenException::class);
         $this->expectExceptionMessage('A filepath needs to be passed in order to store the export');
@@ -41,7 +41,7 @@ class ExportableTest extends TestCase
         $export->store();
     }
 
-    public function test_needs_to_have_a_file_name_when_queuing()
+    public function test_needs_to_have_a_file_name_when_queuing(): void
     {
         $this->expectException(NoFilePathGivenException::class);
         $this->expectExceptionMessage('A filepath needs to be passed in order to store the export');
@@ -54,7 +54,7 @@ class ExportableTest extends TestCase
         $export->queue();
     }
 
-    public function test_responsable_needs_to_have_file_name_configured_inside_the_export()
+    public function test_responsable_needs_to_have_file_name_configured_inside_the_export(): void
     {
         $this->expectException(NoFilenameGivenException::class);
         $this->expectExceptionMessage('A filename needs to be passed in order to download the export');
@@ -67,7 +67,7 @@ class ExportableTest extends TestCase
         $export->toResponse(new Request);
     }
 
-    public function test_is_responsable()
+    public function test_is_responsable(): void
     {
         $export = new class implements Responsable
         {
@@ -83,7 +83,7 @@ class ExportableTest extends TestCase
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
     }
 
-    public function test_can_have_customized_header()
+    public function test_can_have_customized_header(): void
     {
         $export = new class
         {
@@ -99,7 +99,7 @@ class ExportableTest extends TestCase
         $this->assertEquals('text/csv', $response->headers->get('Content-Type'));
     }
 
-    public function test_can_set_custom_headers_in_export_class()
+    public function test_can_set_custom_headers_in_export_class(): void
     {
         $export = new class
         {
@@ -118,7 +118,7 @@ class ExportableTest extends TestCase
         $this->assertEquals('text/csv', $response->headers->get('Content-Type'));
     }
 
-    public function test_can_get_raw_export_contents()
+    public function test_can_get_raw_export_contents(): void
     {
         $export = new EmptyExport;
 
@@ -127,7 +127,7 @@ class ExportableTest extends TestCase
         $this->assertNotEmpty($response);
     }
 
-    public function test_can_have_customized_disk_options_when_storing()
+    public function test_can_have_customized_disk_options_when_storing(): void
     {
         $export = new EmptyExport;
 
@@ -138,7 +138,7 @@ class ExportableTest extends TestCase
         $export->store('name.csv', 's3', Excel::CSV, ['visibility' => 'private']);
     }
 
-    public function test_can_have_customized_disk_options_when_queueing()
+    public function test_can_have_customized_disk_options_when_queueing(): void
     {
         $export = new EmptyExport;
 
@@ -149,7 +149,7 @@ class ExportableTest extends TestCase
         $export->queue('name.csv', 's3', Excel::CSV, ['visibility' => 'private']);
     }
 
-    public function test_can_set_disk_options_in_export_class_when_storing()
+    public function test_can_set_disk_options_in_export_class_when_storing(): void
     {
         $export = new class
         {
@@ -169,7 +169,7 @@ class ExportableTest extends TestCase
         $export->store('name.csv');
     }
 
-    public function test_can_set_disk_options_in_export_class_when_queuing()
+    public function test_can_set_disk_options_in_export_class_when_queuing(): void
     {
         $export = new class
         {
@@ -189,7 +189,7 @@ class ExportableTest extends TestCase
         $export->queue('name.csv');
     }
 
-    public function test_can_override_export_class_disk_options_when_calling_store()
+    public function test_can_override_export_class_disk_options_when_calling_store(): void
     {
         $export = new class
         {
@@ -205,7 +205,7 @@ class ExportableTest extends TestCase
         $export->store('name.csv', 's3', Excel::CSV, ['visibility' => 'private']);
     }
 
-    public function test_can_override_export_class_disk_options_when_calling_queue()
+    public function test_can_override_export_class_disk_options_when_calling_queue(): void
     {
         $export = new class
         {
@@ -221,7 +221,7 @@ class ExportableTest extends TestCase
         $export->queue('name.csv', 's3', Excel::CSV, ['visibility' => 'private']);
     }
 
-    public function test_can_have_empty_disk_options_when_storing()
+    public function test_can_have_empty_disk_options_when_storing(): void
     {
         $export = new EmptyExport;
 
@@ -232,7 +232,7 @@ class ExportableTest extends TestCase
         $export->store('name.csv');
     }
 
-    public function test_can_have_empty_disk_options_when_queueing()
+    public function test_can_have_empty_disk_options_when_queueing(): void
     {
         $export = new EmptyExport;
 

--- a/tests/Concerns/FromArrayTest.php
+++ b/tests/Concerns/FromArrayTest.php
@@ -8,7 +8,7 @@ use Maatwebsite\Excel\Tests\TestCase;
 
 class FromArrayTest extends TestCase
 {
-    public function test_can_export_from_array()
+    public function test_can_export_from_array(): void
     {
         $export = new class implements FromArray
         {

--- a/tests/Concerns/FromCollectionTest.php
+++ b/tests/Concerns/FromCollectionTest.php
@@ -12,7 +12,7 @@ use Maatwebsite\Excel\Tests\TestCase;
 
 class FromCollectionTest extends TestCase
 {
-    public function test_can_export_from_collection()
+    public function test_can_export_from_collection(): void
     {
         $export = new SheetWith100Rows('A');
 
@@ -25,7 +25,7 @@ class FromCollectionTest extends TestCase
         $this->assertEquals($export->collection()->toArray(), $contents);
     }
 
-    public function test_can_export_with_multiple_sheets_from_collection()
+    public function test_can_export_with_multiple_sheets_from_collection(): void
     {
         $export = new QueuedExport;
 
@@ -46,7 +46,7 @@ class FromCollectionTest extends TestCase
         }
     }
 
-    public function test_can_export_from_lazy_collection()
+    public function test_can_export_from_lazy_collection(): void
     {
         if (!class_exists(LazyCollection::class)) {
             $this->markTestSkipped('Skipping test because LazyCollection is not supported');
@@ -68,7 +68,7 @@ class FromCollectionTest extends TestCase
         );
     }
 
-    public function test_can_export_from_lazy_collection_with_queue()
+    public function test_can_export_from_lazy_collection_with_queue(): void
     {
         if (!class_exists(LazyCollection::class)) {
             $this->markTestSkipped('Skipping test because LazyCollection is not supported');

--- a/tests/Concerns/FromGeneratorTest.php
+++ b/tests/Concerns/FromGeneratorTest.php
@@ -9,7 +9,7 @@ use Maatwebsite\Excel\Tests\TestCase;
 
 class FromGeneratorTest extends TestCase
 {
-    public function test_can_export_from_generator()
+    public function test_can_export_from_generator(): void
     {
         $export = new class implements FromGenerator
         {

--- a/tests/Concerns/FromIteratorTest.php
+++ b/tests/Concerns/FromIteratorTest.php
@@ -10,7 +10,7 @@ use Maatwebsite\Excel\Tests\TestCase;
 
 class FromIteratorTest extends TestCase
 {
-    public function test_can_export_from_iterator()
+    public function test_can_export_from_iterator(): void
     {
         $export = new class implements FromIterator
         {

--- a/tests/Concerns/FromQueryTest.php
+++ b/tests/Concerns/FromQueryTest.php
@@ -32,7 +32,7 @@ class FromQueryTest extends TestCase
         User::factory()->has(Group::factory(['name' => 'Group 2']))->count(5)->create();
     }
 
-    public function test_can_export_from_query()
+    public function test_can_export_from_query(): void
     {
         $export = new FromUsersQueryExport;
 
@@ -47,7 +47,7 @@ class FromQueryTest extends TestCase
         $this->assertEquals($allUsers, $contents);
     }
 
-    public function test_can_export_from_query_with_join()
+    public function test_can_export_from_query_with_join(): void
     {
         $export = new FromUsersQueryWithJoinExport;
 
@@ -62,7 +62,7 @@ class FromQueryTest extends TestCase
         $this->assertEquals($allUsers, $contents);
     }
 
-    public function test_can_export_from_relation_query_queued()
+    public function test_can_export_from_relation_query_queued(): void
     {
         $export = new FromGroupUsersQueuedQueryExport;
 
@@ -75,7 +75,7 @@ class FromQueryTest extends TestCase
         $this->assertEquals($allUsers, $contents);
     }
 
-    public function test_can_export_from_query_with_eager_loads()
+    public function test_can_export_from_query_with_eager_loads(): void
     {
         DB::connection()->enableQueryLog();
         $export = new FromUsersQueryExportWithEagerLoad;
@@ -97,7 +97,7 @@ class FromQueryTest extends TestCase
         $this->assertEquals($allUsers, $contents);
     }
 
-    public function test_can_export_from_query_with_eager_loads_and_queued()
+    public function test_can_export_from_query_with_eager_loads_and_queued(): void
     {
         DB::connection()->enableQueryLog();
         $export = new FromUsersQueryExportWithEagerLoad;
@@ -118,7 +118,7 @@ class FromQueryTest extends TestCase
         $this->assertEquals($allUsers, $contents);
     }
 
-    public function test_can_export_from_query_builder_without_using_eloquent()
+    public function test_can_export_from_query_builder_without_using_eloquent(): void
     {
         $export = new FromNonEloquentQueryExport;
 
@@ -133,7 +133,7 @@ class FromQueryTest extends TestCase
         $this->assertEquals($allUsers, $contents);
     }
 
-    public function test_can_export_from_query_builder_without_using_eloquent_and_queued()
+    public function test_can_export_from_query_builder_without_using_eloquent_and_queued(): void
     {
         $export = new FromNonEloquentQueryExport;
 
@@ -146,7 +146,7 @@ class FromQueryTest extends TestCase
         $this->assertEquals($allUsers, $contents);
     }
 
-    public function test_can_export_from_query_builder_with_nested_arrays()
+    public function test_can_export_from_query_builder_with_nested_arrays(): void
     {
         $export = new FromNestedArraysQueryExport;
 
@@ -159,7 +159,7 @@ class FromQueryTest extends TestCase
         $this->assertEquals($this->format_nested_arrays_expected_data($export->query()->get()), $contents);
     }
 
-    public function test_can_export_from_query_builder_with_nested_arrays_queued()
+    public function test_can_export_from_query_builder_with_nested_arrays_queued(): void
     {
         $export = new FromNestedArraysQueryExport;
 
@@ -170,7 +170,7 @@ class FromQueryTest extends TestCase
         $this->assertEquals($this->format_nested_arrays_expected_data($export->query()->get()), $contents);
     }
 
-    public function test_can_export_from_query_with_batch_caching()
+    public function test_can_export_from_query_with_batch_caching(): void
     {
         config()->set('excel.cache.driver', 'batch');
 
@@ -187,7 +187,7 @@ class FromQueryTest extends TestCase
         $this->assertEquals($allUsers, $contents);
     }
 
-    public function test_can_export_from_query_with_prepare_rows()
+    public function test_can_export_from_query_with_prepare_rows(): void
     {
         $export = new FromUsersQueryExportWithPrepareRows;
 
@@ -208,7 +208,7 @@ class FromQueryTest extends TestCase
         $this->assertEquals($allUsers, $contents);
     }
 
-    public function test_can_export_from_scout()
+    public function test_can_export_from_scout(): void
     {
         if (!class_exists(DatabaseEngine::class)) {
             $this->markTestSkipped('Laravel Scout is too old');

--- a/tests/Concerns/FromViewTest.php
+++ b/tests/Concerns/FromViewTest.php
@@ -20,7 +20,7 @@ class FromViewTest extends TestCase
         $this->loadLaravelMigrations(['--database' => 'testing']);
     }
 
-    public function test_can_export_from_view()
+    public function test_can_export_from_view(): void
     {
         /** @var Collection|User[] $users */
         $users = User::factory()->count(100)->create();
@@ -61,7 +61,7 @@ class FromViewTest extends TestCase
         $this->assertEquals($expected, $contents);
     }
 
-    public function test_can_export_multiple_sheets_from_view()
+    public function test_can_export_multiple_sheets_from_view(): void
     {
         /** @var Collection|User[] $users */
         $users = User::factory()->count(300)->create();

--- a/tests/Concerns/ImportableTest.php
+++ b/tests/Concerns/ImportableTest.php
@@ -12,13 +12,13 @@ use PHPUnit\Framework\Assert;
 
 class ImportableTest extends TestCase
 {
-    public function test_can_import_a_simple_xlsx_file()
+    public function test_can_import_a_simple_xlsx_file(): void
     {
         $import = new class implements ToArray
         {
             use Importable;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     ['test', 'test'],
@@ -32,13 +32,13 @@ class ImportableTest extends TestCase
         $this->assertInstanceOf(Importer::class, $imported);
     }
 
-    public function test_can_import_a_simple_xlsx_file_from_uploaded_file()
+    public function test_can_import_a_simple_xlsx_file_from_uploaded_file(): void
     {
         $import = new class implements ToArray
         {
             use Importable;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     ['test', 'test'],
@@ -50,13 +50,13 @@ class ImportableTest extends TestCase
         $import->import($this->givenUploadedFile(__DIR__ . '/../Data/Disks/Local/import.xlsx'));
     }
 
-    public function test_can_import_a_simple_csv_file_with_html_tags_inside()
+    public function test_can_import_a_simple_csv_file_with_html_tags_inside(): void
     {
         $import = new class implements ToArray
         {
             use Importable;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     ['key1', 'A', 'row1'],
@@ -72,7 +72,7 @@ class ImportableTest extends TestCase
         $import->import('csv-with-html-tags.csv', 'local', Excel::CSV);
     }
 
-    public function test_can_import_a_simple_xlsx_file_with_ignore_empty_set_to_true()
+    public function test_can_import_a_simple_xlsx_file_with_ignore_empty_set_to_true(): void
     {
         config()->set('excel.imports.ignore_empty', true);
 
@@ -80,7 +80,7 @@ class ImportableTest extends TestCase
         {
             use Importable;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     ['test', 'test'],
@@ -94,7 +94,7 @@ class ImportableTest extends TestCase
         $this->assertInstanceOf(Importer::class, $imported);
     }
 
-    public function test_can_import_a_simple_xlsx_file_with_ignore_empty_set_to_false()
+    public function test_can_import_a_simple_xlsx_file_with_ignore_empty_set_to_false(): void
     {
         config()->set('excel.imports.ignore_empty', false);
 
@@ -102,7 +102,7 @@ class ImportableTest extends TestCase
         {
             use Importable;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     ['test', 'test'],
@@ -118,7 +118,7 @@ class ImportableTest extends TestCase
         $this->assertInstanceOf(Importer::class, $imported);
     }
 
-    public function test_cannot_import_a_non_existing_xlsx_file()
+    public function test_cannot_import_a_non_existing_xlsx_file(): void
     {
         $this->expectException(FileNotFoundException::class);
 

--- a/tests/Concerns/OnEachRowTest.php
+++ b/tests/Concerns/OnEachRowTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Assert;
 
 class OnEachRowTest extends TestCase
 {
-    public function test_can_import_each_row_individually()
+    public function test_can_import_each_row_individually(): void
     {
         $import = new class implements OnEachRow
         {
@@ -18,7 +18,7 @@ class OnEachRowTest extends TestCase
 
             public $called = 0;
 
-            public function onRow(Row $row)
+            public function onRow(Row $row): void
             {
                 foreach ($row->getCellIterator() as $cell) {
                     Assert::assertEquals('test', $cell->getValue());
@@ -39,13 +39,13 @@ class OnEachRowTest extends TestCase
         $this->assertEquals(2, $import->called);
     }
 
-    public function test_it_respects_the_end_column()
+    public function test_it_respects_the_end_column(): void
     {
         $import = new class implements OnEachRow
         {
             use Importable;
 
-            public function onRow(Row $row)
+            public function onRow(Row $row): void
             {
                 // Accessing a row as an array calls toArray() without an end
                 // column. This saves the row in the cache, so we have to

--- a/tests/Concerns/RegistersEventListenersTest.php
+++ b/tests/Concerns/RegistersEventListenersTest.php
@@ -19,31 +19,31 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class RegistersEventListenersTest extends TestCase
 {
-    public function test_events_get_called_when_exporting()
+    public function test_events_get_called_when_exporting(): void
     {
         $event = new ExportWithRegistersEventListeners;
 
         $eventsTriggered = 0;
 
-        $event::$beforeExport = function ($event) use (&$eventsTriggered) {
+        $event::$beforeExport = function ($event) use (&$eventsTriggered): void {
             $this->assertInstanceOf(BeforeExport::class, $event);
             $this->assertInstanceOf(Writer::class, $event->writer);
             $eventsTriggered++;
         };
 
-        $event::$beforeWriting = function ($event) use (&$eventsTriggered) {
+        $event::$beforeWriting = function ($event) use (&$eventsTriggered): void {
             $this->assertInstanceOf(BeforeWriting::class, $event);
             $this->assertInstanceOf(Writer::class, $event->writer);
             $eventsTriggered++;
         };
 
-        $event::$beforeSheet = function ($event) use (&$eventsTriggered) {
+        $event::$beforeSheet = function ($event) use (&$eventsTriggered): void {
             $this->assertInstanceOf(BeforeSheet::class, $event);
             $this->assertInstanceOf(Sheet::class, $event->sheet);
             $eventsTriggered++;
         };
 
-        $event::$afterSheet = function ($event) use (&$eventsTriggered) {
+        $event::$afterSheet = function ($event) use (&$eventsTriggered): void {
             $this->assertInstanceOf(AfterSheet::class, $event);
             $this->assertInstanceOf(Sheet::class, $event->sheet);
             $eventsTriggered++;
@@ -53,25 +53,25 @@ class RegistersEventListenersTest extends TestCase
         $this->assertEquals(4, $eventsTriggered);
     }
 
-    public function test_events_get_called_when_importing()
+    public function test_events_get_called_when_importing(): void
     {
         $event = new ImportWithRegistersEventListeners;
 
         $eventsTriggered = 0;
 
-        $event::$beforeImport = function ($event) use (&$eventsTriggered) {
+        $event::$beforeImport = function ($event) use (&$eventsTriggered): void {
             $this->assertInstanceOf(BeforeImport::class, $event);
             $this->assertInstanceOf(Reader::class, $event->reader);
             $eventsTriggered++;
         };
 
-        $event::$beforeSheet = function ($event) use (&$eventsTriggered) {
+        $event::$beforeSheet = function ($event) use (&$eventsTriggered): void {
             $this->assertInstanceOf(BeforeSheet::class, $event);
             $this->assertInstanceOf(Sheet::class, $event->sheet);
             $eventsTriggered++;
         };
 
-        $event::$afterSheet = function ($event) use (&$eventsTriggered) {
+        $event::$afterSheet = function ($event) use (&$eventsTriggered): void {
             $this->assertInstanceOf(AfterSheet::class, $event);
             $this->assertInstanceOf(Sheet::class, $event->sheet);
             $eventsTriggered++;
@@ -81,11 +81,11 @@ class RegistersEventListenersTest extends TestCase
         $this->assertEquals(3, $eventsTriggered);
     }
 
-    public function test_can_have_invokable_class_as_listener()
+    public function test_can_have_invokable_class_as_listener(): void
     {
         $event = new ExportWithEvents;
 
-        $event->beforeExport = new BeforeExportListener(function ($event) {
+        $event->beforeExport = new BeforeExportListener(function ($event): void {
             $this->assertInstanceOf(BeforeExport::class, $event);
             $this->assertInstanceOf(Writer::class, $event->writer);
         });

--- a/tests/Concerns/RemembersChunkOffsetTest.php
+++ b/tests/Concerns/RemembersChunkOffsetTest.php
@@ -10,7 +10,7 @@ use Maatwebsite\Excel\Tests\TestCase;
 
 class RemembersChunkOffsetTest extends TestCase
 {
-    public function test_can_set_and_get_chunk_offset()
+    public function test_can_set_and_get_chunk_offset(): void
     {
         $import = new class
         {
@@ -23,7 +23,7 @@ class RemembersChunkOffsetTest extends TestCase
         $this->assertEquals(50, $import->getChunkOffset());
     }
 
-    public function test_can_access_chunk_offset_on_import_to_array_in_chunks()
+    public function test_can_access_chunk_offset_on_import_to_array_in_chunks(): void
     {
         $import = new class implements ToArray, WithChunkReading
         {
@@ -32,7 +32,7 @@ class RemembersChunkOffsetTest extends TestCase
 
             public $offsets = [];
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 $this->offsets[] = $this->getChunkOffset();
             }

--- a/tests/Concerns/RemembersRowNumberTest.php
+++ b/tests/Concerns/RemembersRowNumberTest.php
@@ -11,7 +11,7 @@ use Maatwebsite\Excel\Tests\TestCase;
 
 class RemembersRowNumberTest extends TestCase
 {
-    public function test_can_set_and_get_row_number()
+    public function test_can_set_and_get_row_number(): void
     {
         $import = new class
         {
@@ -24,7 +24,7 @@ class RemembersRowNumberTest extends TestCase
         $this->assertEquals(50, $import->getRowNumber());
     }
 
-    public function test_can_access_row_number_on_import_to_model()
+    public function test_can_access_row_number_on_import_to_model(): void
     {
         $import = new class implements ToModel
         {
@@ -33,7 +33,7 @@ class RemembersRowNumberTest extends TestCase
 
             public $rowNumbers = [];
 
-            public function model(array $row)
+            public function model(array $row): void
             {
                 $this->rowNumbers[] = $this->getRowNumber();
             }
@@ -44,7 +44,7 @@ class RemembersRowNumberTest extends TestCase
         $this->assertEquals([46, 47, 48, 49, 50, 51, 52, 53, 54, 55], array_slice($import->rowNumbers, 45, 10));
     }
 
-    public function test_can_access_row_number_on_import_to_array_in_chunks()
+    public function test_can_access_row_number_on_import_to_array_in_chunks(): void
     {
         $import = new class implements ToModel, WithChunkReading
         {
@@ -58,7 +58,7 @@ class RemembersRowNumberTest extends TestCase
                 return 50;
             }
 
-            public function model(array $row)
+            public function model(array $row): void
             {
                 $this->rowNumbers[] = $this->getRowNumber();
             }
@@ -69,7 +69,7 @@ class RemembersRowNumberTest extends TestCase
         $this->assertEquals([46, 47, 48, 49, 50, 51, 52, 53, 54, 55], array_slice($import->rowNumbers, 45, 10));
     }
 
-    public function test_can_access_row_number_on_import_to_array_in_chunks_with_batch_inserts()
+    public function test_can_access_row_number_on_import_to_array_in_chunks_with_batch_inserts(): void
     {
         $import = new class implements ToModel, WithBatchInserts, WithChunkReading
         {
@@ -83,7 +83,7 @@ class RemembersRowNumberTest extends TestCase
                 return 50;
             }
 
-            public function model(array $row)
+            public function model(array $row): void
             {
                 $this->rowNumbers[] = $this->rowNumber;
             }

--- a/tests/Concerns/ShouldQueueWithoutChainTest.php
+++ b/tests/Concerns/ShouldQueueWithoutChainTest.php
@@ -23,7 +23,7 @@ class ShouldQueueWithoutChainTest extends TestCase
         $this->loadMigrationsFrom(dirname(__DIR__) . '/Data/Stubs/Database/Migrations');
     }
 
-    public function test_can_import_to_model_in_chunks()
+    public function test_can_import_to_model_in_chunks(): void
     {
         DB::connection()->enableQueryLog();
 
@@ -34,7 +34,7 @@ class ShouldQueueWithoutChainTest extends TestCase
         DB::connection()->disableQueryLog();
     }
 
-    public function test_can_import_to_model_without_job_chaining()
+    public function test_can_import_to_model_without_job_chaining(): void
     {
         Queue::fake();
 
@@ -47,7 +47,7 @@ class ShouldQueueWithoutChainTest extends TestCase
         Queue::assertNotPushed(QueueImport::class);
     }
 
-    public function test_a_queue_name_can_be_specified_when_importing()
+    public function test_a_queue_name_can_be_specified_when_importing(): void
     {
         Queue::fake();
 
@@ -60,7 +60,7 @@ class ShouldQueueWithoutChainTest extends TestCase
         Queue::assertPushedOn('queue-name', AfterImportJob::class);
     }
 
-    public function test_the_cleanup_only_runs_when_all_jobs_are_done()
+    public function test_the_cleanup_only_runs_when_all_jobs_are_done(): void
     {
         $fake = Queue::fake();
 
@@ -74,7 +74,7 @@ class ShouldQueueWithoutChainTest extends TestCase
 
         $jobs   = Queue::pushedJobs();
         $chunks = collect($jobs[ReadChunk::class])->pluck('job');
-        $chunks->each(function (ReadChunk $chunk) {
+        $chunks->each(function (ReadChunk $chunk): void {
             self::assertFalse(ReadChunk::isComplete($chunk->getUniqueId()));
         });
         self::assertCount(2, $chunks);
@@ -91,14 +91,14 @@ class ShouldQueueWithoutChainTest extends TestCase
         self::assertTrue(ReadChunk::isComplete($chunks->first()->getUniqueId()));
         self::assertFalse(ReadChunk::isComplete($chunks->last()->getUniqueId()));
 
-        Event::listen(JobProcessed::class, function (JobProcessed $event) {
+        Event::listen(JobProcessed::class, function (JobProcessed $event): void {
             self::assertTrue($event->job->isReleased());
         });
         $fake->push($afterImport);
         Event::forget(JobProcessed::class);
         $fake->push($chunks->last());
 
-        Event::listen(JobProcessed::class, function (JobProcessed $event) {
+        Event::listen(JobProcessed::class, function (JobProcessed $event): void {
             self::assertFalse($event->job->isReleased());
         });
         $fake->push($afterImport);

--- a/tests/Concerns/SkipsEmptyRowsTest.php
+++ b/tests/Concerns/SkipsEmptyRowsTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Assert;
 
 class SkipsEmptyRowsTest extends TestCase
 {
-    public function test_skips_empty_rows_when_importing_to_collection()
+    public function test_skips_empty_rows_when_importing_to_collection(): void
     {
         $import = new class implements SkipsEmptyRows, ToCollection
         {
@@ -23,7 +23,7 @@ class SkipsEmptyRowsTest extends TestCase
 
             public $called = false;
 
-            public function collection(Collection $collection)
+            public function collection(Collection $collection): void
             {
                 $this->called = true;
 
@@ -40,7 +40,7 @@ class SkipsEmptyRowsTest extends TestCase
         $this->assertTrue($import->called);
     }
 
-    public function test_skips_empty_rows_when_importing_on_each_row()
+    public function test_skips_empty_rows_when_importing_on_each_row(): void
     {
         $import = new class implements OnEachRow, SkipsEmptyRows
         {
@@ -48,7 +48,7 @@ class SkipsEmptyRowsTest extends TestCase
 
             public $rows = 0;
 
-            public function onRow(Row $row)
+            public function onRow(Row $row): void
             {
                 Assert::assertFalse($row->isEmpty());
 
@@ -61,7 +61,7 @@ class SkipsEmptyRowsTest extends TestCase
         $this->assertEquals(3, $import->rows);
     }
 
-    public function test_skips_empty_rows_when_importing_to_model()
+    public function test_skips_empty_rows_when_importing_to_model(): void
     {
         $import = new class implements SkipsEmptyRows, ToModel
         {
@@ -85,7 +85,7 @@ class SkipsEmptyRowsTest extends TestCase
         $this->assertEquals(3, $import->rows);
     }
 
-    public function test_custom_skips_rows_when_importing_to_collection()
+    public function test_custom_skips_rows_when_importing_to_collection(): void
     {
         $import = new class implements SkipsEmptyRows, ToCollection
         {
@@ -93,7 +93,7 @@ class SkipsEmptyRowsTest extends TestCase
 
             public $called = false;
 
-            public function collection(Collection $collection)
+            public function collection(Collection $collection): void
             {
                 $this->called = true;
 
@@ -113,7 +113,7 @@ class SkipsEmptyRowsTest extends TestCase
         $this->assertTrue($import->called);
     }
 
-    public function test_custom_skips_rows_when_importing_to_model()
+    public function test_custom_skips_rows_when_importing_to_model(): void
     {
         $import = new class implements SkipsEmptyRows, ToModel
         {
@@ -121,7 +121,7 @@ class SkipsEmptyRowsTest extends TestCase
 
             public $called = false;
 
-            public function model(array $row)
+            public function model(array $row): void
             {
                 Assert::assertEquals('Not empty', $row[0]);
             }
@@ -138,7 +138,7 @@ class SkipsEmptyRowsTest extends TestCase
         $this->assertTrue($import->called);
     }
 
-    public function test_custom_skips_rows_when_using_oneachrow()
+    public function test_custom_skips_rows_when_using_oneachrow(): void
     {
         $import = new class implements OnEachRow, SkipsEmptyRows
         {
@@ -149,7 +149,7 @@ class SkipsEmptyRowsTest extends TestCase
             /**
              * @param  array  $row
              */
-            public function onRow(Row $row)
+            public function onRow(Row $row): void
             {
                 Assert::assertEquals('Not empty', $row[0]);
             }

--- a/tests/Concerns/SkipsOnErrorTest.php
+++ b/tests/Concerns/SkipsOnErrorTest.php
@@ -30,7 +30,7 @@ class SkipsOnErrorTest extends TestCase
         $this->loadLaravelMigrations(['--database' => 'testing']);
     }
 
-    public function test_can_skip_on_error()
+    public function test_can_skip_on_error(): void
     {
         $import = new class implements SkipsOnError, ToModel
         {
@@ -50,7 +50,7 @@ class SkipsOnErrorTest extends TestCase
                 ]);
             }
 
-            public function onError(Throwable $e)
+            public function onError(Throwable $e): void
             {
                 Assert::assertInstanceOf(QueryException::class, $e);
                 Assert::stringContains($e->getMessage(), 'Duplicate entry \'patrick@maatwebsite.nl\'');
@@ -74,7 +74,7 @@ class SkipsOnErrorTest extends TestCase
         ]);
     }
 
-    public function test_can_skip_errors_and_collect_all_errors_at_the_end()
+    public function test_can_skip_errors_and_collect_all_errors_at_the_end(): void
     {
         $import = new class implements SkipsOnError, ToModel
         {
@@ -114,7 +114,7 @@ class SkipsOnErrorTest extends TestCase
         ]);
     }
 
-    public function test_can_skip_on_error_when_using_oneachrow_with_validation()
+    public function test_can_skip_on_error_when_using_oneachrow_with_validation(): void
     {
         $import = new class implements OnEachRow, SkipsOnError, WithValidation
         {
@@ -124,7 +124,7 @@ class SkipsOnErrorTest extends TestCase
 
             public $processedRows = 0;
 
-            public function onRow(Row $row)
+            public function onRow(Row $row): void
             {
                 $this->processedRows++;
 
@@ -145,7 +145,7 @@ class SkipsOnErrorTest extends TestCase
                 ];
             }
 
-            public function onError(Throwable $e)
+            public function onError(Throwable $e): void
             {
                 Assert::assertInstanceOf(ValidationException::class, $e);
                 Assert::stringContains($e->getMessage(), 'The selected 1 is invalid');
@@ -170,7 +170,7 @@ class SkipsOnErrorTest extends TestCase
         ]);
     }
 
-    public function test_can_skip_errors_and_collect_all_errors_when_using_oneachrow_with_validation()
+    public function test_can_skip_errors_and_collect_all_errors_when_using_oneachrow_with_validation(): void
     {
         $import = new class implements OnEachRow, SkipsOnError, WithValidation
         {
@@ -178,7 +178,7 @@ class SkipsOnErrorTest extends TestCase
 
             public $processedRows = 0;
 
-            public function onRow(Row $row)
+            public function onRow(Row $row): void
             {
                 $this->processedRows++;
 
@@ -222,7 +222,7 @@ class SkipsOnErrorTest extends TestCase
         ]);
     }
 
-    public function test_can_skip_on_error_when_exception_thrown_in_onrow()
+    public function test_can_skip_on_error_when_exception_thrown_in_onrow(): void
     {
         $import = new class implements OnEachRow, SkipsOnError
         {
@@ -232,7 +232,7 @@ class SkipsOnErrorTest extends TestCase
 
             public $processedRows = 0;
 
-            public function onRow(Row $row)
+            public function onRow(Row $row): void
             {
                 $this->processedRows++;
 
@@ -250,7 +250,7 @@ class SkipsOnErrorTest extends TestCase
                 ]);
             }
 
-            public function onError(Throwable $e)
+            public function onError(Throwable $e): void
             {
                 Assert::assertInstanceOf(\Exception::class, $e);
                 Assert::assertEquals('Custom error in onRow for Taylor', $e->getMessage());
@@ -275,7 +275,7 @@ class SkipsOnErrorTest extends TestCase
         ]);
     }
 
-    public function test_can_skip_errors_and_collect_all_errors_when_exception_thrown_in_onrow()
+    public function test_can_skip_errors_and_collect_all_errors_when_exception_thrown_in_onrow(): void
     {
         $import = new class implements OnEachRow, SkipsOnError
         {
@@ -283,7 +283,7 @@ class SkipsOnErrorTest extends TestCase
 
             public $processedRows = 0;
 
-            public function onRow(Row $row)
+            public function onRow(Row $row): void
             {
                 $this->processedRows++;
 

--- a/tests/Concerns/SkipsOnFailureTest.php
+++ b/tests/Concerns/SkipsOnFailureTest.php
@@ -31,7 +31,7 @@ class SkipsOnFailureTest extends TestCase
         $this->loadLaravelMigrations(['--database' => 'testing']);
     }
 
-    public function test_can_skip_on_error()
+    public function test_can_skip_on_error(): void
     {
         $import = new class implements SkipsOnFailure, ToModel, WithValidation
         {
@@ -61,7 +61,7 @@ class SkipsOnFailureTest extends TestCase
             /**
              * @param  Failure[]  $failures
              */
-            public function onFailure(Failure ...$failures)
+            public function onFailure(Failure ...$failures): void
             {
                 $failure = $failures[0];
 
@@ -93,7 +93,7 @@ class SkipsOnFailureTest extends TestCase
         ]);
     }
 
-    public function test_skips_only_failed_rows_in_batch()
+    public function test_skips_only_failed_rows_in_batch(): void
     {
         $import = new class implements SkipsOnFailure, ToModel, WithBatchInserts, WithValidation
         {
@@ -123,7 +123,7 @@ class SkipsOnFailureTest extends TestCase
             /**
              * @param  Failure[]  $failures
              */
-            public function onFailure(Failure ...$failures)
+            public function onFailure(Failure ...$failures): void
             {
                 $failure = $failures[0];
 
@@ -155,7 +155,7 @@ class SkipsOnFailureTest extends TestCase
         ]);
     }
 
-    public function test_can_skip_failures_and_collect_all_failures_at_the_end()
+    public function test_can_skip_failures_and_collect_all_failures_at_the_end(): void
     {
         $import = new class implements SkipsOnFailure, ToModel, WithValidation
         {
@@ -203,7 +203,7 @@ class SkipsOnFailureTest extends TestCase
         ]);
     }
 
-    public function test_can_validate_using_oneachrow_and_skipsonfailure()
+    public function test_can_validate_using_oneachrow_and_skipsonfailure(): void
     {
         $import = new class implements OnEachRow, SkipsOnFailure, WithValidation
         {
@@ -247,7 +247,7 @@ class SkipsOnFailureTest extends TestCase
         ]);
     }
 
-    public function test_can_validate_using_tocollection_and_skipsonfailure()
+    public function test_can_validate_using_tocollection_and_skipsonfailure(): void
     {
         $import = new class implements SkipsOnFailure, ToCollection, WithValidation
         {

--- a/tests/Concerns/ToArrayTest.php
+++ b/tests/Concerns/ToArrayTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Assert;
 
 class ToArrayTest extends TestCase
 {
-    public function test_can_import_to_array()
+    public function test_can_import_to_array(): void
     {
         $import = new class implements ToArray
         {
@@ -17,7 +17,7 @@ class ToArrayTest extends TestCase
 
             public $called = false;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 $this->called = true;
 
@@ -33,7 +33,7 @@ class ToArrayTest extends TestCase
         $this->assertTrue($import->called);
     }
 
-    public function test_can_import_multiple_sheets_to_array()
+    public function test_can_import_multiple_sheets_to_array(): void
     {
         $import = new class implements ToArray
         {
@@ -41,7 +41,7 @@ class ToArrayTest extends TestCase
 
             public $called = 0;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 $this->called++;
 

--- a/tests/Concerns/ToCollectionTest.php
+++ b/tests/Concerns/ToCollectionTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Assert;
 
 class ToCollectionTest extends TestCase
 {
-    public function test_can_import_to_collection()
+    public function test_can_import_to_collection(): void
     {
         $import = new class implements ToCollection
         {
@@ -18,7 +18,7 @@ class ToCollectionTest extends TestCase
 
             public $called = false;
 
-            public function collection(Collection $collection)
+            public function collection(Collection $collection): void
             {
                 $this->called = true;
 
@@ -34,7 +34,7 @@ class ToCollectionTest extends TestCase
         $this->assertTrue($import->called);
     }
 
-    public function test_can_import_multiple_sheets_to_collection()
+    public function test_can_import_multiple_sheets_to_collection(): void
     {
         $import = new class implements ToCollection
         {
@@ -42,7 +42,7 @@ class ToCollectionTest extends TestCase
 
             public $called = 0;
 
-            public function collection(Collection $collection)
+            public function collection(Collection $collection): void
             {
                 $this->called++;
 

--- a/tests/Concerns/ToModelTest.php
+++ b/tests/Concerns/ToModelTest.php
@@ -26,7 +26,7 @@ class ToModelTest extends TestCase
         $this->loadMigrationsFrom(dirname(__DIR__) . '/Data/Stubs/Database/Migrations');
     }
 
-    public function test_can_import_each_row_to_model()
+    public function test_can_import_each_row_to_model(): void
     {
         DB::connection()->enableQueryLog();
 
@@ -63,7 +63,7 @@ class ToModelTest extends TestCase
         ]);
     }
 
-    public function test_has_timestamps_when_imported_single_model()
+    public function test_has_timestamps_when_imported_single_model(): void
     {
         $import = new class implements ToModel
         {
@@ -90,7 +90,7 @@ class ToModelTest extends TestCase
         $this->assertNotNull($user->updated_at);
     }
 
-    public function test_can_import_multiple_models_in_single_to_model()
+    public function test_can_import_multiple_models_in_single_to_model(): void
     {
         DB::connection()->enableQueryLog();
 
@@ -127,7 +127,7 @@ class ToModelTest extends TestCase
         DB::connection()->disableQueryLog();
     }
 
-    public function test_can_import_multiple_different_types_of_models_in_single_to_model()
+    public function test_can_import_multiple_different_types_of_models_in_single_to_model(): void
     {
         DB::connection()->enableQueryLog();
 
@@ -162,7 +162,7 @@ class ToModelTest extends TestCase
         DB::connection()->disableQueryLog();
     }
 
-    public function test_can_import_models_with_belongs_to_relations()
+    public function test_can_import_models_with_belongs_to_relations(): void
     {
         User::query()->truncate();
         Group::query()->truncate();
@@ -199,7 +199,7 @@ class ToModelTest extends TestCase
         $this->assertCount(6, DB::getQueryLog());
 
         $users = User::all();
-        $users->each(function (User $user) {
+        $users->each(function (User $user): void {
             $this->assertInstanceOf(Group::class, $user->group);
             $this->assertIsInt($user->group->id);
         });
@@ -209,7 +209,7 @@ class ToModelTest extends TestCase
         DB::connection()->disableQueryLog();
     }
 
-    public function test_can_import_models_with_belongs_to_many_relations()
+    public function test_can_import_models_with_belongs_to_many_relations(): void
     {
         User::query()->truncate();
         Group::query()->truncate();
@@ -246,7 +246,7 @@ class ToModelTest extends TestCase
         $this->assertCount(6, DB::getQueryLog());
 
         $users = User::all();
-        $users->each(function (User $user) {
+        $users->each(function (User $user): void {
             $this->assertInstanceOf(Group::class, $user->groups->first());
         });
 

--- a/tests/Concerns/WithBackgroundColorTest.php
+++ b/tests/Concerns/WithBackgroundColorTest.php
@@ -10,7 +10,7 @@ use PhpOffice\PhpSpreadsheet\Style\Fill;
 
 class WithBackgroundColorTest extends TestCase
 {
-    public function test_can_configure_background_color_from_rgb_string()
+    public function test_can_configure_background_color_from_rgb_string(): void
     {
         $export = new class implements WithBackgroundColor
         {
@@ -31,7 +31,7 @@ class WithBackgroundColorTest extends TestCase
         $this->assertEquals('000000', $sheet->getFill()->getStartColor()->getRGB());
     }
 
-    public function test_can_configure_background_color_as_array()
+    public function test_can_configure_background_color_as_array(): void
     {
         $export = new class implements WithBackgroundColor
         {
@@ -55,7 +55,7 @@ class WithBackgroundColorTest extends TestCase
         $this->assertEquals(Color::COLOR_RED, $sheet->getFill()->getStartColor()->getARGB());
     }
 
-    public function test_can_configure_background_color_with_color_instance()
+    public function test_can_configure_background_color_with_color_instance(): void
     {
         $export = new class implements WithBackgroundColor
         {

--- a/tests/Concerns/WithBatchInsertsTest.php
+++ b/tests/Concerns/WithBatchInsertsTest.php
@@ -24,7 +24,7 @@ class WithBatchInsertsTest extends TestCase
         $this->loadMigrationsFrom(dirname(__DIR__) . '/Data/Stubs/Database/Migrations');
     }
 
-    public function test_can_import_to_model_in_batches()
+    public function test_can_import_to_model_in_batches(): void
     {
         DB::connection()->enableQueryLog();
 
@@ -66,7 +66,7 @@ class WithBatchInsertsTest extends TestCase
         ]);
     }
 
-    public function test_can_import_to_model_in_batches_bigger_file()
+    public function test_can_import_to_model_in_batches_bigger_file(): void
     {
         DB::connection()->enableQueryLog();
 
@@ -96,7 +96,7 @@ class WithBatchInsertsTest extends TestCase
         DB::connection()->disableQueryLog();
     }
 
-    public function test_can_import_multiple_different_types_of_models_in_single_to_model()
+    public function test_can_import_multiple_different_types_of_models_in_single_to_model(): void
     {
         DB::connection()->enableQueryLog();
 
@@ -139,7 +139,7 @@ class WithBatchInsertsTest extends TestCase
         DB::connection()->disableQueryLog();
     }
 
-    public function test_has_timestamps_when_imported_in_batches()
+    public function test_has_timestamps_when_imported_in_batches(): void
     {
         $import = new class implements ToModel, WithBatchInserts
         {

--- a/tests/Concerns/WithCalculatedFormulasTest.php
+++ b/tests/Concerns/WithCalculatedFormulasTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\Assert;
 
 class WithCalculatedFormulasTest extends TestCase
 {
-    public function test_by_default_does_not_calculate_formulas()
+    public function test_by_default_does_not_calculate_formulas(): void
     {
         $import = new class implements ToArray
         {
@@ -24,7 +24,7 @@ class WithCalculatedFormulasTest extends TestCase
 
             public $called = false;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 $this->called = true;
 
@@ -37,7 +37,7 @@ class WithCalculatedFormulasTest extends TestCase
         $this->assertTrue($import->called);
     }
 
-    public function test_can_import_to_array_with_calculated_formulas()
+    public function test_can_import_to_array_with_calculated_formulas(): void
     {
         $import = new class implements ToArray, WithCalculatedFormulas
         {
@@ -45,7 +45,7 @@ class WithCalculatedFormulasTest extends TestCase
 
             public $called = false;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 $this->called = true;
 
@@ -58,7 +58,7 @@ class WithCalculatedFormulasTest extends TestCase
         $this->assertTrue($import->called);
     }
 
-    public function test_can_import_to_model_with_calculated_formulas()
+    public function test_can_import_to_model_with_calculated_formulas(): void
     {
         $import = new class implements ToModel, WithCalculatedFormulas
         {
@@ -84,7 +84,7 @@ class WithCalculatedFormulasTest extends TestCase
         $this->assertTrue($import->called);
     }
 
-    public function can_import_with_formulas_and_reference()
+    public function can_import_with_formulas_and_reference(): void
     {
         $import = new class implements ToModel, WithCalculatedFormulas, WithStartRow
         {
@@ -115,7 +115,7 @@ class WithCalculatedFormulasTest extends TestCase
         $this->assertTrue($import->called);
     }
 
-    public function test_can_import_to_array_with_calculated_formulas_and_multi_sheet_references()
+    public function test_can_import_to_array_with_calculated_formulas_and_multi_sheet_references(): void
     {
         $import = new class implements HasReferencesToOtherSheets, WithMultipleSheets
         {
@@ -130,7 +130,7 @@ class WithCalculatedFormulasTest extends TestCase
                     {
                         public $test = 'test2';
 
-                        public function array(array $array)
+                        public function array(array $array): void
                         {
                             Assert::assertEquals([
                                 ['1', '1'],
@@ -141,7 +141,7 @@ class WithCalculatedFormulasTest extends TestCase
                     {
                         public $test = 'test2';
 
-                        public function array(array $array)
+                        public function array(array $array): void
                         {
                             Assert::assertEquals([
                                 ['2'],
@@ -155,7 +155,7 @@ class WithCalculatedFormulasTest extends TestCase
         $import->import('import-formulas-multiple-sheets.xlsx');
     }
 
-    public function test_can_import_to_array_with_calculated_formulas_and_skips_empty()
+    public function test_can_import_to_array_with_calculated_formulas_and_skips_empty(): void
     {
         $import = new class implements SkipsEmptyRows, ToArray, WithCalculatedFormulas
         {
@@ -163,7 +163,7 @@ class WithCalculatedFormulasTest extends TestCase
 
             public $called = false;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 $this->called = true;
 
@@ -176,7 +176,7 @@ class WithCalculatedFormulasTest extends TestCase
         $this->assertTrue($import->called);
     }
 
-    public function test_can_import_to_model_with_calculated_formulas_and_skips_empty()
+    public function test_can_import_to_model_with_calculated_formulas_and_skips_empty(): void
     {
         $import = new class implements SkipsEmptyRows, ToModel, WithCalculatedFormulas
         {

--- a/tests/Concerns/WithChunkReadingTest.php
+++ b/tests/Concerns/WithChunkReadingTest.php
@@ -39,7 +39,7 @@ class WithChunkReadingTest extends TestCase
         $this->loadMigrationsFrom(dirname(__DIR__) . '/Data/Stubs/Database/Migrations');
     }
 
-    public function test_can_import_to_model_in_chunks_un()
+    public function test_can_import_to_model_in_chunks_un(): void
     {
         DB::connection()->enableQueryLog();
 
@@ -71,11 +71,11 @@ class WithChunkReadingTest extends TestCase
             public function registerEvents(): array
             {
                 return [
-                    BeforeImport::class => function (BeforeImport $event) {
+                    BeforeImport::class => function (BeforeImport $event): void {
                         Assert::assertInstanceOf(Reader::class, $event->reader);
                         $this->before++;
                     },
-                    AfterImport::class => function (AfterImport $event) {
+                    AfterImport::class => function (AfterImport $event): void {
                         Assert::assertInstanceOf(Reader::class, $event->reader);
                         $this->after++;
                     },
@@ -92,7 +92,7 @@ class WithChunkReadingTest extends TestCase
         $this->assertEquals(1, $import->after, 'AfterImport was not called or more than once.');
     }
 
-    public function test_can_import_to_model_in_chunks_and_insert_in_batches()
+    public function test_can_import_to_model_in_chunks_and_insert_in_batches(): void
     {
         DB::connection()->enableQueryLog();
 
@@ -127,7 +127,7 @@ class WithChunkReadingTest extends TestCase
         DB::connection()->disableQueryLog();
     }
 
-    public function test_can_import_to_model_in_chunks_and_insert_in_batches_with_heading_row()
+    public function test_can_import_to_model_in_chunks_and_insert_in_batches_with_heading_row(): void
     {
         DB::connection()->enableQueryLog();
 
@@ -162,7 +162,7 @@ class WithChunkReadingTest extends TestCase
         DB::connection()->disableQueryLog();
     }
 
-    public function test_can_import_csv_in_chunks_and_insert_in_batches()
+    public function test_can_import_csv_in_chunks_and_insert_in_batches(): void
     {
         DB::connection()->enableQueryLog();
 
@@ -197,7 +197,7 @@ class WithChunkReadingTest extends TestCase
         DB::connection()->disableQueryLog();
     }
 
-    public function test_can_import_to_model_in_chunks_and_insert_in_batches_with_multiple_sheets()
+    public function test_can_import_to_model_in_chunks_and_insert_in_batches_with_multiple_sheets(): void
     {
         DB::connection()->enableQueryLog();
 
@@ -232,7 +232,7 @@ class WithChunkReadingTest extends TestCase
         DB::connection()->disableQueryLog();
     }
 
-    public function test_can_import_to_array_in_chunks()
+    public function test_can_import_to_array_in_chunks(): void
     {
         $import = new class implements ToArray, WithChunkReading, WithFormatData
         {
@@ -240,7 +240,7 @@ class WithChunkReadingTest extends TestCase
 
             public $called = 0;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 $this->called++;
 
@@ -258,7 +258,7 @@ class WithChunkReadingTest extends TestCase
         $this->assertEquals(50, $import->called);
     }
 
-    public function test_can_import_to_model_in_chunks_and_insert_in_batches_with_multiple_sheets_objects_by_index()
+    public function test_can_import_to_model_in_chunks_and_insert_in_batches_with_multiple_sheets_objects_by_index(): void
     {
         DB::connection()->enableQueryLog();
 
@@ -319,7 +319,7 @@ class WithChunkReadingTest extends TestCase
         DB::connection()->disableQueryLog();
     }
 
-    public function test_can_import_to_model_in_chunks_and_insert_in_batches_with_multiple_sheets_objects_by_name()
+    public function test_can_import_to_model_in_chunks_and_insert_in_batches_with_multiple_sheets_objects_by_name(): void
     {
         DB::connection()->enableQueryLog();
 
@@ -380,7 +380,7 @@ class WithChunkReadingTest extends TestCase
         DB::connection()->disableQueryLog();
     }
 
-    public function test_can_catch_job_failed_in_chunks()
+    public function test_can_catch_job_failed_in_chunks(): void
     {
         $import = new class implements ToModel, WithChunkReading, WithEvents
         {
@@ -404,7 +404,7 @@ class WithChunkReadingTest extends TestCase
             public function registerEvents(): array
             {
                 return [
-                    ImportFailed::class => function (ImportFailed $event) {
+                    ImportFailed::class => function (ImportFailed $event): void {
                         Assert::assertInstanceOf(Throwable::class, $event->getException());
                         Assert::assertEquals('Something went wrong in the chunk', $event->e->getMessage());
 
@@ -424,7 +424,7 @@ class WithChunkReadingTest extends TestCase
         $this->assertTrue($import->failed, 'ImportFailed event was not called.');
     }
 
-    public function test_can_import_to_array_and_format_in_chunks()
+    public function test_can_import_to_array_and_format_in_chunks(): void
     {
         config()->set('excel.imports.read_only', false);
 
@@ -432,7 +432,7 @@ class WithChunkReadingTest extends TestCase
         {
             use Importable;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertCount(2, $array);
                 Assert::assertCount(1, $array[0]);
@@ -452,7 +452,7 @@ class WithChunkReadingTest extends TestCase
         $import->import('import-batches-with-date.xlsx');
     }
 
-    public function test_can_import_to_array_in_chunks_without_formatting()
+    public function test_can_import_to_array_in_chunks_without_formatting(): void
     {
         config()->set('excel.imports.read_only', true);
 
@@ -460,7 +460,7 @@ class WithChunkReadingTest extends TestCase
         {
             use Importable;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertCount(2, $array);
                 Assert::assertCount(1, $array[0]);

--- a/tests/Concerns/WithColumnFormattingTest.php
+++ b/tests/Concerns/WithColumnFormattingTest.php
@@ -14,7 +14,7 @@ use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 
 class WithColumnFormattingTest extends TestCase
 {
-    public function test_can_export_with_column_formatting()
+    public function test_can_export_with_column_formatting(): void
     {
         $export = new class implements FromCollection, WithColumnFormatting, WithMapping
         {

--- a/tests/Concerns/WithColumnLimitTest.php
+++ b/tests/Concerns/WithColumnLimitTest.php
@@ -21,13 +21,13 @@ class WithColumnLimitTest extends TestCase
         $this->loadLaravelMigrations(['--database' => 'testing']);
     }
 
-    public function test_can_import_to_array_with_column_limit()
+    public function test_can_import_to_array_with_column_limit(): void
     {
         $import = new class implements ToArray, WithColumnLimit
         {
             use Importable;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     [
@@ -48,13 +48,13 @@ class WithColumnLimitTest extends TestCase
         $import->import('import-users.xlsx');
     }
 
-    public function test_can_import_to_array_with_column_limit_and_skips_empty_rows()
+    public function test_can_import_to_array_with_column_limit_and_skips_empty_rows(): void
     {
         $import = new class implements SkipsEmptyRows, ToArray, WithColumnLimit
         {
             use Importable;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     [

--- a/tests/Concerns/WithColumnWidthsTest.php
+++ b/tests/Concerns/WithColumnWidthsTest.php
@@ -9,7 +9,7 @@ use Maatwebsite\Excel\Tests\TestCase;
 
 class WithColumnWidthsTest extends TestCase
 {
-    public function test_can_set_column_width()
+    public function test_can_set_column_width(): void
     {
         $export = new class implements FromArray, WithColumnWidths
         {

--- a/tests/Concerns/WithConditionalSheetsTest.php
+++ b/tests/Concerns/WithConditionalSheetsTest.php
@@ -10,7 +10,7 @@ use Maatwebsite\Excel\Tests\TestCase;
 
 class WithConditionalSheetsTest extends TestCase
 {
-    public function test_can_select_which_sheets_will_be_imported()
+    public function test_can_select_which_sheets_will_be_imported(): void
     {
         $import = new class implements WithMultipleSheets
         {
@@ -23,14 +23,14 @@ class WithConditionalSheetsTest extends TestCase
                 $this->init();
             }
 
-            public function init()
+            public function init(): void
             {
                 $this->sheets = [
                     'Sheet1' => new class implements ToArray
                     {
                         public $called = false;
 
-                        public function array(array $array)
+                        public function array(array $array): void
                         {
                             $this->called = true;
                         }
@@ -39,7 +39,7 @@ class WithConditionalSheetsTest extends TestCase
                     {
                         public $called = false;
 
-                        public function array(array $array)
+                        public function array(array $array): void
                         {
                             $this->called = true;
                         }

--- a/tests/Concerns/WithCustomCsvSettingsTest.php
+++ b/tests/Concerns/WithCustomCsvSettingsTest.php
@@ -25,7 +25,7 @@ class WithCustomCsvSettingsTest extends TestCase
         $this->SUT = $this->app->make(Excel::class);
     }
 
-    public function test_can_store_csv_export_with_custom_settings()
+    public function test_can_store_csv_export_with_custom_settings(): void
     {
         $export = new class implements FromCollection, WithCustomCsvSettings
         {
@@ -64,7 +64,7 @@ class WithCustomCsvSettingsTest extends TestCase
         $this->assertStringContains('A2;B2', $contents);
     }
 
-    public function test_can_store_csv_export_with_custom_encoding()
+    public function test_can_store_csv_export_with_custom_encoding(): void
     {
         $export = new class implements FromCollection, WithCustomCsvSettings
         {
@@ -107,7 +107,7 @@ class WithCustomCsvSettingsTest extends TestCase
         $this->assertStringContains('A2;åßàèòìù', $contents);
     }
 
-    public function test_can_read_csv_with_auto_detecting_delimiter_semicolon()
+    public function test_can_read_csv_with_auto_detecting_delimiter_semicolon(): void
     {
         $this->assertEquals([
             [
@@ -116,7 +116,7 @@ class WithCustomCsvSettingsTest extends TestCase
         ], (new HeadingRowImport)->toArray('csv-with-other-delimiter.csv'));
     }
 
-    public function test_can_read_csv_with_auto_detecting_delimiter_comma()
+    public function test_can_read_csv_with_auto_detecting_delimiter_comma(): void
     {
         $this->assertEquals([
             [
@@ -125,7 +125,7 @@ class WithCustomCsvSettingsTest extends TestCase
         ], (new HeadingRowImport)->toArray('csv-with-comma.csv'));
     }
 
-    public function test_can_read_csv_import_with_custom_settings()
+    public function test_can_read_csv_import_with_custom_settings(): void
     {
         $import = new class implements ToArray, WithCustomCsvSettings
         {
@@ -140,7 +140,7 @@ class WithCustomCsvSettingsTest extends TestCase
                 ];
             }
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     ['A1', 'B1'],
@@ -152,7 +152,7 @@ class WithCustomCsvSettingsTest extends TestCase
         $this->SUT->import($import, 'csv-with-other-delimiter.csv');
     }
 
-    public function test_cannot_read_with_wrong_delimiter()
+    public function test_cannot_read_with_wrong_delimiter(): void
     {
         $import = new class implements ToArray, WithCustomCsvSettings
         {
@@ -163,7 +163,7 @@ class WithCustomCsvSettingsTest extends TestCase
                 ];
             }
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     ['A1;B1'],

--- a/tests/Concerns/WithCustomQuerySizeTest.php
+++ b/tests/Concerns/WithCustomQuerySizeTest.php
@@ -20,14 +20,14 @@ class WithCustomQuerySizeTest extends TestCase
         $this->loadLaravelMigrations(['--database' => 'testing']);
         $this->loadMigrationsFrom(dirname(__DIR__) . '/Data/Stubs/Database/Migrations');
 
-        Group::factory()->count(5)->create()->each(function (Group $group) {
-            $group->users()->attach(User::factory()->count(rand(1, 3))->create());
+        Group::factory()->count(5)->create()->each(function (Group $group): void {
+            $group->users()->attach(User::factory()->count(random_int(1, 3))->create());
         });
 
         config()->set('excel.exports.chunk_size', 2);
     }
 
-    public function test_can_export_with_custom_count()
+    public function test_can_export_with_custom_count(): void
     {
         $export = new FromQueryWithCustomQuerySize;
 

--- a/tests/Concerns/WithCustomStartCellTest.php
+++ b/tests/Concerns/WithCustomStartCellTest.php
@@ -22,7 +22,7 @@ class WithCustomStartCellTest extends TestCase
         $this->SUT = $this->app->make(Excel::class);
     }
 
-    public function test_can_store_collection_with_custom_start_cell()
+    public function test_can_store_collection_with_custom_start_cell(): void
     {
         $export = new class implements FromCollection, WithCustomStartCell
         {

--- a/tests/Concerns/WithCustomValueBinderTest.php
+++ b/tests/Concerns/WithCustomValueBinderTest.php
@@ -16,7 +16,7 @@ use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 
 class WithCustomValueBinderTest extends TestCase
 {
-    public function test_can_set_a_value_binder_on_export()
+    public function test_can_set_a_value_binder_on_export(): void
     {
         Carbon::setTestNow(new Carbon('2018-08-07 18:00:00'));
 

--- a/tests/Concerns/WithDefaultStylesTest.php
+++ b/tests/Concerns/WithDefaultStylesTest.php
@@ -11,7 +11,7 @@ use PhpOffice\PhpSpreadsheet\Style\Style;
 
 class WithDefaultStylesTest extends TestCase
 {
-    public function test_can_configure_default_styles()
+    public function test_can_configure_default_styles(): void
     {
         $export = new class implements FromArray, WithDefaultStyles
         {

--- a/tests/Concerns/WithEventsTest.php
+++ b/tests/Concerns/WithEventsTest.php
@@ -32,31 +32,31 @@ class WithEventsTest extends TestCase
 {
     use WithFaker;
 
-    public function test_export_events_get_called()
+    public function test_export_events_get_called(): void
     {
         $event = new ExportWithEvents;
 
         $eventsTriggered = 0;
 
-        $event->beforeExport = function ($event) use (&$eventsTriggered) {
+        $event->beforeExport = function ($event) use (&$eventsTriggered): void {
             $this->assertInstanceOf(BeforeExport::class, $event);
             $this->assertInstanceOf(Writer::class, $event->getWriter());
             $eventsTriggered++;
         };
 
-        $event->beforeWriting = function ($event) use (&$eventsTriggered) {
+        $event->beforeWriting = function ($event) use (&$eventsTriggered): void {
             $this->assertInstanceOf(BeforeWriting::class, $event);
             $this->assertInstanceOf(Writer::class, $event->getWriter());
             $eventsTriggered++;
         };
 
-        $event->beforeSheet = function ($event) use (&$eventsTriggered) {
+        $event->beforeSheet = function ($event) use (&$eventsTriggered): void {
             $this->assertInstanceOf(BeforeSheet::class, $event);
             $this->assertInstanceOf(Sheet::class, $event->getSheet());
             $eventsTriggered++;
         };
 
-        $event->afterSheet = function ($event) use (&$eventsTriggered) {
+        $event->afterSheet = function ($event) use (&$eventsTriggered): void {
             $this->assertInstanceOf(AfterSheet::class, $event);
             $this->assertInstanceOf(Sheet::class, $event->getSheet());
             $eventsTriggered++;
@@ -66,31 +66,31 @@ class WithEventsTest extends TestCase
         $this->assertEquals(4, $eventsTriggered);
     }
 
-    public function test_import_events_get_called()
+    public function test_import_events_get_called(): void
     {
         $import = new ImportWithEvents;
 
         $eventsTriggered = 0;
 
-        $import->beforeImport = function ($event) use (&$eventsTriggered) {
+        $import->beforeImport = function ($event) use (&$eventsTriggered): void {
             $this->assertInstanceOf(BeforeImport::class, $event);
             $this->assertInstanceOf(Reader::class, $event->getReader());
             $eventsTriggered++;
         };
 
-        $import->afterImport = function ($event) use (&$eventsTriggered) {
+        $import->afterImport = function ($event) use (&$eventsTriggered): void {
             $this->assertInstanceOf(AfterImport::class, $event);
             $this->assertInstanceOf(Reader::class, $event->getReader());
             $eventsTriggered++;
         };
 
-        $import->beforeSheet = function ($event) use (&$eventsTriggered) {
+        $import->beforeSheet = function ($event) use (&$eventsTriggered): void {
             $this->assertInstanceOf(BeforeSheet::class, $event);
             $this->assertInstanceOf(Sheet::class, $event->getSheet());
             $eventsTriggered++;
         };
 
-        $import->afterSheet = function ($event) use (&$eventsTriggered) {
+        $import->afterSheet = function ($event) use (&$eventsTriggered): void {
             $this->assertInstanceOf(AfterSheet::class, $event);
             $this->assertInstanceOf(Sheet::class, $event->getSheet());
             $eventsTriggered++;
@@ -100,7 +100,7 @@ class WithEventsTest extends TestCase
         $this->assertEquals(4, $eventsTriggered);
     }
 
-    public function test_import_chunked_events_get_called()
+    public function test_import_chunked_events_get_called(): void
     {
         $import = new ImportWithEventsChunksAndBatches;
 
@@ -111,30 +111,30 @@ class WithEventsTest extends TestCase
         $afterBatch   = 0;
         $afterChunk   = 0;
 
-        $import->beforeImport = function (BeforeImport $event) use (&$beforeImport) {
+        $import->beforeImport = function (BeforeImport $event) use (&$beforeImport): void {
             $this->assertInstanceOf(Reader::class, $event->getReader());
             // Ensure event is fired only once
             $this->assertEquals(0, $beforeImport, 'Before import called twice');
             $beforeImport++;
         };
 
-        $import->afterImport = function (AfterImport $event) use (&$afterImport) {
+        $import->afterImport = function (AfterImport $event) use (&$afterImport): void {
             $this->assertInstanceOf(Reader::class, $event->getReader());
             $this->assertEquals(0, $afterImport, 'After import called twice');
             $afterImport++;
         };
 
-        $import->beforeSheet = function (BeforeSheet $event) use (&$beforeSheet) {
+        $import->beforeSheet = function (BeforeSheet $event) use (&$beforeSheet): void {
             $this->assertInstanceOf(Sheet::class, $event->getSheet());
             $beforeSheet++;
         };
 
-        $import->afterSheet = function (AfterSheet $event) use (&$afterSheet) {
+        $import->afterSheet = function (AfterSheet $event) use (&$afterSheet): void {
             $this->assertInstanceOf(Sheet::class, $event->getSheet());
             $afterSheet++;
         };
 
-        $import->afterBatch = function (AfterBatch $event) use ($import, &$afterBatch) {
+        $import->afterBatch = function (AfterBatch $event) use ($import, &$afterBatch): void {
             $this->assertEquals(
                 $import->batchSize(),
                 $event->getBatchSize(),
@@ -143,15 +143,17 @@ class WithEventsTest extends TestCase
             $this->assertEquals(
                 $afterBatch * $import->batchSize() + 1,
                 $event->getStartRow(),
-                'Wrong batch start row');
+                'Wrong batch start row'
+            );
             $afterBatch++;
         };
 
-        $import->afterChunk = function (AfterChunk $event) use ($import, &$afterChunk) {
+        $import->afterChunk = function (AfterChunk $event) use ($import, &$afterChunk): void {
             $this->assertEquals(
                 $event->getStartRow(),
                 $afterChunk * $import->chunkSize() + 1,
-                'Wrong chunk start row');
+                'Wrong chunk start row'
+            );
             $afterChunk++;
         };
 
@@ -162,11 +164,11 @@ class WithEventsTest extends TestCase
         $this->assertEquals(10, $afterChunk);
     }
 
-    public function test_can_have_invokable_class_as_listener()
+    public function test_can_have_invokable_class_as_listener(): void
     {
         $event = new ExportWithEvents;
 
-        $event->beforeExport = new BeforeExportListener(function ($event) {
+        $event->beforeExport = new BeforeExportListener(function ($event): void {
             $this->assertInstanceOf(BeforeExport::class, $event);
             $this->assertInstanceOf(Writer::class, $event->getWriter());
         });
@@ -174,7 +176,7 @@ class WithEventsTest extends TestCase
         $this->assertInstanceOf(BinaryFileResponse::class, $event->download('filename.xlsx'));
     }
 
-    public function test_can_have_global_event_listeners()
+    public function test_can_have_global_event_listeners(): void
     {
         $event = new class
         {
@@ -182,22 +184,22 @@ class WithEventsTest extends TestCase
         };
 
         $beforeExport = false;
-        Writer::listen(BeforeExport::class, function () use (&$beforeExport) {
+        Writer::listen(BeforeExport::class, function () use (&$beforeExport): void {
             $beforeExport = true;
         });
 
         $beforeWriting = false;
-        Writer::listen(BeforeWriting::class, function () use (&$beforeWriting) {
+        Writer::listen(BeforeWriting::class, function () use (&$beforeWriting): void {
             $beforeWriting = true;
         });
 
         $beforeSheet = false;
-        Sheet::listen(BeforeSheet::class, function () use (&$beforeSheet) {
+        Sheet::listen(BeforeSheet::class, function () use (&$beforeSheet): void {
             $beforeSheet = true;
         });
 
         $afterSheet = false;
-        Sheet::listen(AfterSheet::class, function () use (&$afterSheet) {
+        Sheet::listen(AfterSheet::class, function () use (&$afterSheet): void {
             $afterSheet = true;
         });
 
@@ -209,10 +211,10 @@ class WithEventsTest extends TestCase
         $this->assertTrue($afterSheet, 'After sheet event not triggered');
     }
 
-    public function test_can_have_custom_concern_handlers()
+    public function test_can_have_custom_concern_handlers(): void
     {
         // Add a custom concern handler for the given concern.
-        Excel::extend(CustomConcern::class, function (CustomConcern $exportable, Writer $writer) {
+        Excel::extend(CustomConcern::class, function (CustomConcern $exportable, Writer $writer): void {
             $writer->getSheetByIndex(0)->append(
                 $exportable->custom()
             );
@@ -247,10 +249,10 @@ class WithEventsTest extends TestCase
         $this->assertEquals([[null]], $actual);
     }
 
-    public function test_can_have_custom_sheet_concern_handlers()
+    public function test_can_have_custom_sheet_concern_handlers(): void
     {
         // Add a custom concern handler for the given concern.
-        Excel::extend(CustomSheetConcern::class, function (CustomSheetConcern $exportable, Sheet $sheet) {
+        Excel::extend(CustomSheetConcern::class, function (CustomSheetConcern $exportable, Sheet $sheet): void {
             $sheet->append(
                 $exportable->custom()
             );
@@ -285,7 +287,7 @@ class WithEventsTest extends TestCase
         $this->assertEquals([[null]], $actual);
     }
 
-    public function test_export_chunked_events_get_called()
+    public function test_export_chunked_events_get_called(): void
     {
         $this->loadLaravelMigrations(['--database' => 'testing']);
 

--- a/tests/Concerns/WithFormatDataTest.php
+++ b/tests/Concerns/WithFormatDataTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\Assert;
 
 class WithFormatDataTest extends TestCase
 {
-    public function test_by_default_import_to_array()
+    public function test_by_default_import_to_array(): void
     {
         $import = new class implements ToArray
         {
@@ -22,7 +22,7 @@ class WithFormatDataTest extends TestCase
 
             public $called = false;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 $this->called = true;
 
@@ -35,7 +35,7 @@ class WithFormatDataTest extends TestCase
         $this->assertTrue($import->called);
     }
 
-    public function test_can_import_to_array_with_format_data()
+    public function test_can_import_to_array_with_format_data(): void
     {
         config()->set('excel.imports.read_only', false);
         $import = new class implements ToArray, WithFormatData
@@ -44,7 +44,7 @@ class WithFormatDataTest extends TestCase
 
             public $called = false;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 $this->called = true;
 
@@ -57,7 +57,7 @@ class WithFormatDataTest extends TestCase
         $this->assertTrue($import->called);
     }
 
-    public function test_can_import_to_array_with_format_data_and_skips_empty_rows()
+    public function test_can_import_to_array_with_format_data_and_skips_empty_rows(): void
     {
         config()->set('excel.imports.read_only', false);
         $import = new class implements SkipsEmptyRows, ToArray, WithFormatData
@@ -66,7 +66,7 @@ class WithFormatDataTest extends TestCase
 
             public $called = false;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 $this->called = true;
 
@@ -79,7 +79,7 @@ class WithFormatDataTest extends TestCase
         $this->assertTrue($import->called);
     }
 
-    public function test_by_default_import_to_collection()
+    public function test_by_default_import_to_collection(): void
     {
         $import = new class implements ToCollection
         {
@@ -106,7 +106,7 @@ class WithFormatDataTest extends TestCase
         $this->assertTrue($import->called);
     }
 
-    public function test_can_import_to_collection_with_format_data()
+    public function test_can_import_to_collection_with_format_data(): void
     {
         config()->set('excel.imports.read_only', false);
         $import = new class implements ToCollection, WithFormatData
@@ -134,7 +134,7 @@ class WithFormatDataTest extends TestCase
         $this->assertTrue($import->called);
     }
 
-    public function test_by_default_import_to_model()
+    public function test_by_default_import_to_model(): void
     {
         $import = new class implements ToModel
         {
@@ -160,7 +160,7 @@ class WithFormatDataTest extends TestCase
         $this->assertTrue($import->called);
     }
 
-    public function test_can_import_to_model_with_format_data()
+    public function test_can_import_to_model_with_format_data(): void
     {
         config()->set('excel.imports.read_only', false);
         $import = new class implements ToModel, WithFormatData

--- a/tests/Concerns/WithGroupedHeadingRowTest.php
+++ b/tests/Concerns/WithGroupedHeadingRowTest.php
@@ -28,13 +28,13 @@ class WithGroupedHeadingRowTest extends TestCase
         $this->loadMigrationsFrom(dirname(__DIR__) . '/Data/Stubs/Database/Migrations');
     }
 
-    public function test_can_import_to_array_with_grouped_headers()
+    public function test_can_import_to_array_with_grouped_headers(): void
     {
         $import = new class implements ToArray, WithGroupedHeadingRow
         {
             use Importable;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     [
@@ -52,16 +52,13 @@ class WithGroupedHeadingRowTest extends TestCase
         $import->import('import-users-with-grouped-headers.xlsx');
     }
 
-    public function test_can_import_oneachrow_with_grouped_headers()
+    public function test_can_import_oneachrow_with_grouped_headers(): void
     {
         $import = new class implements OnEachRow, WithGroupedHeadingRow
         {
             use Importable;
 
-            /**
-             * @return void
-             */
-            public function onRow(Row $row)
+            public function onRow(Row $row): void
             {
                 Assert::assertEquals(
                     [
@@ -71,14 +68,16 @@ class WithGroupedHeadingRowTest extends TestCase
                             'laravel',
                             'excel',
                         ],
-                    ], $row->toArray());
+                    ],
+                    $row->toArray()
+                );
             }
         };
 
         $import->import('import-users-with-grouped-headers.xlsx');
     }
 
-    public function test_can_import_to_collection_with_grouped_headers()
+    public function test_can_import_to_collection_with_grouped_headers(): void
     {
         $import = new class implements ToCollection, WithGroupedHeadingRow
         {
@@ -86,7 +85,7 @@ class WithGroupedHeadingRowTest extends TestCase
 
             public $called = false;
 
-            public function collection(Collection $collection)
+            public function collection(Collection $collection): void
             {
                 $this->called = true;
 
@@ -108,7 +107,7 @@ class WithGroupedHeadingRowTest extends TestCase
         $this->assertTrue($import->called);
     }
 
-    public function test_can_import_each_row_to_model_with_grouped_headers()
+    public function test_can_import_each_row_to_model_with_grouped_headers(): void
     {
         $import = new class implements ToModel, WithGroupedHeadingRow
         {

--- a/tests/Concerns/WithHeadingRowTest.php
+++ b/tests/Concerns/WithHeadingRowTest.php
@@ -25,7 +25,7 @@ class WithHeadingRowTest extends TestCase
         $this->loadLaravelMigrations(['--database' => 'testing']);
     }
 
-    public function test_can_import_each_row_to_model_with_heading_row()
+    public function test_can_import_each_row_to_model_with_heading_row(): void
     {
         $import = new class implements ToModel, WithHeadingRow
         {
@@ -54,7 +54,7 @@ class WithHeadingRowTest extends TestCase
         ]);
     }
 
-    public function test_can_import_each_row_to_model_with_different_heading_row()
+    public function test_can_import_each_row_to_model_with_different_heading_row(): void
     {
         $import = new class implements ToModel, WithHeadingRow
         {
@@ -88,13 +88,13 @@ class WithHeadingRowTest extends TestCase
         ]);
     }
 
-    public function test_can_import_to_array_with_heading_row()
+    public function test_can_import_to_array_with_heading_row(): void
     {
         $import = new class implements ToArray, WithHeadingRow
         {
             use Importable;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     [
@@ -112,13 +112,13 @@ class WithHeadingRowTest extends TestCase
         $import->import('import-users-with-headings.xlsx');
     }
 
-    public function test_can_import_empty_rows_with_header()
+    public function test_can_import_empty_rows_with_header(): void
     {
         $import = new class implements ToArray, WithHeadingRow
         {
             use Importable;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEmpty($array);
             }
@@ -127,7 +127,7 @@ class WithHeadingRowTest extends TestCase
         $import->import('import-empty-users-with-headings.xlsx');
     }
 
-    public function test_can_import_empty_models_with_header()
+    public function test_can_import_empty_models_with_header(): void
     {
         $import = new class implements ToModel, WithHeadingRow
         {
@@ -147,7 +147,7 @@ class WithHeadingRowTest extends TestCase
         $this->assertEmpty(User::all());
     }
 
-    public function test_can_cast_empty_headers_to_indexed_int()
+    public function test_can_cast_empty_headers_to_indexed_int(): void
     {
         $import = new class implements ToCollection, WithHeadingRow
         {
@@ -155,7 +155,7 @@ class WithHeadingRowTest extends TestCase
 
             public $called = false;
 
-            public function collection(Collection $collection)
+            public function collection(Collection $collection): void
             {
                 $this->called = true;
 

--- a/tests/Concerns/WithHeadingsTest.php
+++ b/tests/Concerns/WithHeadingsTest.php
@@ -11,7 +11,7 @@ use Maatwebsite\Excel\Tests\TestCase;
 
 class WithHeadingsTest extends TestCase
 {
-    public function test_can_export_from_collection_with_heading_row()
+    public function test_can_export_from_collection_with_heading_row(): void
     {
         $export = new class implements FromCollection, WithHeadings
         {
@@ -49,7 +49,7 @@ class WithHeadingsTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_can_export_from_collection_with_multiple_heading_rows()
+    public function test_can_export_from_collection_with_multiple_heading_rows(): void
     {
         $export = new class implements FromCollection, WithHeadings
         {
@@ -91,7 +91,7 @@ class WithHeadingsTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_can_export_from_collection_with_heading_row_with_custom_start_cell()
+    public function test_can_export_from_collection_with_heading_row_with_custom_start_cell(): void
     {
         $export = new class implements FromCollection, WithCustomStartCell, WithHeadings
         {

--- a/tests/Concerns/WithLimitTest.php
+++ b/tests/Concerns/WithLimitTest.php
@@ -25,7 +25,7 @@ class WithLimitTest extends TestCase
         $this->loadLaravelMigrations(['--database' => 'testing']);
     }
 
-    public function test_can_import_a_limited_section_of_rows_to_model_with_different_start_row()
+    public function test_can_import_a_limited_section_of_rows_to_model_with_different_start_row(): void
     {
         $import = new class implements ToModel, WithLimit, WithStartRow
         {
@@ -64,13 +64,13 @@ class WithLimitTest extends TestCase
         ]);
     }
 
-    public function test_can_import_to_array_with_limit()
+    public function test_can_import_to_array_with_limit(): void
     {
         $import = new class implements ToArray, WithLimit
         {
             use Importable;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     [
@@ -89,13 +89,13 @@ class WithLimitTest extends TestCase
         $import->import('import-users.xlsx');
     }
 
-    public function test_can_import_single_with_heading_row()
+    public function test_can_import_single_with_heading_row(): void
     {
         $import = new class implements ToArray, WithHeadingRow, WithLimit
         {
             use Importable;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     [
@@ -114,13 +114,13 @@ class WithLimitTest extends TestCase
         $import->import('import-users-with-headings.xlsx');
     }
 
-    public function test_can_import_multiple_with_heading_row()
+    public function test_can_import_multiple_with_heading_row(): void
     {
         $import = new class implements ToArray, WithHeadingRow, WithLimit
         {
             use Importable;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     [
@@ -143,13 +143,13 @@ class WithLimitTest extends TestCase
         $import->import('import-users-with-headings.xlsx');
     }
 
-    public function test_can_set_limit_bigger_than_row_size()
+    public function test_can_set_limit_bigger_than_row_size(): void
     {
         $import = new class implements ToArray, WithLimit
         {
             use Importable;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertCount(2, $array);
             }

--- a/tests/Concerns/WithMappedCellsTest.php
+++ b/tests/Concerns/WithMappedCellsTest.php
@@ -23,7 +23,7 @@ class WithMappedCellsTest extends TestCase
         $this->loadLaravelMigrations(['--database' => 'testing']);
     }
 
-    public function test_can_import_with_references_to_cells()
+    public function test_can_import_with_references_to_cells(): void
     {
         $import = new class implements ToArray, WithMappedCells
         {
@@ -37,7 +37,7 @@ class WithMappedCellsTest extends TestCase
                 ];
             }
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     'name'  => 'Patrick Brouwers',
@@ -49,7 +49,7 @@ class WithMappedCellsTest extends TestCase
         $import->import('mapped-import.xlsx');
     }
 
-    public function test_can_import_with_nested_references_to_cells()
+    public function test_can_import_with_nested_references_to_cells(): void
     {
         $import = new class implements ToArray, WithMappedCells
         {
@@ -69,7 +69,7 @@ class WithMappedCellsTest extends TestCase
                 ];
             }
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     [
@@ -87,7 +87,7 @@ class WithMappedCellsTest extends TestCase
         $import->import('mapped-import.xlsx');
     }
 
-    public function test_can_import_with_references_to_cells_to_model()
+    public function test_can_import_with_references_to_cells_to_model(): void
     {
         $import = new class implements ToModel, WithMappedCells
         {

--- a/tests/Concerns/WithMappingTest.php
+++ b/tests/Concerns/WithMappingTest.php
@@ -10,7 +10,7 @@ use Maatwebsite\Excel\Tests\TestCase;
 
 class WithMappingTest extends TestCase
 {
-    public function test_can_export_with_heading()
+    public function test_can_export_with_heading(): void
     {
         $export = new WithMappingExport;
 
@@ -36,7 +36,7 @@ class WithMappingTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_can_return_multiple_rows_in_map()
+    public function test_can_return_multiple_rows_in_map(): void
     {
         $export = new class implements FromArray, WithMapping
         {
@@ -72,7 +72,7 @@ class WithMappingTest extends TestCase
         $this->assertCount(6, $actual);
     }
 
-    public function test_json_array_columns_shouldnt_be_detected_as_multiple_rows()
+    public function test_json_array_columns_shouldnt_be_detected_as_multiple_rows(): void
     {
         $export = new class implements FromArray
         {

--- a/tests/Concerns/WithMultipleSheetsTest.php
+++ b/tests/Concerns/WithMultipleSheetsTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\Assert;
 
 class WithMultipleSheetsTest extends TestCase
 {
-    public function test_can_export_with_multiple_sheets_using_collections()
+    public function test_can_export_with_multiple_sheets_using_collections(): void
     {
         $export = new class implements WithMultipleSheets
         {
@@ -43,7 +43,7 @@ class WithMultipleSheetsTest extends TestCase
         $this->assertCount(100, $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-view.xlsx', 'Xlsx', 2));
     }
 
-    public function test_can_export_multiple_sheets_from_view()
+    public function test_can_export_multiple_sheets_from_view(): void
     {
         $this->loadLaravelMigrations(['--database' => 'testing']);
         /** @var Collection|User[] $users */
@@ -83,7 +83,7 @@ class WithMultipleSheetsTest extends TestCase
         $this->assertCount(101, $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-view.xlsx', 'Xlsx', 2));
     }
 
-    public function test_unknown_sheet_index_will_throw_sheet_not_found_exception()
+    public function test_unknown_sheet_index_will_throw_sheet_not_found_exception(): void
     {
         $this->expectException(SheetNotFoundException::class);
         $this->expectExceptionMessage('Your requested sheet index: 9999 is out of bounds. The actual number of sheets is 2.');
@@ -105,7 +105,7 @@ class WithMultipleSheetsTest extends TestCase
         $import->import('import-multiple-sheets.xlsx');
     }
 
-    public function test_unknown_sheet_name_will_throw_sheet_not_found_exception()
+    public function test_unknown_sheet_name_will_throw_sheet_not_found_exception(): void
     {
         $this->expectException(SheetNotFoundException::class);
         $this->expectExceptionMessage('Your requested sheet name [Some Random Sheet Name] is out of bounds.');
@@ -127,7 +127,7 @@ class WithMultipleSheetsTest extends TestCase
         $import->import('import-multiple-sheets.xlsx');
     }
 
-    public function test_unknown_sheet_name_can_be_ignored()
+    public function test_unknown_sheet_name_can_be_ignored(): void
     {
         $import = new class implements SkipsUnknownSheets, WithMultipleSheets
         {
@@ -147,7 +147,7 @@ class WithMultipleSheetsTest extends TestCase
             /**
              * @param  string|int  $sheetName
              */
-            public function onUnknownSheet($sheetName)
+            public function onUnknownSheet($sheetName): void
             {
                 $this->unknown = $sheetName;
             }
@@ -158,7 +158,7 @@ class WithMultipleSheetsTest extends TestCase
         $this->assertEquals('Some Random Sheet Name', $import->unknown);
     }
 
-    public function test_unknown_sheet_indices_can_be_ignored_per_name()
+    public function test_unknown_sheet_indices_can_be_ignored_per_name(): void
     {
         $import = new class implements WithMultipleSheets
         {
@@ -172,7 +172,7 @@ class WithMultipleSheetsTest extends TestCase
                         /**
                          * @param  string|int  $sheetName
                          */
-                        public function onUnknownSheet($sheetName)
+                        public function onUnknownSheet($sheetName): void
                         {
                             Assert::assertEquals('Some Random Sheet Name', $sheetName);
                         }
@@ -184,7 +184,7 @@ class WithMultipleSheetsTest extends TestCase
         $import->import('import-multiple-sheets.xlsx');
     }
 
-    public function test_unknown_sheet_indices_can_be_ignored()
+    public function test_unknown_sheet_indices_can_be_ignored(): void
     {
         $import = new class implements SkipsUnknownSheets, WithMultipleSheets
         {
@@ -204,7 +204,7 @@ class WithMultipleSheetsTest extends TestCase
             /**
              * @param  string|int  $sheetName
              */
-            public function onUnknownSheet($sheetName)
+            public function onUnknownSheet($sheetName): void
             {
                 $this->unknown = $sheetName;
             }
@@ -215,7 +215,7 @@ class WithMultipleSheetsTest extends TestCase
         $this->assertEquals(99999, $import->unknown);
     }
 
-    public function test_unknown_sheet_indices_can_be_ignored_per_sheet()
+    public function test_unknown_sheet_indices_can_be_ignored_per_sheet(): void
     {
         $import = new class implements WithMultipleSheets
         {
@@ -229,7 +229,7 @@ class WithMultipleSheetsTest extends TestCase
                         /**
                          * @param  string|int  $sheetName
                          */
-                        public function onUnknownSheet($sheetName)
+                        public function onUnknownSheet($sheetName): void
                         {
                             Assert::assertEquals(99999, $sheetName);
                         }
@@ -241,7 +241,7 @@ class WithMultipleSheetsTest extends TestCase
         $import->import('import-multiple-sheets.xlsx');
     }
 
-    public function test_can_import_multiple_sheets()
+    public function test_can_import_multiple_sheets(): void
     {
         $import = new class implements WithMultipleSheets
         {
@@ -252,7 +252,7 @@ class WithMultipleSheetsTest extends TestCase
                 return [
                     new class implements ToArray
                     {
-                        public function array(array $array)
+                        public function array(array $array): void
                         {
                             Assert::assertEquals([
                                 ['1.A1', '1.B1'],
@@ -262,7 +262,7 @@ class WithMultipleSheetsTest extends TestCase
                     },
                     new class implements ToArray
                     {
-                        public function array(array $array)
+                        public function array(array $array): void
                         {
                             Assert::assertEquals([
                                 ['2.A1', '2.B1'],
@@ -277,7 +277,7 @@ class WithMultipleSheetsTest extends TestCase
         $import->import('import-multiple-sheets.xlsx');
     }
 
-    public function test_can_import_multiple_sheets_by_sheet_name()
+    public function test_can_import_multiple_sheets_by_sheet_name(): void
     {
         $import = new class implements WithMultipleSheets
         {
@@ -288,7 +288,7 @@ class WithMultipleSheetsTest extends TestCase
                 return [
                     'Sheet2' => new class implements ToArray
                     {
-                        public function array(array $array)
+                        public function array(array $array): void
                         {
                             Assert::assertEquals([
                                 ['2.A1', '2.B1'],
@@ -298,7 +298,7 @@ class WithMultipleSheetsTest extends TestCase
                     },
                     'Sheet1' => new class implements ToArray
                     {
-                        public function array(array $array)
+                        public function array(array $array): void
                         {
                             Assert::assertEquals([
                                 ['1.A1', '1.B1'],
@@ -313,7 +313,7 @@ class WithMultipleSheetsTest extends TestCase
         $import->import('import-multiple-sheets.xlsx');
     }
 
-    public function test_can_import_multiple_sheets_by_sheet_index_and_name()
+    public function test_can_import_multiple_sheets_by_sheet_index_and_name(): void
     {
         $import = new class implements WithMultipleSheets
         {
@@ -328,7 +328,7 @@ class WithMultipleSheetsTest extends TestCase
                     {
                         public $called = false;
 
-                        public function array(array $array)
+                        public function array(array $array): void
                         {
                             $this->called = true;
                             Assert::assertEquals([
@@ -341,7 +341,7 @@ class WithMultipleSheetsTest extends TestCase
                     {
                         public $called = false;
 
-                        public function array(array $array)
+                        public function array(array $array): void
                         {
                             $this->called = true;
                             Assert::assertEquals([
@@ -366,7 +366,7 @@ class WithMultipleSheetsTest extends TestCase
         }
     }
 
-    public function test_can_import_multiple_sheets_by_sheet_name_and_index()
+    public function test_can_import_multiple_sheets_by_sheet_name_and_index(): void
     {
         $import = new class implements WithMultipleSheets
         {
@@ -381,7 +381,7 @@ class WithMultipleSheetsTest extends TestCase
                     {
                         public $called = false;
 
-                        public function array(array $array)
+                        public function array(array $array): void
                         {
                             $this->called = true;
                             Assert::assertEquals([
@@ -394,7 +394,7 @@ class WithMultipleSheetsTest extends TestCase
                     {
                         public $called = false;
 
-                        public function array(array $array)
+                        public function array(array $array): void
                         {
                             $this->called = true;
                             Assert::assertEquals([

--- a/tests/Concerns/WithPropertiesTest.php
+++ b/tests/Concerns/WithPropertiesTest.php
@@ -8,7 +8,7 @@ use Maatwebsite\Excel\Tests\TestCase;
 
 class WithPropertiesTest extends TestCase
 {
-    public function test_can_set_custom_document_properties()
+    public function test_can_set_custom_document_properties(): void
     {
         $export = new class implements WithProperties
         {
@@ -46,7 +46,7 @@ class WithPropertiesTest extends TestCase
         $this->assertEquals('I', $props->getCompany());
     }
 
-    public function test_it_merges_with_default_properties()
+    public function test_it_merges_with_default_properties(): void
     {
         config()->set('excel.exports.properties.title', 'Default Title');
         config()->set('excel.exports.properties.description', 'Default Description');
@@ -72,7 +72,7 @@ class WithPropertiesTest extends TestCase
         $this->assertEquals('Custom Description', $props->getDescription());
     }
 
-    public function test_it_ignores_empty_properties()
+    public function test_it_ignores_empty_properties(): void
     {
         $export = new class implements WithProperties
         {

--- a/tests/Concerns/WithReadFilterTest.php
+++ b/tests/Concerns/WithReadFilterTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Assert;
 
 class WithReadFilterTest extends TestCase
 {
-    public function test_can_register_custom_read_filter()
+    public function test_can_register_custom_read_filter(): void
     {
         $export = new class implements WithReadFilter
         {

--- a/tests/Concerns/WithSkipDuplicatesTest.php
+++ b/tests/Concerns/WithSkipDuplicatesTest.php
@@ -23,7 +23,7 @@ class WithSkipDuplicatesTest extends TestCase
         $this->loadLaravelMigrations(['--database' => 'testing']);
     }
 
-    public function test_can_skip_duplicate_models_in_batches()
+    public function test_can_skip_duplicate_models_in_batches(): void
     {
         User::create([
             'name'     => 'Funny Banana',
@@ -83,7 +83,7 @@ class WithSkipDuplicatesTest extends TestCase
         $this->assertEquals(2, User::count());
     }
 
-    public function test_can_skip_duplicate_models_in_rows()
+    public function test_can_skip_duplicate_models_in_rows(): void
     {
         User::create([
             'name'     => 'Funny Potato',

--- a/tests/Concerns/WithStartRowTest.php
+++ b/tests/Concerns/WithStartRowTest.php
@@ -23,7 +23,7 @@ class WithStartRowTest extends TestCase
         $this->loadLaravelMigrations(['--database' => 'testing']);
     }
 
-    public function test_can_import_each_row_to_model_with_different_start_row()
+    public function test_can_import_each_row_to_model_with_different_start_row(): void
     {
         $import = new class implements ToModel, WithStartRow
         {
@@ -57,13 +57,13 @@ class WithStartRowTest extends TestCase
         ]);
     }
 
-    public function test_can_import_to_array_with_start_row()
+    public function test_can_import_to_array_with_start_row(): void
     {
         $import = new class implements ToArray, WithStartRow
         {
             use Importable;
 
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     [

--- a/tests/Concerns/WithStrictNullComparisonTest.php
+++ b/tests/Concerns/WithStrictNullComparisonTest.php
@@ -11,7 +11,7 @@ use Maatwebsite\Excel\Tests\TestCase;
 
 class WithStrictNullComparisonTest extends TestCase
 {
-    public function test_exported_zero_values_are_not_null_when_exporting_with_strict_null_comparison()
+    public function test_exported_zero_values_are_not_null_when_exporting_with_strict_null_comparison(): void
     {
         $export = new class implements FromCollection, WithHeadings, WithStrictNullComparison
         {
@@ -47,7 +47,7 @@ class WithStrictNullComparisonTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_exported_zero_values_are_null_when_not_exporting_with_strict_null_comparison()
+    public function test_exported_zero_values_are_null_when_not_exporting_with_strict_null_comparison(): void
     {
         $export = new class implements FromCollection, WithHeadings
         {
@@ -83,7 +83,7 @@ class WithStrictNullComparisonTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function test_exports_trailing_empty_cells()
+    public function test_exports_trailing_empty_cells(): void
     {
         $export = new class implements FromCollection, WithStrictNullComparison
         {
@@ -120,7 +120,7 @@ class WithStrictNullComparisonTest extends TestCase
         $this->assertStringContains('"a2","","","d2",""', $contents);
     }
 
-    public function test_exports_trailing_empty_cells_by_setting_config_strict_null_comparison()
+    public function test_exports_trailing_empty_cells_by_setting_config_strict_null_comparison(): void
     {
         config()->set('excel.exports.strict_null_comparison', false);
 

--- a/tests/Concerns/WithStylesTest.php
+++ b/tests/Concerns/WithStylesTest.php
@@ -10,7 +10,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 class WithStylesTest extends TestCase
 {
-    public function test_can_configure_styles()
+    public function test_can_configure_styles(): void
     {
         $export = new class implements FromArray, WithStyles
         {

--- a/tests/Concerns/WithTitleTest.php
+++ b/tests/Concerns/WithTitleTest.php
@@ -10,7 +10,7 @@ use Maatwebsite\Excel\Tests\TestCase;
 
 class WithTitleTest extends TestCase
 {
-    public function test_can_export_with_title()
+    public function test_can_export_with_title(): void
     {
         $export = new WithTitleExport;
 
@@ -24,7 +24,7 @@ class WithTitleTest extends TestCase
         $this->assertEquals('given-title', $spreadsheet->getActiveSheet()->getTitle());
     }
 
-    public function test_can_export_sheet_title_when_longer_than_max_length()
+    public function test_can_export_sheet_title_when_longer_than_max_length(): void
     {
         $export = new class implements WithMultipleSheets, WithTitle
         {

--- a/tests/Concerns/WithUpsertsTest.php
+++ b/tests/Concerns/WithUpsertsTest.php
@@ -29,7 +29,7 @@ class WithUpsertsTest extends TestCase
         $this->loadLaravelMigrations(['--database' => 'testing']);
     }
 
-    public function test_can_upsert_models_in_batches()
+    public function test_can_upsert_models_in_batches(): void
     {
         User::create([
             'name'     => 'Funny Banana',
@@ -89,7 +89,7 @@ class WithUpsertsTest extends TestCase
         $this->assertEquals(2, User::count());
     }
 
-    public function test_can_upsert_models_in_rows()
+    public function test_can_upsert_models_in_rows(): void
     {
         User::create([
             'name'     => 'Funny Potato',
@@ -144,7 +144,7 @@ class WithUpsertsTest extends TestCase
         $this->assertEquals(2, User::count());
     }
 
-    public function test_can_upsert_models_in_batches_with_defined_upsert_columns()
+    public function test_can_upsert_models_in_batches_with_defined_upsert_columns(): void
     {
         User::create([
             'name'     => 'Funny Banana',
@@ -212,7 +212,7 @@ class WithUpsertsTest extends TestCase
         $this->assertEquals(2, User::count());
     }
 
-    public function test_can_upsert_models_in_rows_with_defined_upsert_columns()
+    public function test_can_upsert_models_in_rows_with_defined_upsert_columns(): void
     {
         User::create([
             'name'     => 'Funny Potato',

--- a/tests/Concerns/WithValidationTest.php
+++ b/tests/Concerns/WithValidationTest.php
@@ -35,7 +35,7 @@ class WithValidationTest extends TestCase
         $this->loadMigrationsFrom(dirname(__DIR__) . '/Data/Stubs/Database/Migrations');
     }
 
-    public function test_can_validate_rows()
+    public function test_can_validate_rows(): void
     {
         $import = new class implements ToModel, WithValidation
         {
@@ -77,7 +77,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_validate_rows_with_closure_validation_rules()
+    public function test_can_validate_rows_with_closure_validation_rules(): void
     {
         $import = new class implements ToModel, WithValidation
         {
@@ -98,7 +98,7 @@ class WithValidationTest extends TestCase
             public function rules(): array
             {
                 return [
-                    '1' => function ($attribute, $value, $onFail) {
+                    '1' => function ($attribute, $value, $onFail): void {
                         if ($value !== 'patrick@maatwebsite.nl') {
                             $onFail(sprintf('Value in column 1 is not an allowed e-mail.'));
                         }
@@ -123,7 +123,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_validate_rows_with_custom_validation_rule_objects()
+    public function test_can_validate_rows_with_custom_validation_rule_objects(): void
     {
         $import = new class implements ToModel, WithValidation
         {
@@ -186,7 +186,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_validate_rows_with_conditionality()
+    public function test_can_validate_rows_with_conditionality(): void
     {
         $import = new class implements ToModel, WithValidation
         {
@@ -223,7 +223,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_validate_rows_with_unless_conditionality()
+    public function test_can_validate_rows_with_unless_conditionality(): void
     {
         $import = new class implements ToModel, WithValidation
         {
@@ -260,7 +260,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_validate_rows_with_combined_rules_with_colons()
+    public function test_can_validate_rows_with_combined_rules_with_colons(): void
     {
         $import = new class implements ToModel, WithValidation
         {
@@ -303,7 +303,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_validate_with_custom_attributes()
+    public function test_can_validate_with_custom_attributes(): void
     {
         $import = new class implements ToModel, WithValidation
         {
@@ -348,7 +348,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_validate_with_custom_attributes_pointing_to_another_attribute()
+    public function test_can_validate_with_custom_attributes_pointing_to_another_attribute(): void
     {
         $import = new class implements ToModel, WithValidation
         {
@@ -394,7 +394,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_validate_with_custom_message()
+    public function test_can_validate_with_custom_message(): void
     {
         $import = new class implements ToModel, WithValidation
         {
@@ -441,7 +441,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_validate_rows_with_headings()
+    public function test_can_validate_rows_with_headings(): void
     {
         $import = new class implements ToModel, WithHeadingRow, WithValidation
         {
@@ -478,7 +478,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_validate_rows_with_grouped_headings()
+    public function test_can_validate_rows_with_grouped_headings(): void
     {
         $import = new class implements ToModel, WithGroupedHeadingRow, WithValidation
         {
@@ -531,7 +531,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_validate_rows_in_batches()
+    public function test_can_validate_rows_in_batches(): void
     {
         $import = new class implements ToModel, WithBatchInserts, WithHeadingRow, WithValidation
         {
@@ -573,7 +573,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_validate_using_oneachrow()
+    public function test_can_validate_using_oneachrow(): void
     {
         $import = new class implements OnEachRow, WithHeadingRow, WithValidation
         {
@@ -612,13 +612,13 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_validate_using_collection()
+    public function test_can_validate_using_collection(): void
     {
         $import = new class implements ToCollection, WithHeadingRow, WithValidation
         {
             use Importable;
 
-            public function collection(Collection $rows)
+            public function collection(Collection $rows): void
             {
                 //
             }
@@ -642,13 +642,13 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_validate_using_array()
+    public function test_can_validate_using_array(): void
     {
         $import = new class implements ToArray, WithHeadingRow, WithValidation
         {
             use Importable;
 
-            public function array(array $rows)
+            public function array(array $rows): void
             {
                 //
             }
@@ -672,7 +672,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_configure_validator()
+    public function test_can_configure_validator(): void
     {
         $import = new class implements ToModel, WithValidation
         {
@@ -701,9 +701,8 @@ class WithValidationTest extends TestCase
              * Configure the validator.
              *
              * @param  Validator  $validator
-             * @return void
              */
-            public function withValidator($validator)
+            public function withValidator($validator): void
             {
                 $validator->sometimes('*.1', Rule::in(['patrick@maatwebsite.nl']), fn () => true);
             }
@@ -725,7 +724,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_prepare_using_toarray()
+    public function test_can_prepare_using_toarray(): void
     {
         $import = new class implements ToArray, WithValidation
         {
@@ -777,7 +776,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_prepare_using_tocollection()
+    public function test_can_prepare_using_tocollection(): void
     {
         $import = new class implements ToCollection, WithValidation
         {
@@ -829,7 +828,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_prepare_using_tomodel()
+    public function test_can_prepare_using_tomodel(): void
     {
         $import = new class implements ToModel, WithValidation
         {
@@ -885,7 +884,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_prepare_using_oneachrow()
+    public function test_can_prepare_using_oneachrow(): void
     {
         $import = new class implements OnEachRow, WithValidation
         {
@@ -912,10 +911,7 @@ class WithValidationTest extends TestCase
                 return $row;
             }
 
-            /**
-             * @return void
-             */
-            public function onRow(Row $row)
+            public function onRow(Row $row): void
             {
                 User::query()->create([
                     'name'     => $row[0],
@@ -941,7 +937,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    public function test_can_prepare_using_skipsemptyrows()
+    public function test_can_prepare_using_skipsemptyrows(): void
     {
         $import = new class implements OnEachRow, SkipsEmptyRows, WithValidation
         {
@@ -968,10 +964,7 @@ class WithValidationTest extends TestCase
                 return $row;
             }
 
-            /**
-             * @return void
-             */
-            public function onRow(Row $row)
+            public function onRow(Row $row): void
             {
                 User::query()->create([
                     'name'     => $row[0],
@@ -997,7 +990,7 @@ class WithValidationTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
-    private function validateFailure(ValidationException $e, int $row, string $attribute, array $messages)
+    private function validateFailure(ValidationException $e, int $row, string $attribute, array $messages): void
     {
         $failures = $e->failures();
         $failure  = head($failures);

--- a/tests/Data/Stubs/AfterQueueExportJob.php
+++ b/tests/Data/Stubs/AfterQueueExportJob.php
@@ -14,7 +14,7 @@ class AfterQueueExportJob implements ShouldQueue
     {
     }
 
-    public function handle()
+    public function handle(): void
     {
         TestCase::assertFileExists($this->filePath);
     }

--- a/tests/Data/Stubs/AfterQueueImportJob.php
+++ b/tests/Data/Stubs/AfterQueueImportJob.php
@@ -15,7 +15,7 @@ class AfterQueueImportJob implements ShouldQueue
     {
     }
 
-    public function handle()
+    public function handle(): void
     {
         Assert::assertEquals($this->totalRows, DB::table('groups')->count('id'));
     }

--- a/tests/Data/Stubs/BeforeExportListener.php
+++ b/tests/Data/Stubs/BeforeExportListener.php
@@ -14,7 +14,7 @@ class BeforeExportListener
         $this->assertions = $assertions;
     }
 
-    public function __invoke()
+    public function __invoke(): void
     {
         ($this->assertions)(...func_get_args());
     }

--- a/tests/Data/Stubs/Database/Migrations/0000_00_00_000000_create_groups_table.php
+++ b/tests/Data/Stubs/Database/Migrations/0000_00_00_000000_create_groups_table.php
@@ -9,9 +9,9 @@ class CreateGroupsTable extends Migration
     /**
      * Run the migrations.
      */
-    public function up()
+    public function up(): void
     {
-        Schema::create('groups', function (Blueprint $table) {
+        Schema::create('groups', function (Blueprint $table): void {
             $table->increments('id');
             $table->string('name');
             $table->timestamps();
@@ -21,7 +21,7 @@ class CreateGroupsTable extends Migration
     /**
      * Reverse the migrations.
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('groups');
     }

--- a/tests/Data/Stubs/Database/Migrations/0000_00_00_000001_create_group_user_table.php
+++ b/tests/Data/Stubs/Database/Migrations/0000_00_00_000001_create_group_user_table.php
@@ -9,9 +9,9 @@ class CreateGroupUserTable extends Migration
     /**
      * Run the migrations.
      */
-    public function up()
+    public function up(): void
     {
-        Schema::create('group_user', function (Blueprint $table) {
+        Schema::create('group_user', function (Blueprint $table): void {
             $table->increments('id');
             $table->unsignedInteger('group_id')->index();
             $table->unsignedInteger('user_id')->index();
@@ -21,7 +21,7 @@ class CreateGroupUserTable extends Migration
     /**
      * Reverse the migrations.
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('group_user');
     }

--- a/tests/Data/Stubs/Database/Migrations/0000_00_00_000002_add_group_id_to_users_table.php
+++ b/tests/Data/Stubs/Database/Migrations/0000_00_00_000002_add_group_id_to_users_table.php
@@ -9,9 +9,9 @@ class AddGroupIdToUsersTable extends Migration
     /**
      * Run the migrations.
      */
-    public function up()
+    public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             $table->unsignedInteger('group_id')->index()->nullable();
         });
     }
@@ -19,9 +19,9 @@ class AddGroupIdToUsersTable extends Migration
     /**
      * Reverse the migrations.
      */
-    public function down()
+    public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             $table->dropColumn('group_id');
         });
     }

--- a/tests/Data/Stubs/Database/Migrations/0000_00_00_000002_add_options_to_users.php
+++ b/tests/Data/Stubs/Database/Migrations/0000_00_00_000002_add_options_to_users.php
@@ -9,9 +9,9 @@ class AddOptionsToUsers extends Migration
     /**
      * Run the migrations.
      */
-    public function up()
+    public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             $table->text('options')->nullable();
         });
     }
@@ -19,9 +19,9 @@ class AddOptionsToUsers extends Migration
     /**
      * Reverse the migrations.
      */
-    public function down()
+    public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             $table->dropColumn('options');
         });
     }

--- a/tests/Data/Stubs/ExportWithEvents.php
+++ b/tests/Data/Stubs/ExportWithEvents.php
@@ -36,13 +36,13 @@ class ExportWithEvents implements WithEvents
     public function registerEvents(): array
     {
         return [
-            BeforeExport::class => $this->beforeExport ?? function () {
+            BeforeExport::class => $this->beforeExport ?? function (): void {
             },
-            BeforeWriting::class => $this->beforeWriting ?? function () {
+            BeforeWriting::class => $this->beforeWriting ?? function (): void {
             },
-            BeforeSheet::class => $this->beforeSheet ?? function () {
+            BeforeSheet::class => $this->beforeSheet ?? function (): void {
             },
-            AfterSheet::class => $this->afterSheet ?? function () {
+            AfterSheet::class => $this->afterSheet ?? function (): void {
             },
         ];
     }

--- a/tests/Data/Stubs/ExportWithEventsChunks.php
+++ b/tests/Data/Stubs/ExportWithEventsChunks.php
@@ -21,7 +21,7 @@ class ExportWithEventsChunks implements FromQuery, ShouldQueue, WithCustomChunkS
     public function registerEvents(): array
     {
         return [
-            AfterChunk::class => function (AfterChunk $event) {
+            AfterChunk::class => function (AfterChunk $event): void {
                 ExportWithEventsChunks::$calledEvent++;
                 Assert::assertInstanceOf(ExportWithEventsChunks::class, $event->getConcernable());
             },

--- a/tests/Data/Stubs/ExportWithRegistersEventListeners.php
+++ b/tests/Data/Stubs/ExportWithRegistersEventListeners.php
@@ -30,22 +30,22 @@ class ExportWithRegistersEventListeners implements WithEvents
      */
     public static $afterSheet;
 
-    public static function beforeExport()
+    public static function beforeExport(): void
     {
         (static::$beforeExport)(...func_get_args());
     }
 
-    public static function beforeWriting()
+    public static function beforeWriting(): void
     {
         (static::$beforeWriting)(...func_get_args());
     }
 
-    public static function beforeSheet()
+    public static function beforeSheet(): void
     {
         (static::$beforeSheet)(...func_get_args());
     }
 
-    public static function afterSheet()
+    public static function afterSheet(): void
     {
         (static::$afterSheet)(...func_get_args());
     }

--- a/tests/Data/Stubs/FromUsersQueryExportWithEagerLoad.php
+++ b/tests/Data/Stubs/FromUsersQueryExportWithEagerLoad.php
@@ -20,7 +20,7 @@ class FromUsersQueryExportWithEagerLoad implements FromQuery, WithMapping
     public function query()
     {
         return User::query()->with([
-            'groups' => function ($query) {
+            'groups' => function ($query): void {
                 $query->where('name', 'Group 1');
             },
         ])->withCount('groups');

--- a/tests/Data/Stubs/FromUsersQueryExportWithMapping.php
+++ b/tests/Data/Stubs/FromUsersQueryExportWithMapping.php
@@ -27,7 +27,7 @@ class FromUsersQueryExportWithMapping implements FromQuery, WithEvents, WithMapp
     public function registerEvents(): array
     {
         return [
-            BeforeSheet::class => function (BeforeSheet $event) {
+            BeforeSheet::class => function (BeforeSheet $event): void {
                 $event->sheet->chunkSize(10);
             },
         ];

--- a/tests/Data/Stubs/ImportWithEvents.php
+++ b/tests/Data/Stubs/ImportWithEvents.php
@@ -36,13 +36,13 @@ class ImportWithEvents implements WithEvents
     public function registerEvents(): array
     {
         return [
-            BeforeImport::class => $this->beforeImport ?? function () {
+            BeforeImport::class => $this->beforeImport ?? function (): void {
             },
-            AfterImport::class => $this->afterImport ?? function () {
+            AfterImport::class => $this->afterImport ?? function (): void {
             },
-            BeforeSheet::class => $this->beforeSheet ?? function () {
+            BeforeSheet::class => $this->beforeSheet ?? function (): void {
             },
-            AfterSheet::class => $this->afterSheet ?? function () {
+            AfterSheet::class => $this->afterSheet ?? function (): void {
             },
         ];
     }

--- a/tests/Data/Stubs/ImportWithEventsChunksAndBatches.php
+++ b/tests/Data/Stubs/ImportWithEventsChunksAndBatches.php
@@ -24,14 +24,14 @@ class ImportWithEventsChunksAndBatches extends ImportWithEvents implements ToMod
     public function registerEvents(): array
     {
         return parent::registerEvents() + [
-            AfterBatch::class => $this->afterBatch ?? function () {
+            AfterBatch::class => $this->afterBatch ?? function (): void {
             },
-            AfterChunk::class => $this->afterChunk ?? function () {
+            AfterChunk::class => $this->afterChunk ?? function (): void {
             },
         ];
     }
 
-    public function model(array $row)
+    public function model(array $row): void
     {
     }
 

--- a/tests/Data/Stubs/ImportWithRegistersEventListeners.php
+++ b/tests/Data/Stubs/ImportWithRegistersEventListeners.php
@@ -25,17 +25,17 @@ class ImportWithRegistersEventListeners implements WithEvents
      */
     public static $afterSheet;
 
-    public static function beforeImport()
+    public static function beforeImport(): void
     {
         (static::$beforeImport)(...func_get_args());
     }
 
-    public static function beforeSheet()
+    public static function beforeSheet(): void
     {
         (static::$beforeSheet)(...func_get_args());
     }
 
-    public static function afterSheet()
+    public static function afterSheet(): void
     {
         (static::$afterSheet)(...func_get_args());
     }

--- a/tests/Data/Stubs/QueueImportWithoutJobChaining.php
+++ b/tests/Data/Stubs/QueueImportWithoutJobChaining.php
@@ -43,11 +43,11 @@ class QueueImportWithoutJobChaining implements ShouldQueueWithoutChain, ToModel,
     public function registerEvents(): array
     {
         return [
-            BeforeImport::class => function (BeforeImport $event) {
+            BeforeImport::class => function (BeforeImport $event): void {
                 Assert::assertInstanceOf(Reader::class, $event->reader);
                 $this->before = true;
             },
-            AfterImport::class => function (AfterImport $event) {
+            AfterImport::class => function (AfterImport $event): void {
                 Assert::assertInstanceOf(Reader::class, $event->reader);
                 $this->after = true;
             },

--- a/tests/Data/Stubs/QueuedExportWithFailedEvents.php
+++ b/tests/Data/Stubs/QueuedExportWithFailedEvents.php
@@ -26,7 +26,7 @@ class QueuedExportWithFailedEvents implements WithEvents, WithMultipleSheets
         ];
     }
 
-    public function failed(Throwable $exception)
+    public function failed(Throwable $exception): void
     {
         Assert::assertEquals('catch exception from QueueExport job', $exception->getMessage());
 
@@ -36,7 +36,7 @@ class QueuedExportWithFailedEvents implements WithEvents, WithMultipleSheets
     public function registerEvents(): array
     {
         return [
-            BeforeExport::class => function () {
+            BeforeExport::class => function (): void {
                 throw new Exception('catch exception from QueueExport job');
             },
         ];

--- a/tests/Data/Stubs/QueuedExportWithFailedHook.php
+++ b/tests/Data/Stubs/QueuedExportWithFailedHook.php
@@ -40,7 +40,7 @@ class QueuedExportWithFailedHook implements FromCollection, WithMapping
         throw new Exception('we expect this');
     }
 
-    public function failed(Exception $exception)
+    public function failed(Exception $exception): void
     {
         Assert::assertEquals('we expect this', $exception->getMessage());
 

--- a/tests/Data/Stubs/QueuedImportWithMiddleware.php
+++ b/tests/Data/Stubs/QueuedImportWithMiddleware.php
@@ -25,7 +25,7 @@ class QueuedImportWithMiddleware implements ShouldQueue, ToModel, WithChunkReadi
 
     public function middleware()
     {
-        return [function () {
+        return [function (): void {
             throw new \Exception('Job reached middleware method');
         }];
     }

--- a/tests/Data/Stubs/SheetWith100Rows.php
+++ b/tests/Data/Stubs/SheetWith100Rows.php
@@ -44,7 +44,7 @@ class SheetWith100Rows implements FromCollection, ShouldAutoSize, WithEvents, Wi
         return $this->title;
     }
 
-    public static function beforeWriting(BeforeWriting $event)
+    public static function beforeWriting(BeforeWriting $event): void
     {
         TestCase::assertInstanceOf(Writer::class, $event->writer);
     }

--- a/tests/DelegatedMacroableTest.php
+++ b/tests/DelegatedMacroableTest.php
@@ -13,13 +13,13 @@ use PhpOffice\PhpSpreadsheet\Document\Properties;
 
 class DelegatedMacroableTest extends TestCase
 {
-    public function test_can_call_methods_from_delegate()
+    public function test_can_call_methods_from_delegate(): void
     {
         $export = new class implements WithEvents
         {
             use Exportable, RegistersEventListeners;
 
-            public static function beforeExport(BeforeExport $event)
+            public static function beforeExport(BeforeExport $event): void
             {
                 // ->getProperties() will be called via __call on the ->getDelegate()
                 TestCase::assertInstanceOf(Properties::class, $event->writer->getProperties());
@@ -29,10 +29,10 @@ class DelegatedMacroableTest extends TestCase
         $export->download('some-file.xlsx');
     }
 
-    public function test_can_use_writer_macros()
+    public function test_can_use_writer_macros(): void
     {
         $called = false;
-        Writer::macro('test', function () use (&$called) {
+        Writer::macro('test', function () use (&$called): void {
             $called = true;
         });
 
@@ -40,7 +40,7 @@ class DelegatedMacroableTest extends TestCase
         {
             use Exportable, RegistersEventListeners;
 
-            public static function beforeExport(BeforeExport $event)
+            public static function beforeExport(BeforeExport $event): void
             {
                 // call macro method
                 $event->writer->test();
@@ -52,10 +52,10 @@ class DelegatedMacroableTest extends TestCase
         $this->assertTrue($called);
     }
 
-    public function test_can_use_sheet_macros()
+    public function test_can_use_sheet_macros(): void
     {
         $called = false;
-        Sheet::macro('test', function () use (&$called) {
+        Sheet::macro('test', function () use (&$called): void {
             $called = true;
         });
 
@@ -63,7 +63,7 @@ class DelegatedMacroableTest extends TestCase
         {
             use Exportable, RegistersEventListeners;
 
-            public static function beforeSheet(BeforeSheet $event)
+            public static function beforeSheet(BeforeSheet $event): void
             {
                 // call macro method
                 $event->sheet->test();

--- a/tests/ExcelFakeTest.php
+++ b/tests/ExcelFakeTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class ExcelFakeTest extends TestCase
 {
-    public function test_can_fake_an_export()
+    public function test_can_fake_an_export(): void
     {
         ExcelFacade::fake();
 
@@ -25,7 +25,7 @@ class ExcelFakeTest extends TestCase
         $this->assertInstanceOf(ExcelFake::class, $this->app->make('excel'));
     }
 
-    public function test_can_assert_against_a_fake_downloaded_export()
+    public function test_can_assert_against_a_fake_downloaded_export(): void
     {
         ExcelFacade::fake();
 
@@ -39,7 +39,7 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertDownloaded('/\w{10}-\w{8}\.csv/');
     }
 
-    public function test_can_assert_against_a_fake_stored_export()
+    public function test_can_assert_against_a_fake_stored_export(): void
     {
         ExcelFacade::fake();
 
@@ -53,7 +53,7 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertStored('/\w{6}-\w{8}\.csv/', 's3');
     }
 
-    public function test_can_assert_regex_against_a_fake_stored_export_with_multiple_files()
+    public function test_can_assert_regex_against_a_fake_stored_export_with_multiple_files(): void
     {
         ExcelFacade::fake();
 
@@ -70,7 +70,7 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertStored('/\w{6}-\w{8}-two\.csv/', 's3');
     }
 
-    public function test_a_callback_can_be_passed_as_the_second_argument_when_asserting_against_a_faked_stored_export()
+    public function test_a_callback_can_be_passed_as_the_second_argument_when_asserting_against_a_faked_stored_export(): void
     {
         ExcelFacade::fake();
 
@@ -84,7 +84,7 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertStored('/\w{6}-\w{8}\.csv/');
     }
 
-    public function test_can_assert_against_a_fake_queued_export()
+    public function test_can_assert_against_a_fake_queued_export(): void
     {
         ExcelFacade::fake();
 
@@ -98,7 +98,7 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/', 's3');
     }
 
-    public function test_can_assert_against_a_fake_implicitly_queued_export()
+    public function test_can_assert_against_a_fake_implicitly_queued_export(): void
     {
         ExcelFacade::fake();
 
@@ -113,12 +113,14 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/', 's3');
     }
 
-    public function test_can_assert_against_a_fake_queued_export_with_chain()
+    public function test_can_assert_against_a_fake_queued_export_with_chain(): void
     {
         ExcelFacade::fake();
 
         ExcelFacade::queue(
-            $this->givenQueuedExport(), 'queued-filename.csv', 's3'
+            $this->givenQueuedExport(),
+            'queued-filename.csv',
+            's3'
         )->chain([
             new ChainedJobStub,
         ]);
@@ -128,7 +130,7 @@ class ExcelFakeTest extends TestCase
         ]);
     }
 
-    public function test_can_assert_against_a_fake_raw_export()
+    public function test_can_assert_against_a_fake_raw_export(): void
     {
         ExcelFacade::fake();
 
@@ -140,7 +142,7 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertExportedInRaw($this->givenExport()::class, fn (FromCollection $export) => $export->collection()->contains('foo'));
     }
 
-    public function test_can_assert_against_a_fake_import()
+    public function test_can_assert_against_a_fake_import(): void
     {
         ExcelFacade::fake();
 
@@ -152,7 +154,7 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertImported('/\w{6}-\w{8}\.csv/', 's3');
     }
 
-    public function test_can_assert_against_a_fake_import_with_uploaded_file()
+    public function test_can_assert_against_a_fake_import_with_uploaded_file(): void
     {
         ExcelFacade::fake();
 
@@ -164,7 +166,7 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertImported('/\w{6}\.xlsx/');
     }
 
-    public function test_can_assert_against_a_fake_queued_import()
+    public function test_can_assert_against_a_fake_queued_import(): void
     {
         ExcelFacade::fake();
 
@@ -179,7 +181,7 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/', 's3');
     }
 
-    public function test_can_assert_against_a_fake_implicitly_queued_import()
+    public function test_can_assert_against_a_fake_implicitly_queued_import(): void
     {
         ExcelFacade::fake();
 
@@ -194,12 +196,14 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/', 's3');
     }
 
-    public function test_can_assert_against_a_fake_queued_import_with_chain()
+    public function test_can_assert_against_a_fake_queued_import_with_chain(): void
     {
         ExcelFacade::fake();
 
         ExcelFacade::queueImport(
-            $this->givenQueuedImport(), 'queued-filename.csv', 's3'
+            $this->givenQueuedImport(),
+            'queued-filename.csv',
+            's3'
         )->chain([
             new ChainedJobStub,
         ]);
@@ -209,7 +213,7 @@ class ExcelFakeTest extends TestCase
         ]);
     }
 
-    public function test_a_callback_can_be_passed_as_the_second_argument_when_asserting_against_a_faked_queued_export()
+    public function test_a_callback_can_be_passed_as_the_second_argument_when_asserting_against_a_faked_queued_export(): void
     {
         ExcelFacade::fake();
 

--- a/tests/ExcelServiceProviderTest.php
+++ b/tests/ExcelServiceProviderTest.php
@@ -14,25 +14,25 @@ use PhpOffice\PhpSpreadsheet\Settings;
 
 class ExcelServiceProviderTest extends TestCase
 {
-    public function test_custom_transaction_handler_is_bound()
+    public function test_custom_transaction_handler_is_bound(): void
     {
         $this->app->make(TransactionManager::class)->extend('handler', fn () => new CustomTransactionHandler);
 
         $this->assertInstanceOf(CustomTransactionHandler::class, $this->app->make(TransactionManager::class)->driver('handler'));
     }
 
-    public function test_is_bound()
+    public function test_is_bound(): void
     {
         $this->assertTrue($this->app->bound('excel'));
     }
 
-    public function test_has_aliased()
+    public function test_has_aliased(): void
     {
         $this->assertTrue($this->app->isAlias(Excel::class));
         $this->assertEquals('excel', $this->app->getAlias(Excel::class));
     }
 
-    public function test_registers_console_commands()
+    public function test_registers_console_commands(): void
     {
         /** @var Kernel $kernel */
         $kernel   = $this->app->make(Kernel::class);
@@ -42,7 +42,7 @@ class ExcelServiceProviderTest extends TestCase
         $this->assertArrayHasKey('make:import', $commands);
     }
 
-    public function test_sets_php_spreadsheet_settings()
+    public function test_sets_php_spreadsheet_settings(): void
     {
         $driver = config('excel.cache.driver');
 

--- a/tests/ExcelTest.php
+++ b/tests/ExcelTest.php
@@ -37,7 +37,7 @@ class ExcelTest extends TestCase
         $this->SUT = $this->app->make(Excel::class);
     }
 
-    public function test_can_download_an_export_object_with_facade()
+    public function test_can_download_an_export_object_with_facade(): void
     {
         $export = new EmptyExport;
 
@@ -47,7 +47,7 @@ class ExcelTest extends TestCase
         $this->assertEquals('attachment; filename=filename.xlsx', str_replace('"', '', $response->headers->get('Content-Disposition')));
     }
 
-    public function test_can_download_an_export_object()
+    public function test_can_download_an_export_object(): void
     {
         $export = new EmptyExport;
 
@@ -57,7 +57,7 @@ class ExcelTest extends TestCase
         $this->assertEquals('attachment; filename=filename.xlsx', str_replace('"', '', $response->headers->get('Content-Disposition')));
     }
 
-    public function test_can_store_an_export_object_on_default_disk()
+    public function test_can_store_an_export_object_on_default_disk(): void
     {
         $export = new EmptyExport;
         $name   = 'filename.xlsx';
@@ -73,7 +73,7 @@ class ExcelTest extends TestCase
         $this->assertFileExists($path);
     }
 
-    public function test_can_store_an_export_object_on_another_disk()
+    public function test_can_store_an_export_object_on_another_disk(): void
     {
         $export = new EmptyExport;
         $name   = 'filename.xlsx';
@@ -89,7 +89,7 @@ class ExcelTest extends TestCase
         $this->assertFileExists($path);
     }
 
-    public function test_can_store_csv_export_with_default_settings()
+    public function test_can_store_csv_export_with_default_settings(): void
     {
         $export = new EmptyExport;
         $name   = 'filename.csv';
@@ -105,7 +105,7 @@ class ExcelTest extends TestCase
         $this->assertFileExists($path);
     }
 
-    public function test_can_get_raw_export_contents()
+    public function test_can_get_raw_export_contents(): void
     {
         $export = new EmptyExport;
 
@@ -114,7 +114,7 @@ class ExcelTest extends TestCase
         $this->assertNotEmpty($response);
     }
 
-    public function test_can_store_tsv_export_with_default_settings()
+    public function test_can_store_tsv_export_with_default_settings(): void
     {
         $export = new EmptyExport;
         $name   = 'filename.tsv';
@@ -130,7 +130,7 @@ class ExcelTest extends TestCase
         $this->assertFileExists($path);
     }
 
-    public function test_can_store_csv_export_with_custom_settings()
+    public function test_can_store_csv_export_with_custom_settings(): void
     {
         $export = new class implements FromCollection, WithCustomCsvSettings, WithEvents
         {
@@ -168,7 +168,7 @@ class ExcelTest extends TestCase
         $this->assertStringContains('"A2";"B2"', $contents);
     }
 
-    public function test_cannot_use_from_collection_and_from_view_on_same_export()
+    public function test_cannot_use_from_collection_and_from_view_on_same_export(): void
     {
         $this->expectException(ConcernConflictException::class);
         $this->expectExceptionMessage('Cannot use FromQuery, FromArray or FromCollection and FromView on the same sheet');
@@ -194,7 +194,7 @@ class ExcelTest extends TestCase
         $export->download('filename.csv');
     }
 
-    public function test_can_import_a_simple_xlsx_file_to_array()
+    public function test_can_import_a_simple_xlsx_file_to_array(): void
     {
         $import = new class
         {
@@ -209,7 +209,7 @@ class ExcelTest extends TestCase
         ], $import->toArray('import.xlsx'));
     }
 
-    public function test_can_import_a_simple_xlsx_file_to_collection()
+    public function test_can_import_a_simple_xlsx_file_to_collection(): void
     {
         $import = new class
         {
@@ -224,7 +224,7 @@ class ExcelTest extends TestCase
         ]), $import->toCollection('import.xlsx'));
     }
 
-    public function test_can_import_a_simple_xlsx_file_to_collection_without_import_object()
+    public function test_can_import_a_simple_xlsx_file_to_collection_without_import_object(): void
     {
         $this->assertEquals(new Collection([
             new Collection([
@@ -234,11 +234,11 @@ class ExcelTest extends TestCase
         ]), ExcelFacade::toCollection(null, 'import.xlsx'));
     }
 
-    public function test_can_import_a_simple_xlsx_file()
+    public function test_can_import_a_simple_xlsx_file(): void
     {
         $import = new class implements ToArray
         {
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     ['test', 'test'],
@@ -252,11 +252,11 @@ class ExcelTest extends TestCase
         $this->assertInstanceOf(Importer::class, $imported);
     }
 
-    public function test_can_import_a_tsv_file()
+    public function test_can_import_a_tsv_file(): void
     {
         $import = new class implements ToArray, WithCustomCsvSettings
         {
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     'tconst',
@@ -284,11 +284,11 @@ class ExcelTest extends TestCase
         $this->assertInstanceOf(Importer::class, $imported);
     }
 
-    public function test_can_chain_imports()
+    public function test_can_chain_imports(): void
     {
         $import1 = new class implements ToArray
         {
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     ['test', 'test'],
@@ -299,7 +299,7 @@ class ExcelTest extends TestCase
 
         $import2 = new class implements ToArray
         {
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     ['test', 'test'],
@@ -315,11 +315,11 @@ class ExcelTest extends TestCase
         $this->assertInstanceOf(Importer::class, $imported);
     }
 
-    public function test_can_import_a_simple_xlsx_file_from_uploaded_file()
+    public function test_can_import_a_simple_xlsx_file_from_uploaded_file(): void
     {
         $import = new class implements ToArray
         {
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     ['test', 'test'],
@@ -331,11 +331,11 @@ class ExcelTest extends TestCase
         $this->SUT->import($import, $this->givenUploadedFile(__DIR__ . '/Data/Disks/Local/import.xlsx'));
     }
 
-    public function test_can_import_a_simple_xlsx_file_from_real_path()
+    public function test_can_import_a_simple_xlsx_file_from_real_path(): void
     {
         $import = new class implements ToArray
         {
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     ['test', 'test'],
@@ -347,13 +347,13 @@ class ExcelTest extends TestCase
         $this->SUT->import($import, __DIR__ . '/Data/Disks/Local/import.xlsx');
     }
 
-    public function test_import_will_throw_error_when_no_reader_type_could_be_detected_when_no_extension()
+    public function test_import_will_throw_error_when_no_reader_type_could_be_detected_when_no_extension(): void
     {
         $this->expectException(NoTypeDetectedException::class);
 
         $import = new class implements ToArray
         {
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     ['test', 'test'],
@@ -365,13 +365,13 @@ class ExcelTest extends TestCase
         $this->SUT->import($import, UploadedFile::fake()->create('import'));
     }
 
-    public function test_import_will_throw_error_when_no_reader_type_could_be_detected_with_unknown_extension()
+    public function test_import_will_throw_error_when_no_reader_type_could_be_detected_with_unknown_extension(): void
     {
         $this->expectException(NoTypeDetectedException::class);
 
         $import = new class implements ToArray
         {
-            public function array(array $array)
+            public function array(array $array): void
             {
                 //
             }
@@ -380,11 +380,11 @@ class ExcelTest extends TestCase
         $this->SUT->import($import, 'unknown-reader-type.zip');
     }
 
-    public function test_can_import_without_extension_with_explicit_reader_type()
+    public function test_can_import_without_extension_with_explicit_reader_type(): void
     {
         $import = new class implements ToArray
         {
-            public function array(array $array)
+            public function array(array $array): void
             {
                 Assert::assertEquals([
                     ['test', 'test'],

--- a/tests/HeadingRowImportTest.php
+++ b/tests/HeadingRowImportTest.php
@@ -13,7 +13,7 @@ class HeadingRowImportTest extends TestCase
         parent::tearDown();
     }
 
-    public function test_can_import_only_heading_row()
+    public function test_can_import_only_heading_row(): void
     {
         $import = new HeadingRowImport;
 
@@ -26,7 +26,7 @@ class HeadingRowImportTest extends TestCase
         ], $headings);
     }
 
-    public function test_can_import_only_heading_row_with_custom_heading_row_formatter()
+    public function test_can_import_only_heading_row_with_custom_heading_row_formatter(): void
     {
         HeadingRowFormatter::extend('custom', fn ($value) => 'custom-' . $value);
 
@@ -43,7 +43,7 @@ class HeadingRowImportTest extends TestCase
         ], $headings);
     }
 
-    public function test_can_import_only_heading_row_with_custom_heading_row_formatter_with_key()
+    public function test_can_import_only_heading_row_with_custom_heading_row_formatter_with_key(): void
     {
         HeadingRowFormatter::extend('custom', fn ($value, $key) => $key);
 
@@ -60,7 +60,7 @@ class HeadingRowImportTest extends TestCase
         ], $headings);
     }
 
-    public function test_can_import_only_heading_row_with_custom_row_number()
+    public function test_can_import_only_heading_row_with_custom_row_number(): void
     {
         $import = new HeadingRowImport(2);
 
@@ -73,7 +73,7 @@ class HeadingRowImportTest extends TestCase
         ], $headings);
     }
 
-    public function test_can_import_only_heading_row_for_multiple_sheets()
+    public function test_can_import_only_heading_row_for_multiple_sheets(): void
     {
         $import = new HeadingRowImport;
 
@@ -89,7 +89,7 @@ class HeadingRowImportTest extends TestCase
         ], $headings);
     }
 
-    public function test_can_import_only_heading_row_for_multiple_sheets_with_key()
+    public function test_can_import_only_heading_row_for_multiple_sheets_with_key(): void
     {
         HeadingRowFormatter::extend('custom', fn ($value, $key) => $key);
 
@@ -108,7 +108,7 @@ class HeadingRowImportTest extends TestCase
         ], $headings);
     }
 
-    public function test_can_import_only_heading_row_for_multiple_sheets_with_custom_row_number()
+    public function test_can_import_only_heading_row_for_multiple_sheets_with_custom_row_number(): void
     {
         $import = new HeadingRowImport(2);
 
@@ -124,7 +124,7 @@ class HeadingRowImportTest extends TestCase
         ], $headings);
     }
 
-    public function test_can_import_heading_row_with_custom_formatter_defined_in_config()
+    public function test_can_import_heading_row_with_custom_formatter_defined_in_config(): void
     {
         HeadingRowFormatter::extend('custom2', fn ($value) => 'custom2-' . $value);
 

--- a/tests/InteractsWithQueueTest.php
+++ b/tests/InteractsWithQueueTest.php
@@ -19,27 +19,27 @@ class InteractsWithQueueTest extends TestCase
         parent::setUp();
     }
 
-    public function test_read_chunk_job_can_interact_with_queue()
+    public function test_read_chunk_job_can_interact_with_queue(): void
     {
         $this->assertContains(InteractsWithQueue::class, class_uses(ReadChunk::class));
     }
 
-    public function test_append_data_to_sheet_job_can_interact_with_queue()
+    public function test_append_data_to_sheet_job_can_interact_with_queue(): void
     {
         $this->assertContains(InteractsWithQueue::class, class_uses(AppendDataToSheet::class));
     }
 
-    public function test_append_query_to_sheet_job_can_interact_with_queue()
+    public function test_append_query_to_sheet_job_can_interact_with_queue(): void
     {
         $this->assertContains(InteractsWithQueue::class, class_uses(AppendQueryToSheet::class));
     }
 
-    public function test_append_view_to_sheet_job_can_interact_with_queue()
+    public function test_append_view_to_sheet_job_can_interact_with_queue(): void
     {
         $this->assertContains(InteractsWithQueue::class, class_uses(AppendViewToSheet::class));
     }
 
-    public function test_queue_export_job_can_interact_with_queue()
+    public function test_queue_export_job_can_interact_with_queue(): void
     {
         $this->assertContains(InteractsWithQueue::class, class_uses(QueueExport::class));
     }

--- a/tests/Mixins/DownloadCollectionTest.php
+++ b/tests/Mixins/DownloadCollectionTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class DownloadCollectionTest extends TestCase
 {
-    public function test_can_download_a_collection_as_excel()
+    public function test_can_download_a_collection_as_excel(): void
     {
         $collection = new Collection([
             ['column_1' => 'test', 'column_2' => 'test'],
@@ -32,7 +32,7 @@ class DownloadCollectionTest extends TestCase
         );
     }
 
-    public function test_can_download_a_collection_with_headers_as_excel()
+    public function test_can_download_a_collection_with_headers_as_excel(): void
     {
         $collection = new Collection([
             ['column_1' => 'test', 'column_2' => 'test'],
@@ -46,7 +46,7 @@ class DownloadCollectionTest extends TestCase
         $this->assertEquals(['column_1', 'column_2'], collect($array)->first());
     }
 
-    public function test_can_download_collection_with_headers_with_hidden_eloquent_attributes()
+    public function test_can_download_collection_with_headers_with_hidden_eloquent_attributes(): void
     {
         $collection = new Collection([
             new User(['name' => 'Patrick', 'password' => 'my_password']),
@@ -59,7 +59,7 @@ class DownloadCollectionTest extends TestCase
         $this->assertEquals(['name'], collect($array)->first());
     }
 
-    public function test_can_download_collection_with_headers_when_making_attributes_visible()
+    public function test_can_download_collection_with_headers_when_making_attributes_visible(): void
     {
         $user = new User(['name' => 'Patrick', 'password' => 'my_password']);
         $user->makeVisible(['password']);
@@ -75,7 +75,7 @@ class DownloadCollectionTest extends TestCase
         $this->assertEquals(['name', 'password'], collect($array)->first());
     }
 
-    public function test_can_set_custom_response_headers()
+    public function test_can_set_custom_response_headers(): void
     {
         $collection = new Collection([
             ['column_1' => 'test', 'column_2' => 'test'],

--- a/tests/Mixins/DownloadQueryMacroTest.php
+++ b/tests/Mixins/DownloadQueryMacroTest.php
@@ -21,7 +21,7 @@ class DownloadQueryMacroTest extends TestCase
         User::factory()->count(100)->create();
     }
 
-    public function test_can_download_a_query_as_excel()
+    public function test_can_download_a_query_as_excel(): void
     {
         $response = User::downloadExcel('query-download.xlsx', Excel::XLSX);
 
@@ -35,7 +35,7 @@ class DownloadQueryMacroTest extends TestCase
         );
     }
 
-    public function test_can_download_a_collection_with_headers_as_excel()
+    public function test_can_download_a_collection_with_headers_as_excel(): void
     {
         $response = User::downloadExcel('collection-headers-download.xlsx', Excel::XLSX, true);
 

--- a/tests/Mixins/ImportAsMacroTest.php
+++ b/tests/Mixins/ImportAsMacroTest.php
@@ -17,7 +17,7 @@ class ImportAsMacroTest extends TestCase
         $this->loadLaravelMigrations(['--database' => 'testing']);
     }
 
-    public function test_can_import_directly_into_a_model_with_mapping()
+    public function test_can_import_directly_into_a_model_with_mapping(): void
     {
         User::query()->truncate();
 

--- a/tests/Mixins/ImportMacroTest.php
+++ b/tests/Mixins/ImportMacroTest.php
@@ -17,10 +17,10 @@ class ImportMacroTest extends TestCase
         $this->loadLaravelMigrations(['--database' => 'testing']);
     }
 
-    public function test_can_import_directly_into_a_model()
+    public function test_can_import_directly_into_a_model(): void
     {
         User::query()->truncate();
-        User::creating(function ($user) {
+        User::creating(function ($user): void {
             $user->password = 'secret';
         });
 

--- a/tests/Mixins/StoreCollectionTest.php
+++ b/tests/Mixins/StoreCollectionTest.php
@@ -9,7 +9,7 @@ use Maatwebsite\Excel\Tests\TestCase;
 
 class StoreCollectionTest extends TestCase
 {
-    public function test_can_store_a_collection_as_excel()
+    public function test_can_store_a_collection_as_excel(): void
     {
         $collection = new Collection([
             ['test', 'test'],
@@ -22,7 +22,7 @@ class StoreCollectionTest extends TestCase
         $this->assertFileExists(__DIR__ . '/../Data/Disks/Local/collection-store.xlsx');
     }
 
-    public function test_can_store_a_collection_as_excel_on_non_default_disk()
+    public function test_can_store_a_collection_as_excel_on_non_default_disk(): void
     {
         $collection = new Collection([
             ['column_1' => 'test', 'column_2' => 'test'],
@@ -48,7 +48,7 @@ class StoreCollectionTest extends TestCase
         ], collect($array)->values()->all());
     }
 
-    public function test_can_store_a_collection_with_headings_as_excel()
+    public function test_can_store_a_collection_with_headings_as_excel(): void
     {
         $collection = new Collection([
             ['column_1' => 'test', 'column_2' => 'test'],
@@ -71,7 +71,7 @@ class StoreCollectionTest extends TestCase
         ], collect($array)->except(0)->values()->all());
     }
 
-    public function test_can_store_a_model_collection_with_headings_as_excel()
+    public function test_can_store_a_model_collection_with_headings_as_excel(): void
     {
         $collection = User::factory()->count(2)->make();
 

--- a/tests/Mixins/StoreQueryMacroTest.php
+++ b/tests/Mixins/StoreQueryMacroTest.php
@@ -20,7 +20,7 @@ class StoreQueryMacroTest extends TestCase
         User::factory()->count(100)->create();
     }
 
-    public function test_can_download_a_query_as_excel()
+    public function test_can_download_a_query_as_excel(): void
     {
         $response = User::storeExcel('query-store.xlsx', null, Excel::XLSX);
 
@@ -31,7 +31,7 @@ class StoreQueryMacroTest extends TestCase
         $this->assertCount(100, $array);
     }
 
-    public function test_can_download_a_query_as_excel_on_different_disk()
+    public function test_can_download_a_query_as_excel_on_different_disk(): void
     {
         $response = User::storeExcel('query-store.xlsx', 'test', Excel::XLSX);
 
@@ -42,7 +42,7 @@ class StoreQueryMacroTest extends TestCase
         $this->assertCount(100, $array);
     }
 
-    public function test_can_store_a_query_with_headers_as_excel()
+    public function test_can_store_a_query_with_headers_as_excel(): void
     {
         $response = User::storeExcel('query-headers-store.xlsx', null, Excel::XLSX, true);
 

--- a/tests/PhpSpreadsheetV5CompatibilityTest.php
+++ b/tests/PhpSpreadsheetV5CompatibilityTest.php
@@ -21,7 +21,7 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
     // IReadFilter typed signature tests (v5 changed param types)
     // ---------------------------------------------------------------
 
-    public function test_read_filter_receives_typed_parameters()
+    public function test_read_filter_receives_typed_parameters(): void
     {
         $receivedTypes = [];
 
@@ -72,7 +72,7 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
         $this->assertSame('string', $receivedTypes['worksheetName']);
     }
 
-    public function test_read_filter_receives_correct_column_and_row_values()
+    public function test_read_filter_receives_correct_column_and_row_values(): void
     {
         $capturedCells = [];
 
@@ -119,7 +119,7 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
         $this->assertGreaterThanOrEqual(1, $firstCell['row']);
     }
 
-    public function test_read_filter_can_filter_specific_rows()
+    public function test_read_filter_can_filter_specific_rows(): void
     {
         $import = new class implements WithReadFilter
         {
@@ -143,7 +143,7 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
         $this->assertCount(1, $result[0]);
     }
 
-    public function test_read_filter_can_filter_specific_columns()
+    public function test_read_filter_can_filter_specific_columns(): void
     {
         $import = new class implements WithReadFilter
         {
@@ -173,7 +173,7 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
     // WithCustomValueBinder typed signature tests (v5 added types)
     // ---------------------------------------------------------------
 
-    public function test_custom_value_binder_is_not_applied_on_import()
+    public function test_custom_value_binder_is_not_applied_on_import(): void
     {
         // PHPSpreadsheet v5 does not invoke WithCustomValueBinder during reads.
         // This is a breaking change from v1 where value binders were called on import.
@@ -205,7 +205,7 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
         $this->assertNotEmpty($result[0], 'Data should still be imported without the value binder');
     }
 
-    public function test_import_returns_raw_values_without_value_binder_transformation()
+    public function test_import_returns_raw_values_without_value_binder_transformation(): void
     {
         // Since value binders are not called on import in v5,
         // numeric values like dates come through as raw Excel serial numbers.
@@ -226,7 +226,7 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
         }
     }
 
-    public function test_default_value_binder_encodes_arrays_with_typed_signature()
+    public function test_default_value_binder_encodes_arrays_with_typed_signature(): void
     {
         $export = new class implements FromCollection
         {
@@ -255,7 +255,7 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
     // setCreateBlankSheetIfNoneRead tests (v5 behavior change)
     // ---------------------------------------------------------------
 
-    public function test_unknown_sheet_name_is_skipped_with_skips_unknown_sheets()
+    public function test_unknown_sheet_name_is_skipped_with_skips_unknown_sheets(): void
     {
         $import = new class implements SkipsUnknownSheets, WithMultipleSheets
         {
@@ -270,7 +270,7 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
                     {
                         public $data = [];
 
-                        public function array(array $array)
+                        public function array(array $array): void
                         {
                             $this->data = $array;
                         }
@@ -279,7 +279,7 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
                     {
                         public $data = [];
 
-                        public function array(array $array)
+                        public function array(array $array): void
                         {
                             $this->data = $array;
                         }
@@ -287,7 +287,7 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
                 ];
             }
 
-            public function onUnknownSheet($sheetName)
+            public function onUnknownSheet($sheetName): void
             {
                 $this->skippedSheets[] = $sheetName;
             }
@@ -298,7 +298,7 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
         $this->assertContains('NonExistentSheet', $import->skippedSheets);
     }
 
-    public function test_mixed_valid_and_invalid_sheet_names_with_skips()
+    public function test_mixed_valid_and_invalid_sheet_names_with_skips(): void
     {
         $import = new class implements SkipsUnknownSheets, WithMultipleSheets
         {
@@ -324,7 +324,7 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
                 ];
             }
 
-            public function onUnknownSheet($sheetName)
+            public function onUnknownSheet($sheetName): void
             {
                 $this->skippedSheets[] = $sheetName;
             }
@@ -342,7 +342,7 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
         $this->assertNotEmpty($result['Sheet2']);
     }
 
-    public function test_unknown_sheet_name_throws_exception_without_skips()
+    public function test_unknown_sheet_name_throws_exception_without_skips(): void
     {
         $this->expectException(SheetNotFoundException::class);
 
@@ -355,7 +355,7 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
                 return [
                     'NonExistentSheet' => new class implements ToArray
                     {
-                        public function array(array $array)
+                        public function array(array $array): void
                         {
                         }
                     },

--- a/tests/QueuedExportTest.php
+++ b/tests/QueuedExportTest.php
@@ -22,7 +22,7 @@ use Throwable;
 
 class QueuedExportTest extends TestCase
 {
-    public function test_can_queue_an_export()
+    public function test_can_queue_an_export(): void
     {
         $export = new QueuedExport;
 
@@ -31,7 +31,7 @@ class QueuedExportTest extends TestCase
         ]);
     }
 
-    public function test_can_batch_an_export()
+    public function test_can_batch_an_export(): void
     {
         $export = new ShouldBatchExport;
 
@@ -42,7 +42,7 @@ class QueuedExportTest extends TestCase
         $this->assertCount(1, $batch->jobs);
     }
 
-    public function test_can_queue_an_export_and_store_on_different_disk()
+    public function test_can_queue_an_export_and_store_on_different_disk(): void
     {
         $export = new QueuedExport;
 
@@ -51,7 +51,7 @@ class QueuedExportTest extends TestCase
         ]);
     }
 
-    public function test_can_queue_export_with_remote_temp_disk()
+    public function test_can_queue_export_with_remote_temp_disk(): void
     {
         config()->set('excel.temporary_files.remote_disk', 'test');
 
@@ -59,7 +59,7 @@ class QueuedExportTest extends TestCase
         // to simulate using a shared remote disk, without
         // having a dependency on a local temp file.
         $jobs = 0;
-        Queue::before(function (JobProcessing $event) use (&$jobs) {
+        Queue::before(function (JobProcessing $event) use (&$jobs): void {
             if ($event->job->resolveName() === AppendDataToSheet::class) {
                 /** @var TemporaryFile $tempFile */
                 $tempFile = $this->inspectJobProperty($event->job, 'temporaryFile');
@@ -92,7 +92,7 @@ class QueuedExportTest extends TestCase
         $this->assertEquals(3, $jobs);
     }
 
-    public function test_can_queue_export_with_remote_temp_disk_and_prefix()
+    public function test_can_queue_export_with_remote_temp_disk_and_prefix(): void
     {
         config()->set('excel.temporary_files.remote_disk', 'test');
         config()->set('excel.temporary_files.remote_prefix', 'tmp/');
@@ -104,7 +104,7 @@ class QueuedExportTest extends TestCase
         ]);
     }
 
-    public function test_can_implicitly_queue_an_export()
+    public function test_can_implicitly_queue_an_export(): void
     {
         $export = new ShouldQueueExport;
 
@@ -113,7 +113,7 @@ class QueuedExportTest extends TestCase
         ]);
     }
 
-    public function test_can_queue_export_with_mapping_on_eloquent_models()
+    public function test_can_queue_export_with_mapping_on_eloquent_models(): void
     {
         $export = new EloquentCollectionWithMappingExport;
 
@@ -128,7 +128,7 @@ class QueuedExportTest extends TestCase
         ], $actual);
     }
 
-    public function test_can_catch_failures()
+    public function test_can_catch_failures(): void
     {
         $export = new QueuedExportWithFailedHook;
         try {
@@ -139,7 +139,7 @@ class QueuedExportTest extends TestCase
         $this->assertTrue(app('queue-has-failed'));
     }
 
-    public function test_can_catch_failures_on_queue_export_job()
+    public function test_can_catch_failures_on_queue_export_job(): void
     {
         $export = new QueuedExportWithFailedEvents;
 
@@ -151,7 +151,7 @@ class QueuedExportTest extends TestCase
         $this->assertTrue(app('queue-has-failed-from-queue-export-job'));
     }
 
-    public function test_can_set_locale_on_queue_export_job()
+    public function test_can_set_locale_on_queue_export_job(): void
     {
         $currentLocale = app()->getLocale();
 
@@ -164,7 +164,7 @@ class QueuedExportTest extends TestCase
         $this->assertEquals($currentLocale, app()->getLocale());
     }
 
-    public function test_can_queue_export_not_flushing_the_cache()
+    public function test_can_queue_export_not_flushing_the_cache(): void
     {
         config()->set('excel.cache.driver', 'illuminate');
 

--- a/tests/QueuedImportTest.php
+++ b/tests/QueuedImportTest.php
@@ -36,7 +36,7 @@ class QueuedImportTest extends TestCase
         $this->loadMigrationsFrom(__DIR__ . '/Data/Stubs/Database/Migrations');
     }
 
-    public function test_cannot_queue_import_that_does_not_implement_should_queue()
+    public function test_cannot_queue_import_that_does_not_implement_should_queue(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Importable should implement ShouldQueue to be queued.');
@@ -49,7 +49,7 @@ class QueuedImportTest extends TestCase
         $import->queue('import-batches.xlsx');
     }
 
-    public function test_can_queue_an_import()
+    public function test_can_queue_an_import(): void
     {
         $import = new QueuedImport;
 
@@ -60,7 +60,7 @@ class QueuedImportTest extends TestCase
         $this->assertInstanceOf(PendingDispatch::class, $chain);
     }
 
-    public function test_can_batch_an_import()
+    public function test_can_batch_an_import(): void
     {
         $import = new ShouldBatchImport;
 
@@ -71,7 +71,7 @@ class QueuedImportTest extends TestCase
         $this->assertCount(1, $batch->jobs);
     }
 
-    public function test_can_queue_an_import_with_batch_cache_and_file_store()
+    public function test_can_queue_an_import_with_batch_cache_and_file_store(): void
     {
         config()->set('queue.default', 'sync');
         config()->set('excel.cache.driver', 'batch');
@@ -88,14 +88,14 @@ class QueuedImportTest extends TestCase
         $this->assertInstanceOf(PendingDispatch::class, $chain);
     }
 
-    public function test_can_queue_import_with_remote_temp_disk()
+    public function test_can_queue_import_with_remote_temp_disk(): void
     {
         config()->set('excel.temporary_files.remote_disk', 'test');
 
         // Delete the local temp file before each read chunk job
         // to simulate using a shared remote disk, without
         // having a dependency on a local temp file.
-        Queue::before(function (JobProcessing $event) {
+        Queue::before(function (JobProcessing $event): void {
             if ($event->job->resolveName() === ReadChunk::class) {
                 /** @var TemporaryFile $tempFile */
                 $tempFile = $this->inspectJobProperty($event->job, 'temporaryFile');
@@ -122,11 +122,11 @@ class QueuedImportTest extends TestCase
         $this->assertInstanceOf(PendingDispatch::class, $chain);
     }
 
-    public function test_can_keep_extension_for_temp_file_on_remote_disk()
+    public function test_can_keep_extension_for_temp_file_on_remote_disk(): void
     {
         config()->set('excel.temporary_files.remote_disk', 'test');
 
-        Queue::before(function (JobProcessing $event) {
+        Queue::before(function (JobProcessing $event): void {
             if ($event->job->resolveName() === ReadChunk::class) {
                 /** @var TemporaryFile $tempFile */
                 $tempFile = $this->inspectJobProperty($event->job, 'temporaryFile');
@@ -137,7 +137,7 @@ class QueuedImportTest extends TestCase
         (new QueuedImport)->queue('import-batches.xlsx');
     }
 
-    public function test_can_queue_import_with_remote_temp_disk_and_prefix()
+    public function test_can_queue_import_with_remote_temp_disk_and_prefix(): void
     {
         config()->set('excel.temporary_files.remote_disk', 'test');
         config()->set('excel.temporary_files.remote_prefix', 'tmp/');
@@ -151,12 +151,12 @@ class QueuedImportTest extends TestCase
         $this->assertInstanceOf(PendingDispatch::class, $chain);
     }
 
-    public function test_can_automatically_delete_temp_file_on_failure_when_using_remote_disk()
+    public function test_can_automatically_delete_temp_file_on_failure_when_using_remote_disk(): void
     {
         config()->set('excel.temporary_files.remote_disk', 'test');
         $tempFile = '';
 
-        Queue::exceptionOccurred(function (JobExceptionOccurred $event) use (&$tempFile) {
+        Queue::exceptionOccurred(function (JobExceptionOccurred $event) use (&$tempFile): void {
             if ($event->job->resolveName() === ReadChunk::class) {
                 $tempFile = $this->inspectJobProperty($event->job, 'temporaryFile');
             }
@@ -172,11 +172,11 @@ class QueuedImportTest extends TestCase
         $this->assertTrue($tempFile->exists());
     }
 
-    public function test_cannot_automatically_delete_temp_file_on_failure_when_using_local_disk()
+    public function test_cannot_automatically_delete_temp_file_on_failure_when_using_local_disk(): void
     {
         $tempFile = '';
 
-        Queue::exceptionOccurred(function (JobExceptionOccurred $event) use (&$tempFile) {
+        Queue::exceptionOccurred(function (JobExceptionOccurred $event) use (&$tempFile): void {
             if ($event->job->resolveName() === ReadChunk::class) {
                 $tempFile = $this->inspectJobProperty($event->job, 'temporaryFile');
             }
@@ -191,13 +191,13 @@ class QueuedImportTest extends TestCase
         $this->assertTrue($tempFile->exists());
     }
 
-    public function test_can_force_remote_download_and_deletion_for_each_chunk_on_queue()
+    public function test_can_force_remote_download_and_deletion_for_each_chunk_on_queue(): void
     {
         config()->set('excel.temporary_files.remote_disk', 'test');
         config()->set('excel.temporary_files.force_resync_remote', true);
         Bus::fake([AfterImportJob::class]);
 
-        Queue::after(function (JobProcessed $event) {
+        Queue::after(function (JobProcessed $event): void {
             if ($event->job->resolveName() === ReadChunk::class) {
                 $tempFile = $this->inspectJobProperty($event->job, 'temporaryFile');
 
@@ -211,7 +211,7 @@ class QueuedImportTest extends TestCase
         (new QueuedImport)->queue('import-batches.xlsx');
     }
 
-    public function test_can_define_middleware_method_on_queued_import()
+    public function test_can_define_middleware_method_on_queued_import(): void
     {
         try {
             (new QueuedImportWithMiddleware)->queue('import-batches.xlsx');
@@ -220,7 +220,7 @@ class QueuedImportTest extends TestCase
         }
     }
 
-    public function test_can_define_retry_until_method_on_queued_import()
+    public function test_can_define_retry_until_method_on_queued_import(): void
     {
         try {
             (new QueuedImportWithRetryUntil)->queue('import-batches.xlsx');
@@ -229,11 +229,11 @@ class QueuedImportTest extends TestCase
         }
     }
 
-    public function test_can_define_max_exceptions_property_on_queued_import()
+    public function test_can_define_max_exceptions_property_on_queued_import(): void
     {
         $maxExceptionsCount = 0;
 
-        Queue::exceptionOccurred(function (JobExceptionOccurred $event) use (&$maxExceptionsCount) {
+        Queue::exceptionOccurred(function (JobExceptionOccurred $event) use (&$maxExceptionsCount): void {
             if ($event->job->resolveName() === ReadChunk::class) {
                 $maxExceptionsCount = $this->inspectJobProperty($event->job, 'maxExceptions');
             }

--- a/tests/QueuedQueryExportTest.php
+++ b/tests/QueuedQueryExportTest.php
@@ -24,7 +24,7 @@ class QueuedQueryExportTest extends TestCase
         User::factory()->count(100)->create();
     }
 
-    public function test_can_queue_an_export()
+    public function test_can_queue_an_export(): void
     {
         $export = new FromUsersQueryExport;
 
@@ -40,7 +40,7 @@ class QueuedQueryExportTest extends TestCase
         $this->assertCount(6, $actual[0]);
     }
 
-    public function test_can_queue_an_export_with_batch_cache_and_file_store()
+    public function test_can_queue_an_export_with_batch_cache_and_file_store(): void
     {
         config()->set('queue.default', 'sync');
         config()->set('excel.cache.driver', 'batch');
@@ -61,7 +61,7 @@ class QueuedQueryExportTest extends TestCase
         $this->assertCount(100, $actual);
     }
 
-    public function test_can_queue_an_export_with_mapping()
+    public function test_can_queue_an_export_with_mapping(): void
     {
         $export = new FromUsersQueryExportWithMapping;
 
@@ -78,7 +78,7 @@ class QueuedQueryExportTest extends TestCase
         $this->assertEquals(User::value('name'), $actual[0][0]);
     }
 
-    public function test_can_queue_scout_export()
+    public function test_can_queue_scout_export(): void
     {
         if (!class_exists(DatabaseEngine::class)) {
             $this->markTestSkipped('Laravel Scout is too old');

--- a/tests/QueuedViewExportTest.php
+++ b/tests/QueuedViewExportTest.php
@@ -20,7 +20,7 @@ class QueuedViewExportTest extends TestCase
         $this->loadLaravelMigrations(['--database' => 'testing']);
     }
 
-    public function test_can_queue_an_export()
+    public function test_can_queue_an_export(): void
     {
         $users  = User::factory()->count(100)->create();
         $export = new SheetForUsersFromView($users);
@@ -34,7 +34,7 @@ class QueuedViewExportTest extends TestCase
         $this->assertCount(101, $actual);
     }
 
-    public function test_can_export_multiple_sheets_from_view()
+    public function test_can_export_multiple_sheets_from_view(): void
     {
         /** @var Collection|User[] $users */
         $users = User::factory()->count(300)->create();

--- a/tests/TemporaryFileTest.php
+++ b/tests/TemporaryFileTest.php
@@ -30,7 +30,7 @@ class TemporaryFileTest extends TestCase
         @rmdir($path);
     }
 
-    public function test_can_use_default_rights()
+    public function test_can_use_default_rights(): void
     {
         $path = FileHelper::absolutePath('rights-test', 'local');
         FileHelper::recursiveDelete($path);
@@ -47,13 +47,13 @@ class TemporaryFileTest extends TestCase
         $this->assertEquals($this->defaultFilePermissions, substr(sprintf('%o', fileperms($temporaryFile->getLocalPath())), -4));
     }
 
-    public function test_can_use_dir_rights()
+    public function test_can_use_dir_rights(): void
     {
         $path = FileHelper::absolutePath('rights-test', 'local');
         FileHelper::recursiveDelete($path);
 
         config()->set('excel.temporary_files.local_path', $path);
-        config()->set('excel.temporary_files.local_permissions.dir', 0700);
+        config()->set('excel.temporary_files.local_permissions.dir', 0o700);
 
         $temporaryFileFactory = app(TemporaryFileFactory::class);
 
@@ -65,13 +65,13 @@ class TemporaryFileTest extends TestCase
         $this->assertEquals($this->defaultFilePermissions, substr(sprintf('%o', fileperms($temporaryFile->getLocalPath())), -4));
     }
 
-    public function test_can_use_file_rights()
+    public function test_can_use_file_rights(): void
     {
         $path = FileHelper::absolutePath('rights-test', 'local');
         FileHelper::recursiveDelete($path);
 
         config()->set('excel.temporary_files.local_path', $path);
-        config()->set('excel.temporary_files.local_permissions.file', 0600);
+        config()->set('excel.temporary_files.local_permissions.file', 0o600);
 
         $temporaryFileFactory = app(TemporaryFileFactory::class);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -71,7 +71,7 @@ class TestCase extends OrchestraTestCase
     /**
      * @param  Application  $app
      */
-    protected function getEnvironmentSetUp($app)
+    protected function getEnvironmentSetUp($app): void
     {
         $app['config']->set('filesystems.disks.local.root', __DIR__ . '/Data/Disks/Local');
         $app['config']->set('filesystems.disks.test', [
@@ -105,7 +105,7 @@ class TestCase extends OrchestraTestCase
         return $dict[$property] ?? $dict["\0*\0$property"] ?? $dict["\0$class\0$property"];
     }
 
-    protected function assertStringContains(string $needle, string $haystack, string $message = '')
+    protected function assertStringContains(string $needle, string $haystack, string $message = ''): void
     {
         if (method_exists($this, 'assertStringContainsString')) {
             $this->assertStringContainsString($needle, $haystack, $message);
@@ -114,7 +114,7 @@ class TestCase extends OrchestraTestCase
         }
     }
 
-    protected function assertFileMissing(string $path)
+    protected function assertFileMissing(string $path): void
     {
         if (method_exists($this, 'assertFileDoesNotExist')) {
             $this->assertFileDoesNotExist($path);
@@ -123,7 +123,7 @@ class TestCase extends OrchestraTestCase
         }
     }
 
-    protected function assertRegex(string $pattern, string $string)
+    protected function assertRegex(string $pattern, string $string): void
     {
         if (method_exists($this, 'assertMatchesRegularExpression')) {
             $this->assertMatchesRegularExpression($pattern, $string);

--- a/tests/Validators/RowValidatorTest.php
+++ b/tests/Validators/RowValidatorTest.php
@@ -23,7 +23,7 @@ class RowValidatorTest extends TestCase
         $this->validator = new RowValidator(app(Factory::class));
     }
 
-    public function test_format_rule_with_array_input()
+    public function test_format_rule_with_array_input(): void
     {
         $rules = ['rule1', 'rule2'];
 
@@ -32,7 +32,7 @@ class RowValidatorTest extends TestCase
         $this->assertEquals($rules, $result);
     }
 
-    public function test_format_rule_with_object_input()
+    public function test_format_rule_with_object_input(): void
     {
         $rule = new \stdClass;
 
@@ -41,7 +41,7 @@ class RowValidatorTest extends TestCase
         $this->assertEquals($rule, $result);
     }
 
-    public function test_format_rule_with_callable_input()
+    public function test_format_rule_with_callable_input(): void
     {
         $rule = (fn () => 'callable');
 
@@ -50,7 +50,7 @@ class RowValidatorTest extends TestCase
         $this->assertEquals($rule, $result);
     }
 
-    public function test_format_rule_with_required_without_all()
+    public function test_format_rule_with_required_without_all(): void
     {
         $rule = 'required_without_all:first_name,last_name';
 
@@ -59,7 +59,7 @@ class RowValidatorTest extends TestCase
         $this->assertEquals('required_without_all:*.first_name,*.last_name', $result);
     }
 
-    public function test_format_rule_with_required_without()
+    public function test_format_rule_with_required_without(): void
     {
         $rule = 'required_without:first_name';
 
@@ -68,7 +68,7 @@ class RowValidatorTest extends TestCase
         $this->assertEquals('required_without:*.first_name', $result);
     }
 
-    public function test_format_rule_with_string_input_not_matching_pattern()
+    public function test_format_rule_with_string_input_not_matching_pattern(): void
     {
         $rule = 'rule';
 


### PR DESCRIPTION
This applies the PHP-cs-fixers PHP 8.3 and 8.2-risky rules except for strict types. I have done over the result and made sure nothing bad happen from the risky changes, mostly it's just adding native `void` return, new octal annotation and const viability.