### PR TITLE
Apply native types

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -63,7 +63,8 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}.*" "orchestra/testbench:${{ matrix.testbench }}" "laravel/scout:${{ matrix.scout }}"  --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --no-interaction
 
-
+      - name: Execute PHPStan
+        run: vendor/bin/phpstan
 
       - name: Execute tests
         run: vendor/bin/phpunit --testdox --configuration phpunit.xml.dist

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,9 @@
     "laravel/pint": "^1.0",
     "rector/rector": "^2.4.2",
     "driftingly/rector-laravel": "^2.3",
-    "phpstan/phpstan": "^2.1"
+    "phpstan/phpstan": "^2.1",
+    "larastan/larastan": "^3.0",
+    "phpstan/extension-installer": "^1.4"
   },
   "autoload": {
     "psr-4": {
@@ -58,5 +60,10 @@
     }
   },
   "minimum-stability": "dev",
-  "prefer-stable": true
+  "prefer-stable": true,
+  "config": {
+    "allow-plugins": {
+      "phpstan/extension-installer": true
+    }
+  }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,5 +2,10 @@ parameters:
     level: 0
     paths:
         - ./src
+        - ./tests
+        - ./config
     exceptions:
         implicitThrows: false
+    configDirectories:
+        - ./tests
+        - ./config

--- a/src/Cache/BatchCache.php
+++ b/src/Cache/BatchCache.php
@@ -8,27 +8,15 @@ use Psr\SimpleCache\CacheInterface;
 class BatchCache implements CacheInterface
 {
     /**
-     * @var CacheInterface
-     */
-    protected $cache;
-
-    /**
-     * @var MemoryCache
-     */
-    protected $memory;
-
-    /**
      * @var null|int|\DateInterval|callable
      */
     protected $defaultTTL = null;
 
     public function __construct(
-        CacheInterface $cache,
-        MemoryCache $memory,
+        protected CacheInterface $cache,
+        protected MemoryInterface $memory,
         null|int|\DateInterval|callable $defaultTTL = null
     ) {
-        $this->cache      = $cache;
-        $this->memory     = $memory;
         $this->defaultTTL = $defaultTTL;
     }
 

--- a/src/Cache/BatchCacheDeprecated.php
+++ b/src/Cache/BatchCacheDeprecated.php
@@ -8,30 +8,15 @@ use Psr\SimpleCache\CacheInterface;
 class BatchCacheDeprecated implements CacheInterface
 {
     /**
-     * @var CacheInterface
-     */
-    protected $cache;
-
-    /**
-     * @var MemoryCacheDeprecated
-     */
-    protected $memory;
-
-    /**
      * @var null|int|\DateTimeInterface|callable
      */
     protected $defaultTTL = null;
 
-    /**
-     * @param  int|\DateTimeInterface|callable|null  $defaultTTL
-     */
     public function __construct(
-        CacheInterface $cache,
-        MemoryCacheDeprecated $memory,
-        $defaultTTL = null
+        protected CacheInterface $cache,
+        protected MemoryInterface $memory,
+        int|\DateTimeInterface|callable|null $defaultTTL = null
     ) {
-        $this->cache      = $cache;
-        $this->memory     = $memory;
         $this->defaultTTL = $defaultTTL;
     }
 

--- a/src/Cache/MemoryCache.php
+++ b/src/Cache/MemoryCache.php
@@ -3,23 +3,14 @@
 namespace Maatwebsite\Excel\Cache;
 
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
-use Psr\SimpleCache\CacheInterface;
 
-class MemoryCache implements CacheInterface
+class MemoryCache implements MemoryInterface
 {
-    /**
-     * @var int|null
-     */
-    protected $memoryLimit;
+    protected array $cache = [];
 
-    /**
-     * @var array
-     */
-    protected $cache = [];
-
-    public function __construct(?int $memoryLimit = null)
-    {
-        $this->memoryLimit = $memoryLimit;
+    public function __construct(
+        protected ?int $memoryLimit = null,
+    ) {
     }
 
     /**

--- a/src/Cache/MemoryCacheDeprecated.php
+++ b/src/Cache/MemoryCacheDeprecated.php
@@ -3,23 +3,14 @@
 namespace Maatwebsite\Excel\Cache;
 
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
-use Psr\SimpleCache\CacheInterface;
 
-class MemoryCacheDeprecated implements CacheInterface
+class MemoryCacheDeprecated implements MemoryInterface
 {
-    /**
-     * @var int|null
-     */
-    protected $memoryLimit;
+    protected array $cache = [];
 
-    /**
-     * @var array
-     */
-    protected $cache = [];
-
-    public function __construct(?int $memoryLimit = null)
-    {
-        $this->memoryLimit = $memoryLimit;
+    public function __construct(
+        protected ?int $memoryLimit = null,
+    ) {
     }
 
     /**

--- a/src/Cache/MemoryInterface.php
+++ b/src/Cache/MemoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Maatwebsite\Excel\Cache;
+
+use Psr\SimpleCache\CacheInterface;
+
+interface MemoryInterface extends CacheInterface
+{
+    public function reachedMemoryLimit(): bool;
+
+    public function flush(): array;
+}

--- a/src/Cell.php
+++ b/src/Cell.php
@@ -14,16 +14,15 @@ class Cell
 {
     use DelegatedMacroable;
 
-    final public function __construct(private SpreadsheetCell $cell)
-    {
+    final public function __construct(
+        private SpreadsheetCell $cell,
+    ) {
     }
 
     /**
-     * @return Cell
-     *
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      */
-    public static function make(Worksheet $worksheet, string $coordinate)
+    public static function make(Worksheet $worksheet, string $coordinate): Cell
     {
         return new static($worksheet->getCell($coordinate));
     }
@@ -33,13 +32,7 @@ class Cell
         return $this->cell;
     }
 
-    /**
-     * @param  null  $nullValue
-     * @param  bool  $calculateFormulas
-     * @param  bool  $formatData
-     * @return mixed
-     */
-    public function getValue($nullValue = null, $calculateFormulas = false, $formatData = true)
+    public function getValue(mixed $nullValue = null, bool $calculateFormulas = false, bool $formatData = true): mixed
     {
         $value = $nullValue;
         if ($this->cell->getValue() !== null) {

--- a/src/ChunkReader.php
+++ b/src/ChunkReader.php
@@ -26,20 +26,12 @@ use Throwable;
 
 class ChunkReader
 {
-    /**
-     * @var Container
-     */
-    protected $container;
-
-    public function __construct(Container $container)
-    {
-        $this->container = $container;
+    public function __construct(
+        protected Container $container,
+    ) {
     }
 
-    /**
-     * @return PendingDispatch|PendingBatch|Collection|null
-     */
-    public function read(WithChunkReading $import, Reader $reader, TemporaryFile $temporaryFile)
+    public function read(WithChunkReading $import, Reader $reader, TemporaryFile $temporaryFile): PendingDispatch|PendingBatch|Collection|null
     {
         if ($import instanceof WithEvents) {
             $reader->beforeImport($import);
@@ -130,12 +122,8 @@ class ChunkReader
 
     /**
      * Dispatch a command to its appropriate handler in the current process without using the synchronous queue.
-     *
-     * @param  object  $command
-     * @param  mixed  $handler
-     * @return mixed
      */
-    protected function dispatchNow($command, $handler = null)
+    protected function dispatchNow(object $command, mixed $handler = null): mixed
     {
         $uses = class_uses_recursive($command);
 

--- a/src/Concerns/Exportable.php
+++ b/src/Concerns/Exportable.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\Excel\Concerns;
 
+use Illuminate\Bus\PendingBatch;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -12,18 +13,26 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 trait Exportable
 {
+    protected ?string $fileName = null;
+
+    protected ?string $writerType = null;
+
+    protected ?array $headers = [];
+
     protected ?string $filePath = null;
 
+    protected ?string $disk = null;
+
+    protected mixed $diskOptions = [];
+
     /**
-     * @return Response|BinaryFileResponse
-     *
      * @throws NoFilenameGivenException
      */
-    public function download(?string $fileName = null, ?string $writerType = null, ?array $headers = null)
+    public function download(?string $fileName = null, ?string $writerType = null, ?array $headers = null): Response|BinaryFileResponse
     {
-        $headers ??= $this->headers ?? [];
-        $fileName ??= $this->fileName ?? null;
-        $writerType ??= $this->writerType ?? null;
+        $headers ??= $this->headers;
+        $fileName ??= $this->fileName;
+        $writerType ??= $this->writerType;
 
         if ($fileName === null) {
             throw new NoFilenameGivenException;
@@ -33,14 +42,11 @@ trait Exportable
     }
 
     /**
-     * @param  mixed  $diskOptions
-     * @return bool|PendingDispatch
-     *
      * @throws NoFilePathGivenException
      */
-    public function store(?string $filePath = null, ?string $disk = null, ?string $writerType = null, $diskOptions = [])
+    public function store(?string $filePath = null, ?string $disk = null, ?string $writerType = null, mixed $diskOptions = []): bool|PendingDispatch
     {
-        $filePath ??= $this->filePath ?? null;
+        $filePath ??= $this->filePath;
 
         if ($filePath === null) {
             throw NoFilePathGivenException::export();
@@ -49,21 +55,18 @@ trait Exportable
         return $this->getExporter()->store(
             $this,
             $filePath,
-            $disk ?? $this->disk ?? null,
-            $writerType ?? $this->writerType ?? null,
-            $diskOptions ?: $this->diskOptions ?? []
+            $disk ?? $this->disk,
+            $writerType ?? $this->writerType,
+            $diskOptions ?: $this->diskOptions
         );
     }
 
     /**
-     * @param  mixed  $diskOptions
-     * @return PendingDispatch
-     *
      * @throws NoFilePathGivenException
      */
-    public function queue(?string $filePath = null, ?string $disk = null, ?string $writerType = null, $diskOptions = [])
+    public function queue(?string $filePath = null, ?string $disk = null, ?string $writerType = null, mixed $diskOptions = []): PendingDispatch|PendingBatch
     {
-        $filePath ??= $this->filePath ?? null;
+        $filePath ??= $this->filePath;
 
         if ($filePath === null) {
             throw NoFilePathGivenException::export();
@@ -72,19 +75,15 @@ trait Exportable
         return $this->getExporter()->queue(
             $this,
             $filePath,
-            $disk ?? $this->disk ?? null,
-            $writerType ?? $this->writerType ?? null,
-            $diskOptions ?: $this->diskOptions ?? []
+            $disk ?? $this->disk,
+            $writerType ?? $this->writerType,
+            $diskOptions ?: $this->diskOptions
         );
     }
 
-    /**
-     * @param  string|null  $writerType
-     * @return string
-     */
-    public function raw($writerType = null)
+    public function raw(?string $writerType = null): string
     {
-        $writerType ??= $this->writerType ?? null;
+        $writerType ??= $this->writerType;
 
         return $this->getExporter()->raw($this, $writerType);
     }

--- a/src/Concerns/FromCollection.php
+++ b/src/Concerns/FromCollection.php
@@ -2,12 +2,17 @@
 
 namespace Maatwebsite\Excel\Concerns;
 
-use Illuminate\Support\Collection;
+use Illuminate\Support\Enumerable;
 
+/**
+ * @template TKey of array-key
+ *
+ * @template-covariant TValue
+ */
 interface FromCollection
 {
     /**
-     * @return Collection
+     * @return Enumerable<TKey, TValue>
      */
-    public function collection();
+    public function collection(): Enumerable;
 }

--- a/src/Concerns/FromQuery.php
+++ b/src/Concerns/FromQuery.php
@@ -37,8 +37,6 @@ interface FromQuery
      * have a deterministic lexicographic total order, so `orderBy('id')`
      * still works as a tie-breaker — there's no special handling needed,
      * just always set one.
-     *
-     * @return Builder|EloquentBuilder|Relation|ScoutBuilder
      */
-    public function query();
+    public function query(): Builder|EloquentBuilder|Relation|ScoutBuilder;
 }

--- a/src/Concerns/Importable.php
+++ b/src/Concerns/Importable.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\Excel\Concerns;
 
+use Illuminate\Bus\PendingBatch;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\PendingDispatch;
@@ -15,10 +16,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 trait Importable
 {
-    /**
-     * @var OutputStyle|null
-     */
-    protected $output;
+    protected ?OutputStyle $output;
 
     protected ?string $disk = null;
 
@@ -27,29 +25,24 @@ trait Importable
     protected string|UploadedFile|null $filePath = null;
 
     /**
-     * @param  string|UploadedFile|null  $filePath
-     * @return Importer|PendingDispatch
-     *
      * @throws NoFilePathGivenException
      */
-    public function import($filePath = null, ?string $disk = null, ?string $readerType = null)
+    public function import(string|UploadedFile|null $filePath = null, ?string $disk = null, ?string $readerType = null): Importer|PendingDispatch|PendingBatch
     {
         $filePath = $this->getFilePath($filePath);
 
         return $this->getImporter()->import(
             $this,
             $filePath,
-            $disk ?? $this->disk ?? null,
-            $readerType ?? $this->readerType ?? null
+            $disk ?? $this->disk,
+            $readerType ?? $this->readerType
         );
     }
 
     /**
-     * @param  string|UploadedFile|null  $filePath
-     *
      * @throws NoFilePathGivenException
      */
-    public function toArray($filePath = null, ?string $disk = null, ?string $readerType = null): array
+    public function toArray(string|UploadedFile|null $filePath = null, ?string $disk = null, ?string $readerType = null): array
     {
         $filePath = $this->getFilePath($filePath);
 
@@ -62,11 +55,9 @@ trait Importable
     }
 
     /**
-     * @param  string|UploadedFile|null  $filePath
-     *
      * @throws NoFilePathGivenException
      */
-    public function toCollection($filePath = null, ?string $disk = null, ?string $readerType = null): Collection
+    public function toCollection(string|UploadedFile|null $filePath = null, ?string $disk = null, ?string $readerType = null): Collection
     {
         $filePath = $this->getFilePath($filePath);
 
@@ -79,13 +70,10 @@ trait Importable
     }
 
     /**
-     * @param  string|UploadedFile|null  $filePath
-     * @return PendingDispatch
-     *
      * @throws NoFilePathGivenException
      * @throws InvalidArgumentException
      */
-    public function queue($filePath = null, ?string $disk = null, ?string $readerType = null)
+    public function queue(string|UploadedFile|null $filePath = null, ?string $disk = null, ?string $readerType = null): static|PendingDispatch|PendingBatch
     {
         if (!$this instanceof ShouldQueue) {
             throw new InvalidArgumentException('Importable should implement ShouldQueue to be queued.');
@@ -114,12 +102,9 @@ trait Importable
     }
 
     /**
-     * @param  UploadedFile|string|null  $filePath
-     * @return UploadedFile|string
-     *
      * @throws NoFilePathGivenException
      */
-    private function getFilePath($filePath = null)
+    private function getFilePath(UploadedFile|string|null $filePath = null): UploadedFile|string
     {
         $filePath ??= $this->filePath ?? null;
 

--- a/src/Concerns/MapsCsvSettings.php
+++ b/src/Concerns/MapsCsvSettings.php
@@ -6,60 +6,27 @@ use Illuminate\Support\Arr;
 
 trait MapsCsvSettings
 {
-    /**
-     * @var string
-     */
-    protected static $delimiter = ',';
+    protected static ?string $delimiter = ',';
 
-    /**
-     * @var string
-     */
-    protected static $enclosure = '"';
+    protected static string $enclosure = '"';
 
-    /**
-     * @var string
-     */
-    protected static $lineEnding = PHP_EOL;
+    protected static string $lineEnding = PHP_EOL;
 
-    /**
-     * @var bool
-     */
-    protected static $useBom = false;
+    protected static bool $useBom = false;
 
-    /**
-     * @var bool
-     */
-    protected static $includeSeparatorLine = false;
+    protected static bool $includeSeparatorLine = false;
 
-    /**
-     * @var bool
-     */
-    protected static $excelCompatibility = false;
+    protected static bool $excelCompatibility = false;
 
-    /**
-     * @var string
-     */
-    protected static $escapeCharacter = '\\';
+    protected static string $escapeCharacter = '\\';
 
-    /**
-     * @var bool
-     */
-    protected static $contiguous = false;
+    protected static bool $contiguous = false;
 
-    /**
-     * @var string
-     */
-    protected static $inputEncoding = 'UTF-8';
+    protected static string $inputEncoding = 'UTF-8';
 
-    /**
-     * @var string
-     */
-    protected static $outputEncoding = '';
+    protected static string $outputEncoding = '';
 
-    /**
-     * @var bool
-     */
-    protected static $testAutoDetect = true;
+    protected static bool $testAutoDetect = true;
 
     public static function applyCsvSettings(array $config): void
     {

--- a/src/Concerns/RemembersChunkOffset.php
+++ b/src/Concerns/RemembersChunkOffset.php
@@ -4,20 +4,14 @@ namespace Maatwebsite\Excel\Concerns;
 
 trait RemembersChunkOffset
 {
-    /**
-     * @var int|null
-     */
-    protected $chunkOffset;
+    protected ?int $chunkOffset;
 
     public function setChunkOffset(int $chunkOffset): void
     {
         $this->chunkOffset = $chunkOffset;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getChunkOffset()
+    public function getChunkOffset(): ?int
     {
         return $this->chunkOffset;
     }

--- a/src/Concerns/RemembersRowNumber.php
+++ b/src/Concerns/RemembersRowNumber.php
@@ -4,20 +4,14 @@ namespace Maatwebsite\Excel\Concerns;
 
 trait RemembersRowNumber
 {
-    /**
-     * @var int
-     */
-    protected $rowNumber;
+    protected int $rowNumber;
 
     public function rememberRowNumber(int $rowNumber): void
     {
         $this->rowNumber = $rowNumber;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getRowNumber()
+    public function getRowNumber(): ?int
     {
         return $this->rowNumber;
     }

--- a/src/Concerns/SkipsErrors.php
+++ b/src/Concerns/SkipsErrors.php
@@ -10,7 +10,7 @@ trait SkipsErrors
     /**
      * @var Throwable[]
      */
-    protected $errors = [];
+    protected array $errors = [];
 
     public function onError(Throwable $e): void
     {

--- a/src/Concerns/SkipsFailures.php
+++ b/src/Concerns/SkipsFailures.php
@@ -10,7 +10,7 @@ trait SkipsFailures
     /**
      * @var Failure[]
      */
-    protected $failures = [];
+    protected array $failures = [];
 
     public function onFailure(Failure ...$failures): void
     {

--- a/src/Concerns/SkipsOnFailure.php
+++ b/src/Concerns/SkipsOnFailure.php
@@ -6,8 +6,5 @@ use Maatwebsite\Excel\Validators\Failure;
 
 interface SkipsOnFailure
 {
-    /**
-     * @param  Failure[]  $failures
-     */
     public function onFailure(Failure ...$failures);
 }

--- a/src/Concerns/SkipsUnknownSheets.php
+++ b/src/Concerns/SkipsUnknownSheets.php
@@ -4,8 +4,5 @@ namespace Maatwebsite\Excel\Concerns;
 
 interface SkipsUnknownSheets
 {
-    /**
-     * @param  string|int  $sheetName
-     */
-    public function onUnknownSheet($sheetName);
+    public function onUnknownSheet(string|int $sheetName);
 }

--- a/src/Concerns/ToModel.php
+++ b/src/Concerns/ToModel.php
@@ -9,5 +9,5 @@ interface ToModel
     /**
      * @return Model|Model[]|null
      */
-    public function model(array $row);
+    public function model(array $row): Model|array|null;
 }

--- a/src/Concerns/WithBackgroundColor.php
+++ b/src/Concerns/WithBackgroundColor.php
@@ -6,8 +6,5 @@ use PhpOffice\PhpSpreadsheet\Style\Color;
 
 interface WithBackgroundColor
 {
-    /**
-     * @return string|array|Color
-     */
-    public function backgroundColor();
+    public function backgroundColor(): string|array|Color;
 }

--- a/src/Concerns/WithCharts.php
+++ b/src/Concerns/WithCharts.php
@@ -9,5 +9,5 @@ interface WithCharts
     /**
      * @return Chart|Chart[]
      */
-    public function charts();
+    public function charts(): Chart|array;
 }

--- a/src/Concerns/WithConditionalSheets.php
+++ b/src/Concerns/WithConditionalSheets.php
@@ -4,16 +4,12 @@ namespace Maatwebsite\Excel\Concerns;
 
 trait WithConditionalSheets
 {
-    /**
-     * @var array
-     */
-    protected $conditionallySelectedSheets = [];
+    protected array $conditionallySelectedSheets = [];
 
     /**
-     * @param  string|array  $sheets
      * @return $this
      */
-    public function onlySheets($sheets)
+    public function onlySheets(string|array $sheets)
     {
         $this->conditionallySelectedSheets = is_array($sheets) ? $sheets : func_get_args();
 

--- a/src/Concerns/WithDefaultStyles.php
+++ b/src/Concerns/WithDefaultStyles.php
@@ -6,8 +6,5 @@ use PhpOffice\PhpSpreadsheet\Style\Style;
 
 interface WithDefaultStyles
 {
-    /**
-     * @return array|void
-     */
-    public function defaultStyles(Style $defaultStyle);
+    public function defaultStyles(Style $defaultStyle): ?array;
 }

--- a/src/Concerns/WithDrawings.php
+++ b/src/Concerns/WithDrawings.php
@@ -9,5 +9,5 @@ interface WithDrawings
     /**
      * @return BaseDrawing|BaseDrawing[]
      */
-    public function drawings();
+    public function drawings(): BaseDrawing|array;
 }

--- a/src/Concerns/WithMapping.php
+++ b/src/Concerns/WithMapping.php
@@ -9,6 +9,7 @@ interface WithMapping
 {
     /**
      * @param  RowType  $row
+     * @return array<mixed>
      */
-    public function map($row): array;
+    public function map(mixed $row): array;
 }

--- a/src/Concerns/WithUpsertColumns.php
+++ b/src/Concerns/WithUpsertColumns.php
@@ -4,8 +4,5 @@ namespace Maatwebsite\Excel\Concerns;
 
 interface WithUpsertColumns
 {
-    /**
-     * @return array
-     */
-    public function upsertColumns();
+    public function upsertColumns(): array;
 }

--- a/src/Concerns/WithUpserts.php
+++ b/src/Concerns/WithUpserts.php
@@ -4,8 +4,5 @@ namespace Maatwebsite\Excel\Concerns;
 
 interface WithUpserts
 {
-    /**
-     * @return string|array
-     */
-    public function uniqueBy();
+    public function uniqueBy(): string|array;
 }

--- a/src/Console/ExportMakeCommand.php
+++ b/src/Console/ExportMakeCommand.php
@@ -32,10 +32,8 @@ class ExportMakeCommand extends GeneratorCommand
 
     /**
      * Get the stub file for the generator.
-     *
-     * @return string
      */
-    protected function getStub()
+    protected function getStub(): string
     {
         if ($this->option('model') && $this->option('query')) {
             return $this->resolveStubPath('/stubs/export.query-model.stub');

--- a/src/Console/ImportMakeCommand.php
+++ b/src/Console/ImportMakeCommand.php
@@ -32,10 +32,8 @@ class ImportMakeCommand extends GeneratorCommand
 
     /**
      * Get the stub file for the generator.
-     *
-     * @return string
      */
-    protected function getStub()
+    protected function getStub(): string
     {
         return $this->option('model')
             ? $this->resolveStubPath('/stubs/import.model.stub')

--- a/src/Console/WithModelStub.php
+++ b/src/Console/WithModelStub.php
@@ -22,10 +22,8 @@ trait WithModelStub
 
     /**
      * Get the fully-qualified model class name.
-     *
-     * @param  string  $model
      */
-    protected function parseModel($model): string
+    protected function parseModel(string $model): string
     {
         if (preg_match('([^A-Za-z0-9_/\\\\])', $model)) {
             throw new InvalidArgumentException('Model name contains invalid characters.');
@@ -50,11 +48,8 @@ trait WithModelStub
 
     /**
      * Resolve the fully-qualified path to the stub.
-     *
-     * @param  string  $stub
-     * @return string
      */
-    protected function resolveStubPath($stub)
+    protected function resolveStubPath(string $stub): string
     {
         return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
             ? $customPath

--- a/src/Console/stubs/export.model.stub
+++ b/src/Console/stubs/export.model.stub
@@ -4,13 +4,11 @@ namespace DummyNamespace;
 
 use DummyFullModelClass;
 use Maatwebsite\Excel\Concerns\FromCollection;
+use Illuminate\Support\Collection;
 
 class DummyClass implements FromCollection
 {
-    /**
-    * @return \Illuminate\Support\Collection
-    */
-    public function collection()
+    public function collection(): Collection
     {
         return DummyModelClass::all();
     }

--- a/src/Console/stubs/export.plain.stub
+++ b/src/Console/stubs/export.plain.stub
@@ -3,13 +3,11 @@
 namespace DummyNamespace;
 
 use Maatwebsite\Excel\Concerns\FromCollection;
+use Illuminate\Support\Collection;
 
 class DummyClass implements FromCollection
 {
-    /**
-    * @return \Illuminate\Support\Collection
-    */
-    public function collection()
+    public function collection(): Collection
     {
         //
     }

--- a/src/Console/stubs/import.model.stub
+++ b/src/Console/stubs/import.model.stub
@@ -4,15 +4,11 @@ namespace DummyNamespace;
 
 use DummyFullModelClass;
 use Maatwebsite\Excel\Concerns\ToModel;
+use Illuminate\Database\Eloquent\Model;
 
 class DummyClass implements ToModel
 {
-    /**
-    * @param array $row
-    *
-    * @return \Illuminate\Database\Eloquent\Model|null
-    */
-    public function model(array $row)
+    public function model(array $row): Model|null
     {
         return new DummyModelClass([
             //

--- a/src/DelegatedMacroable.php
+++ b/src/DelegatedMacroable.php
@@ -12,12 +12,8 @@ trait DelegatedMacroable
 
     /**
      * Dynamically handle calls to the class.
-     *
-     * @param  string  $method
-     * @param  array  $parameters
-     * @return mixed
      */
-    public function __call($method, $parameters)
+    public function __call(string $method, array $parameters): mixed
     {
         if (method_exists($this->getDelegate(), $method)) {
             return call_user_func_array([$this->getDelegate(), $method], $parameters);
@@ -28,8 +24,5 @@ trait DelegatedMacroable
         return $this->__callMacro($method, $parameters);
     }
 
-    /**
-     * @return object
-     */
-    abstract public function getDelegate();
+    abstract public function getDelegate(): object;
 }

--- a/src/Events/AfterBatch.php
+++ b/src/Events/AfterBatch.php
@@ -6,17 +6,12 @@ use Maatwebsite\Excel\Imports\ModelManager;
 
 class AfterBatch extends Event
 {
-    /**
-     * @var ModelManager
-     */
-    public $manager;
-
-    /**
-     * @param  object  $importable
-     */
-    public function __construct(ModelManager $manager, $importable, private int $batchSize, private int $startRow)
-    {
-        $this->manager = $manager;
+    public function __construct(
+        public ModelManager $manager,
+        object $importable,
+        private int $batchSize,
+        private int $startRow,
+    ) {
         parent::__construct($importable);
     }
 
@@ -25,10 +20,7 @@ class AfterBatch extends Event
         return $this->manager;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getDelegate()
+    public function getDelegate(): mixed
     {
         return $this->manager;
     }

--- a/src/Events/AfterChunk.php
+++ b/src/Events/AfterChunk.php
@@ -6,8 +6,11 @@ use Maatwebsite\Excel\Sheet;
 
 class AfterChunk extends Event
 {
-    public function __construct(private Sheet $sheet, $importable, private int $startRow)
-    {
+    public function __construct(
+        private Sheet $sheet,
+        $importable,
+        private int $startRow,
+    ) {
         parent::__construct($importable);
     }
 
@@ -16,7 +19,7 @@ class AfterChunk extends Event
         return $this->sheet;
     }
 
-    public function getDelegate()
+    public function getDelegate(): mixed
     {
         return $this->sheet;
     }

--- a/src/Events/AfterImport.php
+++ b/src/Events/AfterImport.php
@@ -6,17 +6,10 @@ use Maatwebsite\Excel\Reader;
 
 class AfterImport extends Event
 {
-    /**
-     * @var Reader
-     */
-    public $reader;
-
-    /**
-     * @param  object  $importable
-     */
-    public function __construct(Reader $reader, $importable)
-    {
-        $this->reader = $reader;
+    public function __construct(
+        public Reader $reader,
+        ?object $importable,
+    ) {
         parent::__construct($importable);
     }
 
@@ -25,10 +18,7 @@ class AfterImport extends Event
         return $this->reader;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getDelegate()
+    public function getDelegate(): mixed
     {
         return $this->reader;
     }

--- a/src/Events/AfterSheet.php
+++ b/src/Events/AfterSheet.php
@@ -6,17 +6,10 @@ use Maatwebsite\Excel\Sheet;
 
 class AfterSheet extends Event
 {
-    /**
-     * @var Sheet
-     */
-    public $sheet;
-
-    /**
-     * @param  object  $exportable
-     */
-    public function __construct(Sheet $sheet, $exportable)
-    {
-        $this->sheet = $sheet;
+    public function __construct(
+        public Sheet $sheet,
+        object $exportable,
+    ) {
         parent::__construct($exportable);
     }
 
@@ -25,10 +18,7 @@ class AfterSheet extends Event
         return $this->sheet;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getDelegate()
+    public function getDelegate(): mixed
     {
         return $this->sheet;
     }

--- a/src/Events/BeforeExport.php
+++ b/src/Events/BeforeExport.php
@@ -6,17 +6,10 @@ use Maatwebsite\Excel\Writer;
 
 class BeforeExport extends Event
 {
-    /**
-     * @var Writer
-     */
-    public $writer;
-
-    /**
-     * @param  object  $exportable
-     */
-    public function __construct(Writer $writer, $exportable)
-    {
-        $this->writer = $writer;
+    public function __construct(
+        public Writer $writer,
+        object $exportable,
+    ) {
         parent::__construct($exportable);
     }
 
@@ -25,10 +18,7 @@ class BeforeExport extends Event
         return $this->writer;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getDelegate()
+    public function getDelegate(): mixed
     {
         return $this->writer;
     }

--- a/src/Events/BeforeImport.php
+++ b/src/Events/BeforeImport.php
@@ -6,17 +6,10 @@ use Maatwebsite\Excel\Reader;
 
 class BeforeImport extends Event
 {
-    /**
-     * @var Reader
-     */
-    public $reader;
-
-    /**
-     * @param  object  $importable
-     */
-    public function __construct(Reader $reader, $importable)
-    {
-        $this->reader = $reader;
+    public function __construct(
+        public Reader $reader,
+        ?object $importable,
+    ) {
         parent::__construct($importable);
     }
 
@@ -25,10 +18,7 @@ class BeforeImport extends Event
         return $this->reader;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getDelegate()
+    public function getDelegate(): mixed
     {
         return $this->reader;
     }

--- a/src/Events/BeforeSheet.php
+++ b/src/Events/BeforeSheet.php
@@ -6,17 +6,10 @@ use Maatwebsite\Excel\Sheet;
 
 class BeforeSheet extends Event
 {
-    /**
-     * @var Sheet
-     */
-    public $sheet;
-
-    /**
-     * @param  object  $exportable
-     */
-    public function __construct(Sheet $sheet, $exportable)
-    {
-        $this->sheet = $sheet;
+    public function __construct(
+        public Sheet $sheet,
+        object $exportable,
+    ) {
         parent::__construct($exportable);
     }
 
@@ -25,10 +18,7 @@ class BeforeSheet extends Event
         return $this->sheet;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getDelegate()
+    public function getDelegate(): mixed
     {
         return $this->sheet;
     }

--- a/src/Events/BeforeWriting.php
+++ b/src/Events/BeforeWriting.php
@@ -6,22 +6,12 @@ use Maatwebsite\Excel\Writer;
 
 class BeforeWriting extends Event
 {
-    /**
-     * @var Writer
-     */
-    public $writer;
+    private object $exportable;
 
-    /**
-     * @var object
-     */
-    private $exportable;
-
-    /**
-     * @param  object  $exportable
-     */
-    public function __construct(Writer $writer, $exportable)
-    {
-        $this->writer = $writer;
+    public function __construct(
+        public Writer $writer,
+        object $exportable
+    ) {
         parent::__construct($exportable);
     }
 
@@ -30,10 +20,7 @@ class BeforeWriting extends Event
         return $this->writer;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getDelegate()
+    public function getDelegate(): mixed
     {
         return $this->writer;
     }

--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -10,22 +10,17 @@ abstract class Event
     /**
      * @param  object  $concernable
      */
-    public function __construct(protected $concernable)
-    {
+    public function __construct(
+        protected $concernable,
+    ) {
     }
 
-    /**
-     * @return object
-     */
-    public function getConcernable()
+    public function getConcernable(): object
     {
         return $this->concernable;
     }
 
-    /**
-     * @return mixed
-     */
-    abstract public function getDelegate();
+    abstract public function getDelegate(): mixed;
 
     public function appliesToConcern(string $concern): bool
     {

--- a/src/Events/ImportFailed.php
+++ b/src/Events/ImportFailed.php
@@ -6,14 +6,9 @@ use Throwable;
 
 class ImportFailed
 {
-    /**
-     * @var Throwable
-     */
-    public $e;
-
-    public function __construct(Throwable $e)
-    {
-        $this->e = $e;
+    public function __construct(
+        public Throwable $e,
+    ) {
     }
 
     public function getException(): Throwable

--- a/src/Excel.php
+++ b/src/Excel.php
@@ -11,6 +11,7 @@ use Maatwebsite\Excel\Files\Filesystem;
 use Maatwebsite\Excel\Files\TemporaryFile;
 use Maatwebsite\Excel\Helpers\FileTypeDetector;
 use PhpOffice\PhpSpreadsheet\Exception;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class Excel implements Exporter, Importer
 {
@@ -40,36 +41,18 @@ class Excel implements Exporter, Importer
 
     public const TCPDF = 'Tcpdf';
 
-    /**
-     * @var Writer
-     */
-    protected $writer;
-
-    /**
-     * @var QueuedWriter
-     */
-    protected $queuedWriter;
-
-    /**
-     * @var Filesystem
-     */
-    protected $filesystem;
-
     public function __construct(
-        Writer $writer,
-        QueuedWriter $queuedWriter,
+        protected Writer $writer,
+        protected QueuedWriter $queuedWriter,
         private Reader $reader,
-        Filesystem $filesystem
+        protected Filesystem $filesystem,
     ) {
-        $this->writer       = $writer;
-        $this->filesystem   = $filesystem;
-        $this->queuedWriter = $queuedWriter;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function download($export, string $fileName, ?string $writerType = null, array $headers = [])
+    public function download($export, string $fileName, ?string $writerType = null, array $headers = []): BinaryFileResponse
     {
         // Clear output buffer to prevent stuff being prepended to the Excel output.
         if (ob_get_length() > 0) {
@@ -89,7 +72,7 @@ class Excel implements Exporter, Importer
      *
      * @param  string|null  $disk  Fallback for usage with named properties
      */
-    public function store($export, string $filePath, ?string $diskName = null, ?string $writerType = null, $diskOptions = [], ?string $disk = null)
+    public function store($export, string $filePath, ?string $diskName = null, ?string $writerType = null, $diskOptions = [], ?string $disk = null): bool|PendingDispatch|PendingBatch
     {
         if ($export instanceof ShouldQueue) {
             return $this->queue($export, $filePath, $diskName ?: $disk, $writerType, $diskOptions);
@@ -107,10 +90,7 @@ class Excel implements Exporter, Importer
         return $exported;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function queue($export, string $filePath, ?string $disk = null, ?string $writerType = null, $diskOptions = [])
+    public function queue($export, string $filePath, ?string $disk = null, ?string $writerType = null, $diskOptions = []): PendingDispatch|PendingBatch
     {
         $writerType = FileTypeDetector::detectStrict($filePath, $writerType);
 
@@ -123,10 +103,7 @@ class Excel implements Exporter, Importer
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function raw($export, string $writerType)
+    public function raw($export, string $writerType): string
     {
         $temporaryFile = $this->writer->export($export, $writerType);
 
@@ -136,10 +113,7 @@ class Excel implements Exporter, Importer
         return $contents;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function import($import, $filePath, ?string $disk = null, ?string $readerType = null)
+    public function import($import, $filePath, ?string $disk = null, ?string $readerType = null): static|Reader|PendingDispatch|PendingBatch
     {
         $readerType = FileTypeDetector::detect($filePath, $readerType);
         $response   = $this->reader->read($import, $filePath, $readerType, $disk);
@@ -151,9 +125,6 @@ class Excel implements Exporter, Importer
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray($import, $filePath, ?string $disk = null, ?string $readerType = null): array
     {
         $readerType = FileTypeDetector::detect($filePath, $readerType);
@@ -161,31 +132,22 @@ class Excel implements Exporter, Importer
         return $this->reader->toArray($import, $filePath, $readerType, $disk);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function toCollection($import, $filePath, ?string $disk = null, ?string $readerType = null): Collection
+    public function toCollection(?object $import, $filePath, ?string $disk = null, ?string $readerType = null): Collection
     {
         $readerType = FileTypeDetector::detect($filePath, $readerType);
 
         return $this->reader->toCollection($import, $filePath, $readerType, $disk);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function queueImport(ShouldQueue $import, $filePath, ?string $disk = null, ?string $readerType = null)
+    public function queueImport(ShouldQueue $import, $filePath, ?string $disk = null, ?string $readerType = null): PendingDispatch|PendingBatch
     {
         return $this->import($import, $filePath, $disk, $readerType);
     }
 
     /**
-     * @param  object  $export
-     * @param  string|null  $fileName
-     *
      * @throws Exception
      */
-    protected function export($export, string $fileName, ?string $writerType = null): TemporaryFile
+    protected function export(object $export, string $fileName, ?string $writerType = null): TemporaryFile
     {
         $writerType = FileTypeDetector::detectStrict($fileName, $writerType);
 

--- a/src/ExcelServiceProvider.php
+++ b/src/ExcelServiceProvider.php
@@ -23,9 +23,6 @@ use Maatwebsite\Excel\Transactions\TransactionManager;
 
 class ExcelServiceProvider extends ServiceProvider
 {
-    /**
-     * {@inheritdoc}
-     */
     public function boot(): void
     {
         if ($this->app->runningInConsole()) {

--- a/src/Exceptions/ConcernConflictException.php
+++ b/src/Exceptions/ConcernConflictException.php
@@ -6,10 +6,7 @@ use LogicException;
 
 final class ConcernConflictException extends LogicException implements LaravelExcelException
 {
-    /**
-     * @return ConcernConflictException
-     */
-    public static function queryOrCollectionAndView()
+    public static function queryOrCollectionAndView(): ConcernConflictException
     {
         return new self('Cannot use FromQuery, FromArray or FromCollection and FromView on the same sheet.');
     }

--- a/src/Exceptions/NoFilePathGivenException.php
+++ b/src/Exceptions/NoFilePathGivenException.php
@@ -7,30 +7,20 @@ use Throwable;
 
 class NoFilePathGivenException extends InvalidArgumentException implements LaravelExcelException
 {
-    /**
-     * @param  string  $message
-     * @param  int  $code
-     */
     final public function __construct(
-        $message = 'A filepath needs to be passed.',
-        $code = 0,
+        string $message = 'A filepath needs to be passed.',
+        int $code = 0,
         ?Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);
     }
 
-    /**
-     * @return NoFilePathGivenException
-     */
-    public static function import()
+    public static function import(): NoFilePathGivenException
     {
         return new static('A filepath or UploadedFile needs to be passed to start the import.');
     }
 
-    /**
-     * @return NoFilePathGivenException
-     */
-    public static function export()
+    public static function export(): NoFilePathGivenException
     {
         return new static('A filepath needs to be passed in order to store the export.');
     }

--- a/src/Exceptions/NoFilenameGivenException.php
+++ b/src/Exceptions/NoFilenameGivenException.php
@@ -7,13 +7,9 @@ use Throwable;
 
 class NoFilenameGivenException extends InvalidArgumentException implements LaravelExcelException
 {
-    /**
-     * @param  string  $message
-     * @param  int  $code
-     */
     public function __construct(
-        $message = 'A filename needs to be passed in order to download the export',
-        $code = 0,
+        string $message = 'A filename needs to be passed in order to download the export',
+        int $code = 0,
         ?Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);

--- a/src/Exceptions/NoTypeDetectedException.php
+++ b/src/Exceptions/NoTypeDetectedException.php
@@ -7,13 +7,9 @@ use Throwable;
 
 class NoTypeDetectedException extends Exception implements LaravelExcelException
 {
-    /**
-     * @param  string  $message
-     * @param  int  $code
-     */
     public function __construct(
-        $message = 'No ReaderType or WriterType could be detected. Make sure you either pass a valid extension to the filename or pass an explicit type.',
-        $code = 0,
+        string $message = 'No ReaderType or WriterType could be detected. Make sure you either pass a valid extension to the filename or pass an explicit type.',
+        int $code = 0,
         ?Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);

--- a/src/Exceptions/RowSkippedException.php
+++ b/src/Exceptions/RowSkippedException.php
@@ -11,7 +11,7 @@ class RowSkippedException extends Exception
     /**
      * @var Failure[]
      */
-    private $failures;
+    private array $failures;
 
     public function __construct(Failure ...$failures)
     {

--- a/src/Exceptions/UnreadableFileException.php
+++ b/src/Exceptions/UnreadableFileException.php
@@ -7,13 +7,9 @@ use Throwable;
 
 class UnreadableFileException extends Exception implements LaravelExcelException
 {
-    /**
-     * @param  string  $message
-     * @param  int  $code
-     */
     public function __construct(
-        $message = 'File could not be read',
-        $code = 0,
+        string $message = 'File could not be read',
+        int $code = 0,
         ?Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\Excel;
 
+use Illuminate\Bus\PendingBatch;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use PhpOffice\PhpSpreadsheet\Exception;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -9,35 +10,18 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 interface Exporter
 {
     /**
-     * @param  object  $export
-     * @param  string|null  $fileName
-     * @return BinaryFileResponse
-     *
      * @throws Exception
      * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
      */
-    public function download($export, string $fileName, ?string $writerType = null, array $headers = []);
+    public function download(object $export, string $fileName, ?string $writerType = null, array $headers = []): BinaryFileResponse;
 
     /**
-     * @param  object  $export
-     * @param  mixed  $diskOptions
-     * @return bool
-     *
      * @throws Exception
      * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
      */
-    public function store($export, string $filePath, ?string $diskName = null, ?string $writerType = null, $diskOptions = []);
+    public function store(object $export, string $filePath, ?string $diskName = null, ?string $writerType = null, mixed $diskOptions = []): bool|PendingDispatch|PendingBatch;
 
-    /**
-     * @param  object  $export
-     * @param  mixed  $diskOptions
-     * @return PendingDispatch
-     */
-    public function queue($export, string $filePath, ?string $disk = null, ?string $writerType = null, $diskOptions = []);
+    public function queue(object $export, string $filePath, ?string $disk = null, ?string $writerType = null, mixed $diskOptions = []): PendingDispatch|PendingBatch;
 
-    /**
-     * @param  object  $export
-     * @return string
-     */
-    public function raw($export, string $writerType);
+    public function raw(object $export, string $writerType): string;
 }

--- a/src/Facades/Excel.php
+++ b/src/Facades/Excel.php
@@ -40,10 +40,8 @@ class Excel extends Facade
 
     /**
      * Get the registered name of the component.
-     *
-     * @return string
      */
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return 'excel';
     }

--- a/src/Factories/ReaderFactory.php
+++ b/src/Factories/ReaderFactory.php
@@ -20,14 +20,12 @@ class ReaderFactory
     use MapsCsvSettings;
 
     /**
-     * @param  object  $import
-     *
      * @throws Exception
      */
-    public static function make($import, TemporaryFile $file, ?string $readerType = null): IReader
+    public static function make(?object $import, TemporaryFile $file, ?string $readerType = null): IReader
     {
         $reader = IOFactory::createReader(
-            $readerType ?: static::identify($file)
+            $readerType ?: self::identify($file)
         );
 
         if (method_exists($reader, 'setReadDataOnly')) {

--- a/src/Factories/WriterFactory.php
+++ b/src/Factories/WriterFactory.php
@@ -20,11 +20,9 @@ class WriterFactory
     use MapsCsvSettings;
 
     /**
-     * @param  object  $export
-     *
      * @throws Exception
      */
-    public static function make(string $writerType, Spreadsheet $spreadsheet, $export, ?string $filePath = null): IWriter
+    public static function make(string $writerType, Spreadsheet $spreadsheet, object $export, ?string $filePath = null): IWriter
     {
         $writer = IOFactory::createWriter($spreadsheet, $writerType);
 
@@ -32,7 +30,7 @@ class WriterFactory
             config('excel.cache.driver', CacheManager::DRIVER_MEMORY) !== CacheManager::DRIVER_MEMORY
         );
 
-        if (static::includesCharts($export)) {
+        if (self::includesCharts($export)) {
             $writer->setIncludeCharts(true);
         }
 
@@ -44,7 +42,7 @@ class WriterFactory
             static::applyCsvSettings(config('excel.exports.csv', []));
 
             // Auto-detect TSV files and apply tab delimiter
-            if ($filePath && static::isTsvFile($filePath) && !($export instanceof WithCustomCsvSettings)) {
+            if ($filePath && self::isTsvFile($filePath) && !($export instanceof WithCustomCsvSettings)) {
                 static::applyCsvSettings(['delimiter' => "\t"]);
             }
 

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\Excel\Fakes;
 
+use Exception;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -13,8 +14,8 @@ use Illuminate\Support\Traits\Macroable;
 use Maatwebsite\Excel\Concerns\ShouldBatch;
 use Maatwebsite\Excel\Exporter;
 use Maatwebsite\Excel\Importer;
-use Maatwebsite\Excel\Reader;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\ExpectationFailedException;
 use SebastianBergmann\RecursionContext\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -23,45 +24,24 @@ class ExcelFake implements Exporter, Importer
 {
     use Macroable;
 
-    /**
-     * @var array
-     */
-    protected $downloads = [];
+    protected array $downloads = [];
 
-    /**
-     * @var array
-     */
-    protected $stored = [];
+    protected array $stored = [];
 
-    /**
-     * @var array
-     */
-    protected $queued = [];
+    protected array $queued = [];
 
-    /**
-     * @var array
-     */
-    protected $raws = [];
+    protected array $raws = [];
 
-    /**
-     * @var array
-     */
-    protected $imported = [];
+    protected array $imported = [];
 
-    /**
-     * @var bool
-     */
-    protected $matchByRegex = false;
+    protected bool $matchByRegex = false;
 
-    /**
-     * @var object|null
-     */
-    protected $job;
+    protected ?object $job = null;
 
     /**
      * {@inheritdoc}
      */
-    public function download($export, string $fileName, ?string $writerType = null, array $headers = [])
+    public function download($export, string $fileName, ?string $writerType = null, array $headers = []): BinaryFileResponse
     {
         $this->downloads[$fileName] = $export;
 
@@ -69,11 +49,9 @@ class ExcelFake implements Exporter, Importer
     }
 
     /**
-     * {@inheritdoc}
-     *
      * @param  string|null  $diskName  Fallback for usage with named properties
      */
-    public function store($export, string $filePath, ?string $disk = null, ?string $writerType = null, $diskOptions = [], ?string $diskName = null)
+    public function store($export, string $filePath, ?string $disk = null, ?string $writerType = null, $diskOptions = [], ?string $diskName = null): bool|PendingDispatch
     {
         if ($export instanceof ShouldQueue) {
             return $this->queue($export, $filePath, $disk ?: $diskName, $writerType);
@@ -84,10 +62,7 @@ class ExcelFake implements Exporter, Importer
         return true;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function queue($export, string $filePath, ?string $disk = null, ?string $writerType = null, $diskOptions = [])
+    public function queue($export, string $filePath, ?string $disk = null, ?string $writerType = null, $diskOptions = []): PendingDispatch
     {
         Queue::fake();
 
@@ -114,23 +89,14 @@ class ExcelFake implements Exporter, Importer
         return new PendingDispatch($this->job);
     }
 
-    /**
-     * @param  object  $export
-     * @return string
-     */
-    public function raw($export, string $writerType)
+    public function raw(object $export, string $writerType): string
     {
         $this->raws[$export::class] = $export;
 
         return 'RAW-CONTENTS';
     }
 
-    /**
-     * @param  object  $import
-     * @param  string|UploadedFile  $file
-     * @return Reader|PendingDispatch|PendingBatch
-     */
-    public function import($import, $file, ?string $disk = null, ?string $readerType = null)
+    public function import(object $import, string|UploadedFile $file, ?string $disk = null, ?string $readerType = null): static|PendingDispatch|PendingBatch
     {
         if ($import instanceof ShouldQueue) {
             return $this->queueImport($import, $file, $disk, $readerType);
@@ -143,11 +109,7 @@ class ExcelFake implements Exporter, Importer
         return $this;
     }
 
-    /**
-     * @param  object  $import
-     * @param  string|UploadedFile  $file
-     */
-    public function toArray($import, $file, ?string $disk = null, ?string $readerType = null): array
+    public function toArray(object $import, string|UploadedFile $file, ?string $disk = null, ?string $readerType = null): array
     {
         $filePath = ($file instanceof UploadedFile) ? $file->getFilename() : $file;
 
@@ -156,11 +118,7 @@ class ExcelFake implements Exporter, Importer
         return [];
     }
 
-    /**
-     * @param  object  $import
-     * @param  string|UploadedFile  $file
-     */
-    public function toCollection($import, $file, ?string $disk = null, ?string $readerType = null): Collection
+    public function toCollection(object $import, string|UploadedFile $file, ?string $disk = null, ?string $readerType = null): Collection
     {
         $filePath = ($file instanceof UploadedFile) ? $file->getFilename() : $file;
 
@@ -169,11 +127,7 @@ class ExcelFake implements Exporter, Importer
         return new Collection;
     }
 
-    /**
-     * @param  string|UploadedFile  $file
-     * @return PendingDispatch|PendingBatch
-     */
-    public function queueImport(ShouldQueue $import, $file, ?string $disk = null, ?string $readerType = null)
+    public function queueImport(ShouldQueue $import, string|UploadedFile $file, ?string $disk = null, ?string $readerType = null): PendingDispatch|PendingBatch
     {
         Queue::fake();
 
@@ -220,10 +174,7 @@ class ExcelFake implements Exporter, Importer
         $this->matchByRegex = false;
     }
 
-    /**
-     * @param  callable|null  $callback
-     */
-    public function assertDownloaded(string $fileName, $callback = null): void
+    public function assertDownloaded(string $fileName, ?callable $callback = null): void
     {
         $fileName = $this->assertArrayHasKey($fileName, $this->downloads, sprintf('%s is not downloaded', $fileName));
 
@@ -235,11 +186,7 @@ class ExcelFake implements Exporter, Importer
         );
     }
 
-    /**
-     * @param  string|callable|null  $disk
-     * @param  callable|null  $callback
-     */
-    public function assertStored(string $filePath, $disk = null, $callback = null): void
+    public function assertStored(string $filePath, string|callable|null $disk = null, ?callable $callback = null): void
     {
         if (is_callable($disk)) {
             $callback = $disk;
@@ -263,11 +210,7 @@ class ExcelFake implements Exporter, Importer
         );
     }
 
-    /**
-     * @param  string|callable|null  $disk
-     * @param  callable|null  $callback
-     */
-    public function assertQueued(string $filePath, $disk = null, $callback = null): void
+    public function assertQueued(string $filePath, string|callable|null $disk = null, ?callable $callback = null): void
     {
         if (is_callable($disk)) {
             $callback = $disk;
@@ -296,10 +239,7 @@ class ExcelFake implements Exporter, Importer
         Queue::assertPushedWithChain($this->job::class, $chain);
     }
 
-    /**
-     * @param  callable|null  $callback
-     */
-    public function assertExportedInRaw(string $classname, $callback = null): void
+    public function assertExportedInRaw(string $classname, ?callable $callback = null): void
     {
         Assert::assertArrayHasKey($classname, $this->raws, sprintf('%s is not exported in raw', $classname));
 
@@ -311,11 +251,7 @@ class ExcelFake implements Exporter, Importer
         );
     }
 
-    /**
-     * @param  string|callable|null  $disk
-     * @param  callable|null  $callback
-     */
-    public function assertImported(string $filePath, $disk = null, $callback = null): void
+    public function assertImported(string $filePath, string|callable|null $disk = null, ?callable $callback = null): void
     {
         if (is_callable($disk)) {
             $callback = $disk;
@@ -343,8 +279,6 @@ class ExcelFake implements Exporter, Importer
      * Asserts that an array has a specified key and returns the key if successful.
      *
      * @see matchByRegex for more information about file path matching
-     *
-     * @param  array  $array
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException

--- a/src/Files/Disk.php
+++ b/src/Files/Disk.php
@@ -12,34 +12,14 @@ use Illuminate\Contracts\Filesystem\Filesystem as IlluminateFilesystem;
  */
 class Disk
 {
-    /**
-     * @var IlluminateFilesystem
-     */
-    protected $disk;
-
-    /**
-     * @var string|null
-     */
-    protected $name;
-
-    /**
-     * @var array
-     */
-    protected $diskOptions;
-
-    public function __construct(IlluminateFilesystem $disk, ?string $name = null, array $diskOptions = [])
-    {
-        $this->disk        = $disk;
-        $this->name        = $name;
-        $this->diskOptions = $diskOptions;
+    public function __construct(
+        protected IlluminateFilesystem $disk,
+        protected ?string $name = null,
+        protected array $diskOptions = [],
+    ) {
     }
 
-    /**
-     * @param  string  $name
-     * @param  array  $arguments
-     * @return mixed
-     */
-    public function __call($name, $arguments)
+    public function __call(string $name, array $arguments): mixed
     {
         return $this->disk->{$name}(...$arguments);
     }

--- a/src/Files/Filesystem.php
+++ b/src/Files/Filesystem.php
@@ -6,8 +6,9 @@ use Illuminate\Contracts\Filesystem\Factory;
 
 class Filesystem
 {
-    public function __construct(private Factory $filesystem)
-    {
+    public function __construct(
+        private Factory $filesystem,
+    ) {
     }
 
     public function disk(?string $disk = null, array $diskOptions = []): Disk

--- a/src/Files/LocalTemporaryFile.php
+++ b/src/Files/LocalTemporaryFile.php
@@ -4,10 +4,7 @@ namespace Maatwebsite\Excel\Files;
 
 class LocalTemporaryFile extends TemporaryFile
 {
-    /**
-     * @var string
-     */
-    private $filePath;
+    private string $filePath;
 
     public function __construct(string $filePath)
     {
@@ -52,7 +49,7 @@ class LocalTemporaryFile extends TemporaryFile
     }
 
     /**
-     * @param @param string|resource $contents
+     * @param  string|resource  $contents
      */
     public function put($contents): void
     {

--- a/src/Files/RemoteTemporaryFile.php
+++ b/src/Files/RemoteTemporaryFile.php
@@ -6,13 +6,13 @@ use Illuminate\Support\Arr;
 
 class RemoteTemporaryFile extends TemporaryFile
 {
-    /**
-     * @var Disk|null
-     */
-    private $diskInstance;
+    private ?Disk $diskInstance = null;
 
-    public function __construct(private string $disk, private string $filename, private LocalTemporaryFile $localTemporaryFile)
-    {
+    public function __construct(
+        private string $disk,
+        private string $filename,
+        private LocalTemporaryFile $localTemporaryFile,
+    ) {
         $this->disk()->touch($this->filename);
     }
 
@@ -101,6 +101,6 @@ class RemoteTemporaryFile extends TemporaryFile
 
     public function disk(): Disk
     {
-        return $this->diskInstance ?: $this->diskInstance = app(Filesystem::class)->disk($this->disk);
+        return $this->diskInstance ??= app(Filesystem::class)->disk($this->disk);
     }
 }

--- a/src/Files/TemporaryFile.php
+++ b/src/Files/TemporaryFile.php
@@ -12,7 +12,7 @@ abstract class TemporaryFile
     abstract public function exists(): bool;
 
     /**
-     * @param @param string|resource $contents
+     * @param  string|resource  $contents
      */
     abstract public function put($contents);
 
@@ -30,10 +30,7 @@ abstract class TemporaryFile
         return $this;
     }
 
-    /**
-     * @param  string|UploadedFile  $filePath
-     */
-    public function copyFrom($filePath, ?string $disk = null): TemporaryFile
+    public function copyFrom(string|UploadedFile $filePath, ?string $disk = null): TemporaryFile
     {
         if ($filePath instanceof UploadedFile) {
             $readStream = fopen($filePath->getRealPath(), 'rb');

--- a/src/Files/TemporaryFileFactory.php
+++ b/src/Files/TemporaryFileFactory.php
@@ -6,8 +6,10 @@ use Illuminate\Support\Str;
 
 class TemporaryFileFactory
 {
-    public function __construct(private ?string $temporaryPath = null, private ?string $temporaryDisk = null)
-    {
+    public function __construct(
+        private ?string $temporaryPath = null,
+        private ?string $temporaryDisk = null,
+    ) {
     }
 
     public function make(?string $fileExtension = null): TemporaryFile

--- a/src/Filters/ChunkReadFilter.php
+++ b/src/Filters/ChunkReadFilter.php
@@ -6,19 +6,17 @@ use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
 
 class ChunkReadFilter implements IReadFilter
 {
-    /**
-     * @var int
-     */
-    private $endRow;
+    private int $endRow;
 
-    public function __construct(private int $headingRow, private int $startRow, int $chunkSize, private string $worksheetName)
-    {
+    public function __construct(
+        private int $headingRow,
+        private int $startRow,
+        int $chunkSize,
+        private string $worksheetName,
+    ) {
         $this->endRow = $this->startRow + $chunkSize;
     }
 
-    /**
-     * @param  string  $column
-     */
     public function readCell(string $columnAddress, int $row, string $worksheetName = ''): bool
     {
         //  Only read the heading row, and the rows that are configured in $this->_startRow and $this->_endRow

--- a/src/Filters/LimitFilter.php
+++ b/src/Filters/LimitFilter.php
@@ -6,19 +6,15 @@ use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
 
 class LimitFilter implements IReadFilter
 {
-    /**
-     * @var int
-     */
-    private $endRow;
+    private int $endRow;
 
-    public function __construct(private int $startRow, int $limit)
-    {
+    public function __construct(
+        private int $startRow,
+        int $limit,
+    ) {
         $this->endRow = $this->startRow + $limit;
     }
 
-    /**
-     * @param  string  $column
-     */
     public function readCell(string $columnAddress, int $row, string $worksheetName = ''): bool
     {
         return $row >= $this->startRow && $row <= $this->endRow;

--- a/src/HasEventBus.php
+++ b/src/HasEventBus.php
@@ -4,15 +4,9 @@ namespace Maatwebsite\Excel;
 
 trait HasEventBus
 {
-    /**
-     * @var array
-     */
-    protected static $globalEvents = [];
+    protected static array $globalEvents = [];
 
-    /**
-     * @var array
-     */
-    protected $events = [];
+    protected array $events = [];
 
     /**
      * Register local event listeners.
@@ -37,10 +31,7 @@ trait HasEventBus
         static::$globalEvents[$event][] = $listener;
     }
 
-    /**
-     * @param  object  $event
-     */
-    public function raise($event): void
+    public function raise(object $event): void
     {
         foreach ($this->listeners($event) as $listener) {
             $listener($event);
@@ -48,10 +39,9 @@ trait HasEventBus
     }
 
     /**
-     * @param  object  $event
      * @return callable[]
      */
-    public function listeners($event): array
+    public function listeners(object $event): array
     {
         $name = $event::class;
 

--- a/src/HeadingRowImport.php
+++ b/src/HeadingRowImport.php
@@ -8,12 +8,16 @@ use Maatwebsite\Excel\Concerns\WithMapping;
 use Maatwebsite\Excel\Concerns\WithStartRow;
 use Maatwebsite\Excel\Imports\HeadingRowFormatter;
 
+/**
+ * @implements WithMapping<array>
+ */
 class HeadingRowImport implements WithLimit, WithMapping, WithStartRow
 {
     use Importable;
 
-    public function __construct(private int $headingRow = 1)
-    {
+    public function __construct(
+        private int $headingRow = 1,
+    ) {
     }
 
     public function startRow(): int
@@ -26,10 +30,7 @@ class HeadingRowImport implements WithLimit, WithMapping, WithStartRow
         return 1;
     }
 
-    /**
-     * @param  mixed  $row
-     */
-    public function map($row): array
+    public function map(mixed $row): array
     {
         return HeadingRowFormatter::format($row);
     }

--- a/src/Helpers/FileTypeDetector.php
+++ b/src/Helpers/FileTypeDetector.php
@@ -8,11 +8,9 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 class FileTypeDetector
 {
     /**
-     * @return string|null
-     *
      * @throws NoTypeDetectedException
      */
-    public static function detect($filePath, ?string $type = null)
+    public static function detect($filePath, ?string $type = null): ?string
     {
         if ($type !== null) {
             return $type;

--- a/src/Importer.php
+++ b/src/Importer.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\Excel;
 
+use Illuminate\Bus\PendingBatch;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Collection;
@@ -9,28 +10,11 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 interface Importer
 {
-    /**
-     * @param  object  $import
-     * @param  string|UploadedFile  $filePath
-     * @return Reader|PendingDispatch
-     */
-    public function import($import, $filePath, ?string $disk = null, ?string $readerType = null);
+    public function import(object $import, string|UploadedFile $filePath, ?string $disk = null, ?string $readerType = null): static|Reader|PendingDispatch|PendingBatch;
 
-    /**
-     * @param  object  $import
-     * @param  string|UploadedFile  $filePath
-     */
-    public function toArray($import, $filePath, ?string $disk = null, ?string $readerType = null): array;
+    public function toArray(object $import, string|UploadedFile $filePath, ?string $disk = null, ?string $readerType = null): array;
 
-    /**
-     * @param  object  $import
-     * @param  string|UploadedFile  $filePath
-     */
-    public function toCollection($import, $filePath, ?string $disk = null, ?string $readerType = null): Collection;
+    public function toCollection(object $import, string|UploadedFile $filePath, ?string $disk = null, ?string $readerType = null): Collection;
 
-    /**
-     * @param  string|UploadedFile  $filePath
-     * @return PendingDispatch
-     */
-    public function queueImport(ShouldQueue $import, $filePath, ?string $disk = null, ?string $readerType = null);
+    public function queueImport(ShouldQueue $import, string|UploadedFile $filePath, ?string $disk = null, ?string $readerType = null): PendingDispatch|PendingBatch;
 }

--- a/src/Imports/EndRowFinder.php
+++ b/src/Imports/EndRowFinder.php
@@ -6,11 +6,7 @@ use Maatwebsite\Excel\Concerns\WithLimit;
 
 class EndRowFinder
 {
-    /**
-     * @param  object|WithLimit  $import
-     * @return int|null
-     */
-    public static function find($import, ?int $startRow = null, ?int $highestRow = null)
+    public static function find(?object $import, ?int $startRow = null, ?int $highestRow = null): ?int
     {
         if (!$import instanceof WithLimit) {
             return null;

--- a/src/Imports/HeadingRowExtractor.php
+++ b/src/Imports/HeadingRowExtractor.php
@@ -16,20 +16,14 @@ class HeadingRowExtractor
      */
     public const DEFAULT_HEADING_ROW = 1;
 
-    /**
-     * @param  WithHeadingRow|mixed  $importable
-     */
-    public static function headingRow($importable): int
+    public static function headingRow(mixed $importable): int
     {
         return method_exists($importable, 'headingRow')
             ? $importable->headingRow()
             : self::DEFAULT_HEADING_ROW;
     }
 
-    /**
-     * @param  WithHeadingRow|mixed  $importable
-     */
-    public static function determineStartRow($importable): int
+    public static function determineStartRow(mixed $importable): int
     {
         if ($importable instanceof WithStartRow) {
             return $importable->startRow();
@@ -41,10 +35,7 @@ class HeadingRowExtractor
             : self::DEFAULT_HEADING_ROW;
     }
 
-    /**
-     * @param  WithHeadingRow|mixed  $importable
-     */
-    public static function extract(Worksheet $worksheet, $importable): array
+    public static function extract(Worksheet $worksheet, mixed $importable): array
     {
         if (!$importable instanceof WithHeadingRow) {
             return [];
@@ -58,12 +49,7 @@ class HeadingRowExtractor
         return HeadingRowFormatter::format((new Row($headingRow))->toArray(null, false, false, $endColumn));
     }
 
-    /**
-     * @param  array  $headingRow
-     * @param  WithGroupedHeadingRow|mixed  $importable
-     * @return array
-     */
-    public static function extractGrouping($headingRow, $importable)
+    public static function extractGrouping(array $headingRow, mixed $importable): array
     {
         $headerIsGrouped = array_fill(0, count($headingRow), false);
 

--- a/src/Imports/HeadingRowFormatter.php
+++ b/src/Imports/HeadingRowFormatter.php
@@ -18,20 +18,14 @@ class HeadingRowFormatter
      */
     public const FORMATTER_SLUG = 'slug';
 
-    /**
-     * @var string
-     */
-    protected static $formatter;
+    protected static ?string $formatter;
 
     /**
      * @var callable[]
      */
-    protected static $customFormatters = [];
+    protected static array $customFormatters = [];
 
-    /**
-     * @var array
-     */
-    protected static $defaultFormatters = [
+    protected static array $defaultFormatters = [
         self::FORMATTER_NONE,
         self::FORMATTER_SLUG,
     ];
@@ -63,11 +57,7 @@ class HeadingRowFormatter
         static::default();
     }
 
-    /**
-     * @param  mixed  $value
-     * @return mixed
-     */
-    protected static function callFormatter($value, $key = null)
+    protected static function callFormatter(mixed $value, $key = null): mixed
     {
         static::$formatter ??= config('excel.imports.heading_row.formatter', self::FORMATTER_SLUG);
 

--- a/src/Imports/ModelImporter.php
+++ b/src/Imports/ModelImporter.php
@@ -22,14 +22,12 @@ class ModelImporter
 {
     use HasEventBus;
 
-    public function __construct(private ModelManager $manager)
-    {
+    public function __construct(
+        private ModelManager $manager,
+    ) {
     }
 
     /**
-     * @param  int|null  $startRow
-     * @param  string|null  $endColumn
-     *
      * @throws ValidationException
      */
     public function import(Worksheet $worksheet, ToModel $import, int $startRow = 1): void

--- a/src/Imports/ModelManager.php
+++ b/src/Imports/ModelManager.php
@@ -19,18 +19,14 @@ use Throwable;
 
 class ModelManager
 {
-    /**
-     * @var array
-     */
-    private $rows = [];
+    private array $rows = [];
 
-    /**
-     * @var bool
-     */
-    private $remembersRowNumber = false;
+    private bool $remembersRowNumber = false;
 
-    public function __construct(private RowValidator $validator, private CascadePersistManager $cascade)
-    {
+    public function __construct(
+        private RowValidator $validator,
+        private CascadePersistManager $cascade,
+    ) {
     }
 
     public function add(int $row, array $attributes): void
@@ -62,10 +58,9 @@ class ModelManager
     }
 
     /**
-     * @param  int|null  $rowNumber
      * @return Model[]|Collection
      */
-    public function toModels(ToModel $import, array $attributes, $rowNumber = null): Collection
+    public function toModels(ToModel $import, array $attributes, ?int $rowNumber = null): Collection
     {
         if ($this->remembersRowNumber) {
             $import->rememberRowNumber($rowNumber);

--- a/src/Imports/Persistence/CascadePersistManager.php
+++ b/src/Imports/Persistence/CascadePersistManager.php
@@ -11,10 +11,7 @@ use Maatwebsite\Excel\Transactions\TransactionHandler;
 /** @todo  */
 class CascadePersistManager
 {
-    /**
-     * @var TransactionHandler
-     */
-    private $transaction;
+    private TransactionHandler $transaction;
 
     public function __construct(TransactionHandler $transaction)
     {

--- a/src/Jobs/AfterImportJob.php
+++ b/src/Jobs/AfterImportJob.php
@@ -18,18 +18,17 @@ class AfterImportJob implements ShouldQueue
 {
     use Batchable, Dispatchable, HasEventBus, InteractsWithQueue, Queueable;
 
-    /**
-     * @var iterable
-     */
-    private $dependencyIds = [];
+    private iterable $dependencyIds = [];
 
     private $interval = 60;
 
     /**
      * @param  object  $import
      */
-    public function __construct(private $import, private Reader $reader)
-    {
+    public function __construct(
+        private $import,
+        private Reader $reader,
+    ) {
     }
 
     public function setInterval(int $interval): void

--- a/src/Jobs/AppendDataToSheet.php
+++ b/src/Jobs/AppendDataToSheet.php
@@ -16,43 +16,19 @@ class AppendDataToSheet implements ShouldQueue
 {
     use Batchable, Dispatchable, InteractsWithQueue, ProxyFailures, Queueable;
 
-    /**
-     * @var array
-     */
-    public $data = [];
-
-    /**
-     * @var string
-     */
-    public $temporaryFile;
-
-    /**
-     * @var string
-     */
-    public $writerType;
-
-    /**
-     * @var int
-     */
-    public $sheetIndex;
-
-    /**
-     * @param  object  $sheetExport
-     */
-    public function __construct(public $sheetExport, TemporaryFile $temporaryFile, string $writerType, int $sheetIndex, array $data)
-    {
-        $this->data          = $data;
-        $this->temporaryFile = $temporaryFile;
-        $this->writerType    = $writerType;
-        $this->sheetIndex    = $sheetIndex;
+    public function __construct(
+        public object $sheetExport,
+        public TemporaryFile $temporaryFile,
+        public string $writerType,
+        public int $sheetIndex,
+        public array $data,
+    ) {
     }
 
     /**
      * Get the middleware the job should be dispatched through.
-     *
-     * @return array
      */
-    public function middleware()
+    public function middleware(): array
     {
         return (method_exists($this->sheetExport, 'middleware')) ? $this->sheetExport->middleware() : [];
     }

--- a/src/Jobs/AppendPaginatedToSheet.php
+++ b/src/Jobs/AppendPaginatedToSheet.php
@@ -21,58 +21,20 @@ class AppendPaginatedToSheet implements ShouldQueue
 {
     use Batchable, Dispatchable, InteractsWithQueue, ProxyFailures, Queueable;
 
-    /**
-     * @var TemporaryFile
-     */
-    public $temporaryFile;
-
-    /**
-     * @var string
-     */
-    public $writerType;
-
-    /**
-     * @var int
-     */
-    public $sheetIndex;
-
-    /**
-     * @var FromQuery
-     */
-    public $sheetExport;
-
-    /**
-     * @var int
-     */
-    public $page;
-
-    /**
-     * @var int
-     */
-    public $perPage;
-
     public function __construct(
-        FromQuery $sheetExport,
-        TemporaryFile $temporaryFile,
-        string $writerType,
-        int $sheetIndex,
-        int $page,
-        int $perPage
+        public FromQuery $sheetExport,
+        public TemporaryFile $temporaryFile,
+        public string $writerType,
+        public int $sheetIndex,
+        public int $page,
+        public int $perPage,
     ) {
-        $this->sheetExport   = $sheetExport;
-        $this->temporaryFile = $temporaryFile;
-        $this->writerType    = $writerType;
-        $this->sheetIndex    = $sheetIndex;
-        $this->page          = $page;
-        $this->perPage       = $perPage;
     }
 
     /**
      * Get the middleware the job should be dispatched through.
-     *
-     * @return array
      */
-    public function middleware()
+    public function middleware(): array
     {
         return (method_exists($this->sheetExport, 'middleware')) ? $this->sheetExport->middleware() : [];
     }
@@ -99,10 +61,7 @@ class AppendPaginatedToSheet implements ShouldQueue
         });
     }
 
-    /**
-     * @param  Builder|Relation|EloquentBuilder|ScoutBuilder  $query
-     */
-    protected function chunk($query)
+    protected function chunk(Builder|Relation|EloquentBuilder|ScoutBuilder $query)
     {
         if ($query instanceof ScoutBuilder) {
             return $query->paginate($this->perPage, 'page', $this->page)->items();

--- a/src/Jobs/AppendQueryToSheet.php
+++ b/src/Jobs/AppendQueryToSheet.php
@@ -20,58 +20,20 @@ class AppendQueryToSheet implements ShouldQueue
 {
     use Batchable, Dispatchable, HasEventBus, InteractsWithQueue, ProxyFailures, Queueable;
 
-    /**
-     * @var TemporaryFile
-     */
-    public $temporaryFile;
-
-    /**
-     * @var string
-     */
-    public $writerType;
-
-    /**
-     * @var int
-     */
-    public $sheetIndex;
-
-    /**
-     * @var FromQuery
-     */
-    public $sheetExport;
-
-    /**
-     * @var int
-     */
-    public $page;
-
-    /**
-     * @var int
-     */
-    public $chunkSize;
-
     public function __construct(
-        FromQuery $sheetExport,
-        TemporaryFile $temporaryFile,
-        string $writerType,
-        int $sheetIndex,
-        int $page,
-        int $chunkSize
+        public FromQuery $sheetExport,
+        public TemporaryFile $temporaryFile,
+        public string $writerType,
+        public int $sheetIndex,
+        public int $page,
+        public int $chunkSize,
     ) {
-        $this->sheetExport   = $sheetExport;
-        $this->temporaryFile = $temporaryFile;
-        $this->writerType    = $writerType;
-        $this->sheetIndex    = $sheetIndex;
-        $this->page          = $page;
-        $this->chunkSize     = $chunkSize;
     }
 
     /**
      * Get the middleware the job should be dispatched through.
-     *
-     * @return array
      */
-    public function middleware()
+    public function middleware(): array
     {
         return (method_exists($this->sheetExport, 'middleware')) ? $this->sheetExport->middleware() : [];
     }

--- a/src/Jobs/AppendViewToSheet.php
+++ b/src/Jobs/AppendViewToSheet.php
@@ -17,43 +17,18 @@ class AppendViewToSheet implements ShouldQueue
 {
     use Batchable, Dispatchable, InteractsWithQueue, Queueable;
 
-    /**
-     * @var TemporaryFile
-     */
-    public $temporaryFile;
-
-    /**
-     * @var string
-     */
-    public $writerType;
-
-    /**
-     * @var int
-     */
-    public $sheetIndex;
-
-    /**
-     * @var FromView
-     */
-    public $sheetExport;
-
-    /**
-     * @param  array  $data
-     */
-    public function __construct(FromView $sheetExport, TemporaryFile $temporaryFile, string $writerType, int $sheetIndex)
-    {
-        $this->sheetExport   = $sheetExport;
-        $this->temporaryFile = $temporaryFile;
-        $this->writerType    = $writerType;
-        $this->sheetIndex    = $sheetIndex;
+    public function __construct(
+        public FromView $sheetExport,
+        public TemporaryFile $temporaryFile,
+        public string $writerType,
+        public int $sheetIndex,
+    ) {
     }
 
     /**
      * Get the middleware the job should be dispatched through.
-     *
-     * @return array
      */
-    public function middleware()
+    public function middleware(): array
     {
         return (method_exists($this->sheetExport, 'middleware')) ? $this->sheetExport->middleware() : [];
     }

--- a/src/Jobs/CloseSheet.php
+++ b/src/Jobs/CloseSheet.php
@@ -16,11 +16,12 @@ class CloseSheet implements ShouldQueue
 {
     use Batchable, Dispatchable, InteractsWithQueue, ProxyFailures, Queueable;
 
-    /**
-     * @param  object  $sheetExport
-     */
-    public function __construct(private $sheetExport, private TemporaryFile $temporaryFile, private string $writerType, private int $sheetIndex)
-    {
+    public function __construct(
+        private object $sheetExport,
+        private TemporaryFile $temporaryFile,
+        private string $writerType,
+        private int $sheetIndex,
+    ) {
     }
 
     /**

--- a/src/Jobs/Middleware/LocalizeJob.php
+++ b/src/Jobs/Middleware/LocalizeJob.php
@@ -15,17 +15,15 @@ class LocalizeJob
      *
      * @param  object  $localizable
      */
-    public function __construct(private $localizable)
-    {
+    public function __construct(
+        private $localizable,
+    ) {
     }
 
     /**
      * Handles the job.
-     *
-     * @param  mixed  $job
-     * @return mixed
      */
-    public function handle($job, Closure $next)
+    public function handle(mixed $job, Closure $next): mixed
     {
         $locale = value(function () {
             if ($this->localizable instanceof HasLocalePreference) {

--- a/src/Jobs/QueueExport.php
+++ b/src/Jobs/QueueExport.php
@@ -18,19 +18,17 @@ class QueueExport implements ShouldQueue
 {
     use Batchable, Dispatchable, ExtendedQueueable, InteractsWithQueue;
 
-    /**
-     * @param  object  $export
-     */
-    public function __construct(public $export, private TemporaryFile $temporaryFile, private string $writerType)
-    {
+    public function __construct(
+        public object $export,
+        private TemporaryFile $temporaryFile,
+        private string $writerType,
+    ) {
     }
 
     /**
      * Get the middleware the job should be dispatched through.
-     *
-     * @return array
      */
-    public function middleware()
+    public function middleware(): array
     {
         return (method_exists($this->export, 'middleware')) ? $this->export->middleware() : [];
     }

--- a/src/Jobs/QueueImport.php
+++ b/src/Jobs/QueueImport.php
@@ -9,15 +9,9 @@ class QueueImport implements ShouldQueue
 {
     use Dispatchable, ExtendedQueueable;
 
-    /**
-     * @var int
-     */
-    public $tries;
+    public ?int $tries;
 
-    /**
-     * @var int
-     */
-    public $timeout;
+    public ?int $timeout;
 
     public function __construct(?ShouldQueue $import = null)
     {

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -29,46 +29,35 @@ class ReadChunk implements ShouldQueue
 {
     use Batchable, HasEventBus, InteractsWithQueue, Queueable;
 
-    /**
-     * @var int
-     */
-    public $timeout;
+    public ?int $timeout;
+
+    public ?int $tries;
+
+    public ?int $maxExceptions;
+
+    public ?int $backoff;
 
     /**
-     * @var int
-     */
-    public $tries;
-
-    /**
-     * @var int
-     */
-    public $maxExceptions;
-
-    /**
-     * @var int
-     */
-    public $backoff;
-
-    /**
-     * @var string
+     * @var ?string
      */
     public $queue;
 
     /**
-     * @var string
+     * @var ?string
      */
     public $connection;
 
-    /**
-     * @var string
-     */
-    private $uniqueId;
+    private string $uniqueId;
 
-    /**
-     * @param  object  $sheetImport
-     */
-    public function __construct(private WithChunkReading $import, private IReader $reader, private TemporaryFile $temporaryFile, private string $sheetName, private $sheetImport, private int $startRow, private int $chunkSize)
-    {
+    public function __construct(
+        private WithChunkReading $import,
+        private IReader $reader,
+        private TemporaryFile $temporaryFile,
+        private string $sheetName,
+        private object $sheetImport,
+        private int $startRow,
+        private int $chunkSize,
+    ) {
         $this->timeout       = $this->import->timeout ?? null;
         $this->tries         = $this->import->tries ?? null;
         $this->maxExceptions = $this->import->maxExceptions ?? null;
@@ -94,20 +83,16 @@ class ReadChunk implements ShouldQueue
 
     /**
      * Get the middleware the job should be dispatched through.
-     *
-     * @return array
      */
-    public function middleware()
+    public function middleware(): array
     {
         return (method_exists($this->import, 'middleware')) ? $this->import->middleware() : [];
     }
 
     /**
      * Determine the time at which the job should timeout.
-     *
-     * @return \DateTime
      */
-    public function retryUntil()
+    public function retryUntil(): ?\DateTime
     {
         return (method_exists($this->import, 'retryUntil')) ? $this->import->retryUntil() : null;
     }

--- a/src/Jobs/StoreQueuedExport.php
+++ b/src/Jobs/StoreQueuedExport.php
@@ -14,11 +14,12 @@ class StoreQueuedExport implements ShouldQueue
 {
     use Batchable, Dispatchable, InteractsWithQueue, Queueable;
 
-    /**
-     * @param  array|string  $diskOptions
-     */
-    public function __construct(private TemporaryFile $temporaryFile, private string $filePath, private ?string $disk = null, private $diskOptions = [])
-    {
+    public function __construct(
+        private TemporaryFile $temporaryFile,
+        private string $filePath,
+        private ?string $disk = null,
+        private array|string $diskOptions = [],
+    ) {
     }
 
     public function handle(Filesystem $filesystem): void

--- a/src/Middleware/CellMiddleware.php
+++ b/src/Middleware/CellMiddleware.php
@@ -4,9 +4,5 @@ namespace Maatwebsite\Excel\Middleware;
 
 abstract class CellMiddleware
 {
-    /**
-     * @param  mixed  $value
-     * @return mixed
-     */
-    abstract public function __invoke($value, callable $next);
+    abstract public function __invoke(mixed $value, callable $next): mixed;
 }

--- a/src/Middleware/ConvertEmptyCellValuesToNull.php
+++ b/src/Middleware/ConvertEmptyCellValuesToNull.php
@@ -4,11 +4,7 @@ namespace Maatwebsite\Excel\Middleware;
 
 class ConvertEmptyCellValuesToNull extends CellMiddleware
 {
-    /**
-     * @param  mixed  $value
-     * @return mixed
-     */
-    public function __invoke($value, callable $next)
+    public function __invoke(mixed $value, callable $next): mixed
     {
         return $next(
             $value === '' ? null : $value

--- a/src/Middleware/TrimCellValue.php
+++ b/src/Middleware/TrimCellValue.php
@@ -4,11 +4,7 @@ namespace Maatwebsite\Excel\Middleware;
 
 class TrimCellValue extends CellMiddleware
 {
-    /**
-     * @param  mixed  $value
-     * @return mixed
-     */
-    public function __invoke($value, callable $next)
+    public function __invoke(mixed $value, callable $next): mixed
     {
         if (!is_string($value)) {
             return $next($value);

--- a/src/Mixins/DownloadCollectionMixin.php
+++ b/src/Mixins/DownloadCollectionMixin.php
@@ -11,30 +11,21 @@ use Maatwebsite\Excel\Sheet;
 
 class DownloadCollectionMixin
 {
-    /**
-     * @return callable
-     */
-    public function downloadExcel()
+    public function downloadExcel(): callable
     {
         return function (string $fileName, ?string $writerType = null, $withHeadings = false, array $responseHeaders = []) {
             $export = new class($this, $withHeadings) implements FromCollection, WithHeadings
             {
                 use Exportable;
 
-                /**
-                 * @var Collection
-                 */
-                private $collection;
+                private Collection $collection;
 
                 public function __construct(Collection $collection, private bool $withHeadings = false)
                 {
                     $this->collection = $collection->toBase();
                 }
 
-                /**
-                 * @return Collection
-                 */
-                public function collection()
+                public function collection(): Collection
                 {
                     return $this->collection;
                 }

--- a/src/Mixins/DownloadQueryMacro.php
+++ b/src/Mixins/DownloadQueryMacro.php
@@ -17,17 +17,13 @@ class DownloadQueryMacro
             {
                 use Exportable;
 
-                /**
-                 * @param  Builder  $query
-                 */
-                public function __construct(private $query, private bool $withHeadings = false)
-                {
+                public function __construct(
+                    private Builder $query,
+                    private bool $withHeadings = false,
+                ) {
                 }
 
-                /**
-                 * @return Builder
-                 */
-                public function query()
+                public function query(): Builder
                 {
                     return $this->query;
                 }

--- a/src/Mixins/ImportAsMacro.php
+++ b/src/Mixins/ImportAsMacro.php
@@ -11,6 +11,7 @@ class ImportAsMacro
     public function __invoke()
     {
         return function (string $filename, callable $mapping, ?string $disk = null, ?string $readerType = null) {
+            /** @phpstan-ignore method.notFound */
             $import = new class($this->getModel()::class, $mapping) implements ToModel
             {
                 use Importable;
@@ -20,15 +21,17 @@ class ImportAsMacro
                  */
                 private $mapping;
 
-                public function __construct(private string $model, callable $mapping)
-                {
+                public function __construct(
+                    private string $model,
+                    callable $mapping,
+                ) {
                     $this->mapping = $mapping;
                 }
 
                 /**
                  * @return Model|Model[]|null
                  */
-                public function model(array $row)
+                public function model(array $row): Model|array|null
                 {
                     return (new $this->model)->fill(
                         ($this->mapping)($row)

--- a/src/Mixins/ImportMacro.php
+++ b/src/Mixins/ImportMacro.php
@@ -12,18 +12,20 @@ class ImportMacro
     public function __invoke()
     {
         return function (string $filename, ?string $disk = null, ?string $readerType = null) {
+            /** @phpstan-ignore method.notFound */
             $import = new class($this->getModel()::class) implements ToModel, WithHeadingRow
             {
                 use Importable;
 
-                public function __construct(private string $model)
-                {
+                public function __construct(
+                    private string $model,
+                ) {
                 }
 
                 /**
                  * @return Model|Model[]|null
                  */
-                public function model(array $row)
+                public function model(array $row): Model|array|null
                 {
                     return (new $this->model)->fill($row);
                 }

--- a/src/Mixins/StoreCollectionMixin.php
+++ b/src/Mixins/StoreCollectionMixin.php
@@ -9,30 +9,21 @@ use Maatwebsite\Excel\Concerns\WithHeadings;
 
 class StoreCollectionMixin
 {
-    /**
-     * @return callable
-     */
-    public function storeExcel()
+    public function storeExcel(): callable
     {
         return function (string $filePath, ?string $disk = null, ?string $writerType = null, $withHeadings = false) {
             $export = new class($this, $withHeadings) implements FromCollection, WithHeadings
             {
                 use Exportable;
 
-                /**
-                 * @var Collection
-                 */
-                private $collection;
+                private Collection $collection;
 
                 public function __construct(Collection $collection, private bool $withHeadings = false)
                 {
                     $this->collection = $collection->toBase();
                 }
 
-                /**
-                 * @return Collection
-                 */
-                public function collection()
+                public function collection(): Collection
                 {
                     return $this->collection;
                 }

--- a/src/Mixins/StoreQueryMacro.php
+++ b/src/Mixins/StoreQueryMacro.php
@@ -17,17 +17,13 @@ class StoreQueryMacro
             {
                 use Exportable;
 
-                /**
-                 * @param  Builder  $query
-                 */
-                public function __construct(private $query, private bool $withHeadings = false)
-                {
+                public function __construct(
+                    private Builder $query,
+                    private bool $withHeadings = false,
+                ) {
                 }
 
-                /**
-                 * @return Builder
-                 */
-                public function query()
+                public function query(): Builder
                 {
                     return $this->query;
                 }

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -28,34 +28,16 @@ use Traversable;
 
 class QueuedWriter
 {
-    /**
-     * @var Writer
-     */
-    protected $writer;
+    protected int $chunkSize;
 
-    /**
-     * @var int
-     */
-    protected $chunkSize;
-
-    /**
-     * @var TemporaryFileFactory
-     */
-    protected $temporaryFileFactory;
-
-    public function __construct(Writer $writer, TemporaryFileFactory $temporaryFileFactory)
-    {
-        $this->writer               = $writer;
-        $this->chunkSize            = config('excel.exports.chunk_size', 1000);
-        $this->temporaryFileFactory = $temporaryFileFactory;
+    public function __construct(
+        protected Writer $writer,
+        protected TemporaryFileFactory $temporaryFileFactory,
+    ) {
+        $this->chunkSize = config('excel.exports.chunk_size', 1000);
     }
 
-    /**
-     * @param  object  $export
-     * @param  array|string  $diskOptions
-     * @return PendingDispatch|PendingBatch
-     */
-    public function store($export, string $filePath, ?string $disk = null, ?string $writerType = null, $diskOptions = [])
+    public function store(object $export, string $filePath, ?string $disk = null, ?string $writerType = null, array|string $diskOptions = []): PendingDispatch|PendingBatch
     {
         $extension     = pathinfo($filePath, PATHINFO_EXTENSION);
         $temporaryFile = $this->temporaryFileFactory->make($extension);
@@ -84,10 +66,7 @@ class QueuedWriter
         );
     }
 
-    /**
-     * @param  object  $export
-     */
-    private function buildExportJobs($export, TemporaryFile $temporaryFile, string $writerType): Collection
+    private function buildExportJobs(object $export, TemporaryFile $temporaryFile, string $writerType): Collection
     {
         $sheetExports = [$export];
         if ($export instanceof WithMultipleSheets) {
@@ -110,15 +89,12 @@ class QueuedWriter
         return $jobs;
     }
 
-    /**
-     * @return Collection|LazyCollection
-     */
     private function exportCollection(
         FromCollection $export,
         TemporaryFile $temporaryFile,
         string $writerType,
         int $sheetIndex
-    ) {
+    ): Collection|LazyCollection {
         return $export
             ->collection()
             ->chunk($this->getChunkSize($export))
@@ -218,10 +194,7 @@ class QueuedWriter
         return $jobs;
     }
 
-    /**
-     * @param  object|WithCustomChunkSize  $export
-     */
-    private function getChunkSize($export): int
+    private function getChunkSize(object $export): int
     {
         if ($export instanceof WithCustomChunkSize) {
             return $export->chunkSize();

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -36,42 +36,26 @@ class Reader
 {
     use DelegatedMacroable, HasEventBus;
 
-    /**
-     * @var ?Spreadsheet
-     */
-    protected $spreadsheet;
+    protected ?Spreadsheet $spreadsheet = null;
 
     /**
      * @var ?object[]
      */
-    protected $sheetImports = [];
+    protected ?array $sheetImports = [];
 
-    /**
-     * @var TemporaryFile
-     */
-    protected $currentFile;
+    protected TemporaryFile $currentFile;
 
-    /**
-     * @var TemporaryFileFactory
-     */
-    protected $temporaryFileFactory;
+    protected TransactionHandler $transaction;
 
-    /**
-     * @var TransactionHandler
-     */
-    protected $transaction;
+    protected IReader $reader;
 
-    /**
-     * @var IReader
-     */
-    protected $reader;
-
-    public function __construct(TemporaryFileFactory $temporaryFileFactory, TransactionHandler $transaction)
-    {
+    public function __construct(
+        protected TemporaryFileFactory $temporaryFileFactory,
+        TransactionHandler $transaction,
+    ) {
         $this->setDefaultValueBinder();
 
-        $this->transaction          = $transaction;
-        $this->temporaryFileFactory = $temporaryFileFactory;
+        $this->transaction = $transaction;
     }
 
     public function __sleep()
@@ -85,15 +69,13 @@ class Reader
     }
 
     /**
-     * @param  object  $import
-     * @param  string|UploadedFile  $filePath
      * @return PendingDispatch|$this
      *
      * @throws NoTypeDetectedException
      * @throws FileNotFoundException
      * @throws Exception
      */
-    public function read($import, $filePath, ?string $readerType = null, ?string $disk = null)
+    public function read(object $import, string|UploadedFile $filePath, ?string $readerType = null, ?string $disk = null)
     {
         $this->reader = $this->getReader($import, $filePath, $readerType, $disk);
 
@@ -136,15 +118,12 @@ class Reader
     }
 
     /**
-     * @param  object  $import
-     * @param  string|UploadedFile  $filePath
-     *
      * @throws FileNotFoundException
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @throws NoTypeDetectedException
      * @throws SheetNotFoundException
      */
-    public function toArray($import, $filePath, ?string $readerType = null, ?string $disk = null): array
+    public function toArray(object $import, string|UploadedFile $filePath, ?string $readerType = null, ?string $disk = null): array
     {
         $this->reader = $this->getReader($import, $filePath, $readerType, $disk);
 
@@ -177,15 +156,12 @@ class Reader
     }
 
     /**
-     * @param  object  $import
-     * @param  string|UploadedFile  $filePath
-     *
      * @throws FileNotFoundException
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @throws NoTypeDetectedException
      * @throws SheetNotFoundException
      */
-    public function toCollection($import, $filePath, ?string $readerType = null, ?string $disk = null): Collection
+    public function toCollection(?object $import, string|UploadedFile $filePath, ?string $readerType = null, ?string $disk = null): Collection
     {
         $this->reader = $this->getReader($import, $filePath, $readerType, $disk);
         $this->loadSpreadsheet($import);
@@ -216,10 +192,7 @@ class Reader
         return $sheets;
     }
 
-    /**
-     * @return Spreadsheet
-     */
-    public function getDelegate()
+    public function getDelegate(): Spreadsheet
     {
         return $this->spreadsheet;
     }
@@ -236,10 +209,7 @@ class Reader
         return $this;
     }
 
-    /**
-     * @param  object  $import
-     */
-    public function loadSpreadsheet($import): void
+    public function loadSpreadsheet(?object $import): void
     {
         $this->sheetImports = $this->buildSheetImports($import);
 
@@ -261,18 +231,12 @@ class Reader
         );
     }
 
-    /**
-     * @param  object  $import
-     */
-    public function beforeImport($import): void
+    public function beforeImport(?object $import): void
     {
         $this->raise(new BeforeImport($this, $import));
     }
 
-    /**
-     * @param  object  $import
-     */
-    public function afterImport($import): void
+    public function afterImport(?object $import): void
     {
         $this->raise(new AfterImport($this, $import));
 
@@ -284,10 +248,7 @@ class Reader
         return $this->reader;
     }
 
-    /**
-     * @param  object  $import
-     */
-    public function getWorksheets($import): array
+    public function getWorksheets(object $import): array
     {
         // Csv doesn't have worksheets.
         if (!method_exists($this->reader, 'listWorksheetNames')) {
@@ -338,12 +299,10 @@ class Reader
     }
 
     /**
-     * @return Sheet|null
-     *
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @throws SheetNotFoundException
      */
-    protected function getSheet($import, $sheetImport, $index)
+    protected function getSheet($import, $sheetImport, $index): ?Sheet
     {
         try {
             return Sheet::make($this->spreadsheet, $index);
@@ -364,10 +323,7 @@ class Reader
         }
     }
 
-    /**
-     * @param  object  $import
-     */
-    private function buildSheetImports($import): array
+    private function buildSheetImports(?object $import): array
     {
         $sheetImports = [];
         if ($import instanceof WithMultipleSheets) {
@@ -391,15 +347,12 @@ class Reader
     }
 
     /**
-     * @param  object  $import
-     * @param  string|UploadedFile  $filePath
-     *
      * @throws FileNotFoundException
      * @throws NoTypeDetectedException
      * @throws Exception
      * @throws InvalidArgumentException
      */
-    private function getReader($import, $filePath, ?string $readerType = null, ?string $disk = null): IReader
+    private function getReader(?object $import, string|UploadedFile $filePath, ?string $readerType = null, ?string $disk = null): IReader
     {
         $shouldQueue = $import instanceof ShouldQueue;
         if ($shouldQueue && !$import instanceof WithChunkReading) {

--- a/src/RegistersCustomConcerns.php
+++ b/src/RegistersCustomConcerns.php
@@ -10,10 +10,7 @@ use Maatwebsite\Excel\Events\Event;
 
 trait RegistersCustomConcerns
 {
-    /**
-     * @var array
-     */
-    private static $eventMap = [
+    private static array $eventMap = [
         BeforeWriting::class => Writer::class,
         BeforeExport::class  => Writer::class,
         BeforeSheet::class   => Sheet::class,

--- a/src/Row.php
+++ b/src/Row.php
@@ -12,46 +12,19 @@ class Row implements ArrayAccess
 {
     use DelegatedMacroable;
 
-    /**
-     * @var array
-     */
-    protected $headingRow = [];
+    protected ?Closure $preparationCallback = null;
 
-    /**
-     * @var array
-     */
-    protected $headerIsGrouped = [];
+    protected ?array $rowCache = null;
 
-    /**
-     * @var Closure
-     */
-    protected $preparationCallback;
+    protected ?bool $rowCacheFormatData = null;
 
-    /**
-     * @var SpreadsheetRow
-     */
-    protected $row;
+    protected ?string $rowCacheEndColumn = null;
 
-    /**
-     * @var array|null
-     */
-    protected $rowCache;
-
-    /**
-     * @var bool|null
-     */
-    protected $rowCacheFormatData;
-
-    /**
-     * @var string|null
-     */
-    protected $rowCacheEndColumn;
-
-    public function __construct(SpreadsheetRow $row, array $headingRow = [], array $headerIsGrouped = [])
-    {
-        $this->row             = $row;
-        $this->headingRow      = $headingRow;
-        $this->headerIsGrouped = $headerIsGrouped;
+    public function __construct(
+        protected SpreadsheetRow $row,
+        protected array $headingRow = [],
+        protected array $headerIsGrouped = [],
+    ) {
     }
 
     public function getDelegate(): SpreadsheetRow
@@ -59,23 +32,12 @@ class Row implements ArrayAccess
         return $this->row;
     }
 
-    /**
-     * @param  null  $nullValue
-     * @param  bool  $calculateFormulas
-     * @param  bool  $formatData
-     */
-    public function toCollection($nullValue = null, $calculateFormulas = false, $formatData = true, ?string $endColumn = null): Collection
+    public function toCollection(mixed $nullValue = null, bool $calculateFormulas = false, bool $formatData = true, ?string $endColumn = null): Collection
     {
         return new Collection($this->toArray($nullValue, $calculateFormulas, $formatData, $endColumn));
     }
 
-    /**
-     * @param  null  $nullValue
-     * @param  bool  $calculateFormulas
-     * @param  bool  $formatData
-     * @return array
-     */
-    public function toArray($nullValue = null, $calculateFormulas = false, $formatData = true, ?string $endColumn = null)
+    public function toArray(mixed $nullValue = null, bool $calculateFormulas = false, bool $formatData = true, ?string $endColumn = null): array
     {
         if (is_array($this->rowCache) && ($this->rowCacheFormatData === $formatData) && ($this->rowCacheEndColumn === $endColumn)) {
             return $this->rowCache;
@@ -111,10 +73,7 @@ class Row implements ArrayAccess
         return $cells;
     }
 
-    /**
-     * @param  bool  $calculateFormulas
-     */
-    public function isEmpty($calculateFormulas = false, ?string $endColumn = null): bool
+    public function isEmpty(bool $calculateFormulas = false, ?string $endColumn = null): bool
     {
         return count(array_filter($this->toArray(null, $calculateFormulas, false, $endColumn))) === 0;
     }

--- a/src/SettingsProvider.php
+++ b/src/SettingsProvider.php
@@ -7,8 +7,9 @@ use PhpOffice\PhpSpreadsheet\Settings;
 
 class SettingsProvider
 {
-    public function __construct(private CacheManager $cache)
-    {
+    public function __construct(
+        private CacheManager $cache,
+    ) {
     }
 
     /**

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -68,35 +68,24 @@ class Sheet
 {
     use DelegatedMacroable, HasEventBus;
 
-    /**
-     * @var int
-     */
-    protected $chunkSize;
+    protected int $chunkSize;
 
-    /**
-     * @var TemporaryFileFactory
-     */
-    protected $temporaryFileFactory;
+    protected TemporaryFileFactory $temporaryFileFactory;
 
-    /**
-     * @var object
-     */
-    protected $exportable;
+    protected ?object $exportable = null;
 
-    final public function __construct(private Worksheet $worksheet)
-    {
+    final public function __construct(
+        private Worksheet $worksheet,
+    ) {
         $this->chunkSize            = config('excel.exports.chunk_size', 100);
         $this->temporaryFileFactory = app(TemporaryFileFactory::class);
     }
 
     /**
-     * @param  string|int  $index
-     * @return Sheet
-     *
      * @throws Exception
      * @throws SheetNotFoundException
      */
-    public static function make(Spreadsheet $spreadsheet, $index)
+    public static function make(Spreadsheet $spreadsheet, string|int $index): Sheet
     {
         if (is_numeric($index)) {
             return self::byIndex($spreadsheet, $index);
@@ -131,11 +120,9 @@ class Sheet
     }
 
     /**
-     * @param  object  $sheetExport
-     *
      * @throws Exception
      */
-    public function open($sheetExport): void
+    public function open(object $sheetExport): void
     {
         $this->exportable = $sheetExport;
 
@@ -178,12 +165,10 @@ class Sheet
     }
 
     /**
-     * @param  object  $sheetExport
-     *
      * @throws Exception
      * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception
      */
-    public function export($sheetExport): void
+    public function export(object $sheetExport): void
     {
         $this->open($sheetExport);
 
@@ -214,10 +199,7 @@ class Sheet
         $this->close($sheetExport);
     }
 
-    /**
-     * @param  object  $import
-     */
-    public function import($import, int $startRow = 1): void
+    public function import(object $import, int $startRow = 1): void
     {
         if ($import instanceof WithEvents) {
             $this->registerListeners($import->registerEvents());
@@ -266,7 +248,7 @@ class Sheet
             $endColumn           = $import instanceof WithColumnLimit ? $import->endColumn() : null;
             $preparationCallback = $this->getPreparationCallback($import);
 
-            foreach ($this->worksheet->getRowIterator()->resetStart($startRow ?? 1) as $row) {
+            foreach ($this->worksheet->getRowIterator()->resetStart($startRow) as $row) {
                 $sheetRow = new Row($row, $headingRow, $headerIsGrouped);
 
                 if ($import instanceof WithValidation) {
@@ -316,14 +298,7 @@ class Sheet
         }
     }
 
-    /**
-     * @param  object  $import
-     * @param  null  $nullValue
-     * @param  bool  $calculateFormulas
-     * @param  bool  $formatData
-     * @return array
-     */
-    public function toArray($import, ?int $startRow = null, $nullValue = null, $calculateFormulas = false, $formatData = false)
+    public function toArray(?object $import, ?int $startRow = null, mixed $nullValue = null, bool $calculateFormulas = false, bool $formatData = false): array
     {
         if ($startRow > $this->worksheet->getHighestRow()) {
             return [];
@@ -366,13 +341,7 @@ class Sheet
         return $rows;
     }
 
-    /**
-     * @param  object  $import
-     * @param  null  $nullValue
-     * @param  bool  $calculateFormulas
-     * @param  bool  $formatData
-     */
-    public function toCollection($import, ?int $startRow = null, $nullValue = null, $calculateFormulas = false, $formatData = false): Collection
+    public function toCollection(?object $import, ?int $startRow = null, mixed $nullValue = null, bool $calculateFormulas = false, bool $formatData = false): Collection
     {
         $rows = $this->toArray($import, $startRow, $nullValue, $calculateFormulas, $formatData);
 
@@ -380,11 +349,9 @@ class Sheet
     }
 
     /**
-     * @param  object  $sheetExport
-     *
      * @throws Exception
      */
-    public function close($sheetExport): void
+    public function close(object $sheetExport): void
     {
         if ($sheetExport instanceof WithCharts) {
             $this->addCharts($sheetExport->charts());
@@ -431,11 +398,9 @@ class Sheet
     }
 
     /**
-     * @param  int|null  $sheetIndex
-     *
      * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception
      */
-    public function fromView(FromView $sheetExport, $sheetIndex = null): void
+    public function fromView(FromView $sheetExport, ?int $sheetIndex = null): void
     {
         $temporaryFile = $this->temporaryFileFactory->makeLocal(null, 'html');
         $temporaryFile->put($sheetExport->view()->render());
@@ -561,20 +526,14 @@ class Sheet
         }
     }
 
-    /**
-     * @return Sheet
-     */
-    public function chunkSize(int $chunkSize)
+    public function chunkSize(int $chunkSize): Sheet
     {
         $this->chunkSize = $chunkSize;
 
         return $this;
     }
 
-    /**
-     * @return Worksheet
-     */
-    public function getDelegate()
+    public function getDelegate(): Worksheet
     {
         return $this->worksheet;
     }
@@ -582,7 +541,7 @@ class Sheet
     /**
      * @param  Chart|Chart[]  $charts
      */
-    public function addCharts($charts): void
+    public function addCharts(Chart|array $charts): void
     {
         $charts = \is_array($charts) ? $charts : [$charts];
 
@@ -594,7 +553,7 @@ class Sheet
     /**
      * @param  BaseDrawing|BaseDrawing[]  $drawings
      */
-    public function addDrawings($drawings): void
+    public function addDrawings(BaseDrawing|array $drawings): void
     {
         $drawings = \is_array($drawings) ? $drawings : [$drawings];
 
@@ -608,11 +567,7 @@ class Sheet
         return $this->exportable instanceof $concern;
     }
 
-    /**
-     * @param  iterable  $rows
-     * @param  object  $sheetExport
-     */
-    public function appendRows($rows, $sheetExport): void
+    public function appendRows(iterable $rows, object $sheetExport): void
     {
         if (method_exists($sheetExport, 'prepareRows')) {
             $rows = $sheetExport->prepareRows($rows);
@@ -641,10 +596,7 @@ class Sheet
         });
     }
 
-    /**
-     * @param  mixed  $row
-     */
-    public static function mapArraybleRow($row): array
+    public static function mapArraybleRow(mixed $row): array
     {
         // When dealing with eloquent models, we'll skip the relations
         // as we won't be able to display them anyway.
@@ -678,10 +630,7 @@ class Sheet
         unset($this->worksheet);
     }
 
-    /**
-     * @return Collection|array
-     */
-    protected function validated(WithValidation $import, int $startRow, $rows)
+    protected function validated(WithValidation $import, int $startRow, $rows): Collection|array
     {
         $toValidate = (new Collection($rows))->mapWithKeys(fn ($row, $index) => [($startRow + $index) => $row]);
 
@@ -696,10 +645,7 @@ class Sheet
         return $rows;
     }
 
-    /**
-     * @return \Generator
-     */
-    protected function buildColumnRange(string $lower, string $upper)
+    protected function buildColumnRange(string $lower, string $upper): \Generator
     {
         /**
          * @callable(string): string $increment
@@ -722,10 +668,7 @@ class Sheet
         return $this->worksheet->cellExists($startCell);
     }
 
-    /**
-     * @param  object  $sheetExport
-     */
-    private function hasStrictNullComparison($sheetExport): bool
+    private function hasStrictNullComparison(object $sheetExport): bool
     {
         if ($sheetExport instanceof WithStrictNullComparison) {
             return true;
@@ -734,10 +677,7 @@ class Sheet
         return config('excel.exports.strict_null_comparison', false);
     }
 
-    /**
-     * @param  object|WithCustomChunkSize  $export
-     */
-    private function getChunkSize($export): int
+    private function getChunkSize(object $export): int
     {
         if ($export instanceof WithCustomChunkSize) {
             return $export->chunkSize();
@@ -746,11 +686,7 @@ class Sheet
         return $this->chunkSize;
     }
 
-    /**
-     * @param  object|WithValidation  $import
-     * @return Closure|null
-     */
-    private function getPreparationCallback($import)
+    private function getPreparationCallback(object $import): ?Closure
     {
         if (!$import instanceof WithValidation || !method_exists($import, 'prepareForValidation')) {
             return null;

--- a/src/Transactions/DbTransactionHandler.php
+++ b/src/Transactions/DbTransactionHandler.php
@@ -6,16 +6,15 @@ use Illuminate\Database\ConnectionInterface;
 
 class DbTransactionHandler implements TransactionHandler
 {
-    public function __construct(private ConnectionInterface $connection)
-    {
+    public function __construct(
+        private ConnectionInterface $connection,
+    ) {
     }
 
     /**
-     * @return mixed
-     *
      * @throws \Throwable
      */
-    public function __invoke(callable $callback)
+    public function __invoke(callable $callback): mixed
     {
         return $this->connection->transaction($callback);
     }

--- a/src/Transactions/NullTransactionHandler.php
+++ b/src/Transactions/NullTransactionHandler.php
@@ -4,10 +4,7 @@ namespace Maatwebsite\Excel\Transactions;
 
 class NullTransactionHandler implements TransactionHandler
 {
-    /**
-     * @return mixed
-     */
-    public function __invoke(callable $callback)
+    public function __invoke(callable $callback): mixed
     {
         return $callback();
     }

--- a/src/Transactions/TransactionHandler.php
+++ b/src/Transactions/TransactionHandler.php
@@ -4,8 +4,5 @@ namespace Maatwebsite\Excel\Transactions;
 
 interface TransactionHandler
 {
-    /**
-     * @return mixed
-     */
-    public function __invoke(callable $callback);
+    public function __invoke(callable $callback): mixed;
 }

--- a/src/Transactions/TransactionManager.php
+++ b/src/Transactions/TransactionManager.php
@@ -7,26 +7,17 @@ use Illuminate\Support\Manager;
 
 class TransactionManager extends Manager
 {
-    /**
-     * @return string
-     */
-    public function getDefaultDriver()
+    public function getDefaultDriver(): string
     {
         return config('excel.transactions.handler');
     }
 
-    /**
-     * @return NullTransactionHandler
-     */
-    public function createNullDriver()
+    public function createNullDriver(): NullTransactionHandler
     {
         return new NullTransactionHandler;
     }
 
-    /**
-     * @return DbTransactionHandler
-     */
-    public function createDbDriver()
+    public function createDbDriver(): DbTransactionHandler
     {
         return new DbTransactionHandler(
             DB::connection(config('excel.transactions.db.connection'))

--- a/src/Validators/Failure.php
+++ b/src/Validators/Failure.php
@@ -7,26 +7,12 @@ use JsonSerializable;
 
 class Failure implements Arrayable, JsonSerializable
 {
-    /**
-     * @var int
-     */
-    protected $row;
-
-    /**
-     * @var string
-     */
-    protected $attribute;
-
-    /**
-     * @var array
-     */
-    protected $errors;
-
-    public function __construct(int $row, string $attribute, array $errors, private array $values = [])
-    {
-        $this->row       = $row;
-        $this->attribute = $attribute;
-        $this->errors    = $errors;
+    public function __construct(
+        protected int $row,
+        protected string $attribute,
+        protected array $errors,
+        private array $values = [],
+    ) {
     }
 
     public function row(): int
@@ -49,10 +35,7 @@ class Failure implements Arrayable, JsonSerializable
         return $this->values;
     }
 
-    /**
-     * @return array
-     */
-    public function toArray()
+    public function toArray(): array
     {
         return collect($this->errors)->map(fn ($message) => __('There was an error on row :row. :message', ['row' => $this->row, 'message' => $message]))->all();
     }

--- a/src/Validators/RowValidator.php
+++ b/src/Validators/RowValidator.php
@@ -11,8 +11,9 @@ use Maatwebsite\Excel\Exceptions\RowSkippedException;
 
 class RowValidator
 {
-    public function __construct(private Factory $validator)
-    {
+    public function __construct(
+        private Factory $validator,
+    ) {
     }
 
     /**
@@ -88,11 +89,7 @@ class RowValidator
         })->all();
     }
 
-    /**
-     * @param  string|object|callable|array  $rules
-     * @return string|array
-     */
-    private function formatRule($rules)
+    private function formatRule(string|object|callable|array $rules): string|object|callable|array
     {
         if (is_array($rules)) {
             foreach ($rules as $rule) {

--- a/src/Validators/ValidationException.php
+++ b/src/Validators/ValidationException.php
@@ -6,15 +6,12 @@ use Illuminate\Validation\ValidationException as IlluminateValidationException;
 
 class ValidationException extends IlluminateValidationException
 {
-    /**
-     * @var Failure[]
-     */
-    protected $failures;
-
-    public function __construct(IlluminateValidationException $previous, array $failures)
-    {
+    public function __construct(
+        IlluminateValidationException $previous,
+        /** @var Failure[] */
+        protected array $failures,
+    ) {
         parent::__construct($previous->validator, $previous->response, $previous->errorBag);
-        $this->failures = $failures;
     }
 
     /**

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -27,34 +27,20 @@ class Writer
 {
     use DelegatedMacroable, HasEventBus;
 
-    /**
-     * @var ?Spreadsheet
-     */
-    protected $spreadsheet = null;
+    protected ?Spreadsheet $spreadsheet = null;
 
-    /**
-     * @var object
-     */
-    protected $exportable;
+    protected object $exportable;
 
-    /**
-     * @var TemporaryFileFactory
-     */
-    protected $temporaryFileFactory;
-
-    public function __construct(TemporaryFileFactory $temporaryFileFactory)
-    {
-        $this->temporaryFileFactory = $temporaryFileFactory;
-
+    public function __construct(
+        protected TemporaryFileFactory $temporaryFileFactory,
+    ) {
         $this->setDefaultValueBinder();
     }
 
     /**
-     * @param  object  $export
-     *
      * @throws Exception
      */
-    public function export($export, string $writerType): TemporaryFile
+    public function export(object $export, string $writerType): TemporaryFile
     {
         $this->open($export);
 
@@ -71,10 +57,9 @@ class Writer
     }
 
     /**
-     * @param  object  $export
      * @return $this
      */
-    public function open($export)
+    public function open(object $export)
     {
         $this->exportable = $export;
 
@@ -124,11 +109,9 @@ class Writer
     }
 
     /**
-     * @return Writer
-     *
      * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception
      */
-    public function reopen(TemporaryFile $tempFile, string $writerType)
+    public function reopen(TemporaryFile $tempFile, string $writerType): Writer
     {
         $reader            = IOFactory::createReader($writerType);
         $this->spreadsheet = $reader->load($tempFile->sync()->getLocalPath());
@@ -145,12 +128,10 @@ class Writer
     }
 
     /**
-     * @param  object  $export
-     *
      * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
      * @throws Exception
      */
-    public function write($export, TemporaryFile $temporaryFile, string $writerType): TemporaryFile
+    public function write(object $export, TemporaryFile $temporaryFile, string $writerType): TemporaryFile
     {
         $this->exportable = $export;
 
@@ -188,19 +169,14 @@ class Writer
     }
 
     /**
-     * @return Sheet
-     *
      * @throws Exception
      */
-    public function addNewSheet(?int $sheetIndex = null)
+    public function addNewSheet(?int $sheetIndex = null): Sheet
     {
         return new Sheet($this->spreadsheet->createSheet($sheetIndex));
     }
 
-    /**
-     * @return Spreadsheet
-     */
-    public function getDelegate()
+    public function getDelegate(): Spreadsheet
     {
         return $this->spreadsheet;
     }
@@ -218,27 +194,19 @@ class Writer
     }
 
     /**
-     * @return Sheet
-     *
      * @throws Exception
      */
-    public function getSheetByIndex(int $sheetIndex)
+    public function getSheetByIndex(int $sheetIndex): Sheet
     {
         return new Sheet($this->getDelegate()->getSheet($sheetIndex));
     }
 
-    /**
-     * @param  string  $concern
-     */
-    public function hasConcern($concern): bool
+    public function hasConcern(string $concern): bool
     {
         return $this->exportable instanceof $concern;
     }
 
-    /**
-     * @param  object  $export
-     */
-    protected function handleDocumentProperties($export): void
+    protected function handleDocumentProperties(object $export): void
     {
         $properties = config('excel.exports.properties', []);
 

--- a/tests/Cache/BatchCacheTest.php
+++ b/tests/Cache/BatchCacheTest.php
@@ -19,15 +19,9 @@ use Psr\SimpleCache\CacheInterface;
 
 class BatchCacheTest extends TestCase
 {
-    /**
-     * @var Repository
-     */
-    private $cache;
+    private Repository $cache;
 
-    /**
-     * @var MemoryCache
-     */
-    private $memory;
+    private MemoryCache $memory;
 
     public function test_will_get_multiple_from_memory_if_cells_hold_in_memory(): void
     {

--- a/tests/Concerns/ExportableTest.php
+++ b/tests/Concerns/ExportableTest.php
@@ -73,7 +73,10 @@ class ExportableTest extends TestCase
         {
             use Exportable;
 
-            protected $fileName = 'export.xlsx';
+            public function __construct()
+            {
+                $this->fileName = 'export.xlsx';
+            }
         };
 
         $this->assertInstanceOf(Responsable::class, $export);
@@ -105,13 +108,12 @@ class ExportableTest extends TestCase
         {
             use Exportable;
 
-            protected $fileName = 'name.csv';
-
-            protected $writerType = Excel::CSV;
-
-            protected $headers = [
-                'Content-Type' => 'text/csv',
-            ];
+            public function __construct()
+            {
+                $this->fileName   = 'name.csv';
+                $this->writerType = Excel::CSV;
+                $this->headers    = ['Content-Type' => 'text/csv'];
+            }
         };
         $response = $export->toResponse(request());
 
@@ -155,11 +157,12 @@ class ExportableTest extends TestCase
         {
             use Exportable;
 
-            public $disk = 's3';
-
-            public $writerType = Excel::CSV;
-
-            public $diskOptions = ['visibility' => 'private'];
+            public function __construct()
+            {
+                $this->disk        = 's3';
+                $this->writerType  = Excel::CSV;
+                $this->diskOptions = ['visibility' => 'private'];
+            }
         };
 
         $this->mock(Exporter::class)
@@ -175,11 +178,12 @@ class ExportableTest extends TestCase
         {
             use Exportable;
 
-            public $disk = 's3';
-
-            public $writerType = Excel::CSV;
-
-            public $diskOptions = ['visibility' => 'private'];
+            public function __construct()
+            {
+                $this->disk        = 's3';
+                $this->writerType  = Excel::CSV;
+                $this->diskOptions = ['visibility' => 'private'];
+            }
         };
 
         $this->mock(Exporter::class)
@@ -195,7 +199,10 @@ class ExportableTest extends TestCase
         {
             use Exportable;
 
-            public $diskOptions = ['visibility' => 'public'];
+            public function __construct()
+            {
+                $this->diskOptions = ['visibility' => 'public'];
+            }
         };
 
         $this->mock(Exporter::class)
@@ -211,7 +218,10 @@ class ExportableTest extends TestCase
         {
             use Exportable;
 
-            public $diskOptions = ['visibility' => 'public'];
+            public function __construct()
+            {
+                $this->diskOptions = ['visibility' => 'public'];
+            }
         };
 
         $this->mock(Exporter::class)

--- a/tests/Concerns/FromGeneratorTest.php
+++ b/tests/Concerns/FromGeneratorTest.php
@@ -15,9 +15,6 @@ class FromGeneratorTest extends TestCase
         {
             use Exportable;
 
-            /**
-             * @return Generator;
-             */
             public function generator(): Generator
             {
                 for ($i = 1; $i <= 2; $i++) {

--- a/tests/Concerns/FromIteratorTest.php
+++ b/tests/Concerns/FromIteratorTest.php
@@ -16,10 +16,7 @@ class FromIteratorTest extends TestCase
         {
             use Exportable;
 
-            /**
-             * @return array
-             */
-            public function array()
+            public function array(): array
             {
                 return [
                     ['test', 'test'],

--- a/tests/Concerns/FromViewTest.php
+++ b/tests/Concerns/FromViewTest.php
@@ -29,14 +29,9 @@ class FromViewTest extends TestCase
         {
             use Exportable;
 
-            /**
-             * @var Collection
-             */
-            protected $users;
-
-            public function __construct(Collection $users)
-            {
-                $this->users = $users;
+            public function __construct(
+                protected Collection $users,
+            ) {
             }
 
             public function view(): View
@@ -70,14 +65,9 @@ class FromViewTest extends TestCase
         {
             use Exportable;
 
-            /**
-             * @var Collection
-             */
-            protected $users;
-
-            public function __construct(Collection $users)
-            {
-                $this->users = $users;
+            public function __construct(
+                protected Collection $users,
+            ) {
             }
 
             /**

--- a/tests/Concerns/RemembersRowNumberTest.php
+++ b/tests/Concerns/RemembersRowNumberTest.php
@@ -33,9 +33,11 @@ class RemembersRowNumberTest extends TestCase
 
             public $rowNumbers = [];
 
-            public function model(array $row): void
+            public function model(array $row): null
             {
                 $this->rowNumbers[] = $this->getRowNumber();
+
+                return null;
             }
         };
 
@@ -58,9 +60,11 @@ class RemembersRowNumberTest extends TestCase
                 return 50;
             }
 
-            public function model(array $row): void
+            public function model(array $row): null
             {
                 $this->rowNumbers[] = $this->getRowNumber();
+
+                return null;
             }
         };
 
@@ -83,9 +87,11 @@ class RemembersRowNumberTest extends TestCase
                 return 50;
             }
 
-            public function model(array $row): void
+            public function model(array $row): null
             {
                 $this->rowNumbers[] = $this->rowNumber;
+
+                return null;
             }
 
             public function batchSize(): int

--- a/tests/Concerns/ShouldQueueWithoutChainTest.php
+++ b/tests/Concerns/ShouldQueueWithoutChainTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\SyncQueue;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
 use Maatwebsite\Excel\Jobs\AfterImportJob;
@@ -81,7 +82,7 @@ class ShouldQueueWithoutChainTest extends TestCase
         $afterImport = $jobs[AfterImportJob::class][0]['job'];
 
         if (!method_exists($fake, 'except')) {
-            /** @var SyncQueue $queue */
+            /** @var SyncQueue $fake */
             $fake = app(SyncQueue::class);
             $fake->setContainer(app());
         } else {

--- a/tests/Concerns/SkipsEmptyRowsTest.php
+++ b/tests/Concerns/SkipsEmptyRowsTest.php
@@ -72,7 +72,7 @@ class SkipsEmptyRowsTest extends TestCase
             /**
              * @return Model|Model[]|null
              */
-            public function model(array $row)
+            public function model(array $row): Model|array|null
             {
                 $this->rows++;
 
@@ -121,9 +121,11 @@ class SkipsEmptyRowsTest extends TestCase
 
             public $called = false;
 
-            public function model(array $row): void
+            public function model(array $row): null
             {
                 Assert::assertEquals('Not empty', $row[0]);
+
+                return null;
             }
 
             public function isEmptyWhen(array $row): bool

--- a/tests/Concerns/SkipsOnErrorTest.php
+++ b/tests/Concerns/SkipsOnErrorTest.php
@@ -38,10 +38,7 @@ class SkipsOnErrorTest extends TestCase
 
             public $errors = 0;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -80,10 +77,7 @@ class SkipsOnErrorTest extends TestCase
         {
             use Importable, SkipsErrors;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],

--- a/tests/Concerns/SkipsOnFailureTest.php
+++ b/tests/Concerns/SkipsOnFailureTest.php
@@ -39,10 +39,7 @@ class SkipsOnFailureTest extends TestCase
 
             public $failures = 0;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -101,10 +98,7 @@ class SkipsOnFailureTest extends TestCase
 
             public $failures = 0;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -161,10 +155,7 @@ class SkipsOnFailureTest extends TestCase
         {
             use Importable, SkipsFailures;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -209,10 +200,7 @@ class SkipsOnFailureTest extends TestCase
         {
             use Importable, SkipsFailures;
 
-            /**
-             * @return Model|null
-             */
-            public function onRow(Row $row)
+            public function onRow(Row $row): ?Model
             {
                 $row = $row->toArray();
 
@@ -253,13 +241,9 @@ class SkipsOnFailureTest extends TestCase
         {
             use Importable, SkipsFailures;
 
-            /**
-             * @param  Row  $row
-             * @return Model|null
-             */
             public function collection(Collection $rows)
             {
-                $rows = $rows->each(fn ($row) => User::create([
+                return $rows->each(fn ($row) => User::create([
                     'name'     => $row[0],
                     'email'    => $row[1],
                     'password' => 'secret',

--- a/tests/Concerns/ToModelTest.php
+++ b/tests/Concerns/ToModelTest.php
@@ -37,7 +37,7 @@ class ToModelTest extends TestCase
             /**
              * @return Model|Model[]|null
              */
-            public function model(array $row)
+            public function model(array $row): Model|array|null
             {
                 return new User([
                     'name'     => $row[0],
@@ -72,7 +72,7 @@ class ToModelTest extends TestCase
             /**
              * @return Model|Model[]|null
              */
-            public function model(array $row)
+            public function model(array $row): Model|array|null
             {
                 return new User([
                     'name'     => $row[0],
@@ -101,7 +101,7 @@ class ToModelTest extends TestCase
             /**
              * @return Model|Model[]|null
              */
-            public function model(array $row)
+            public function model(array $row): Model|array|null
             {
                 $user1 = new User([
                     'name'     => $row[0],
@@ -138,7 +138,7 @@ class ToModelTest extends TestCase
             /**
              * @return Model|Model[]|null
              */
-            public function model(array $row)
+            public function model(array $row): Model|array|null
             {
                 $user = new User([
                     'name'     => $row[0],
@@ -176,7 +176,7 @@ class ToModelTest extends TestCase
             /**
              * @return Model|Model[]|null
              */
-            public function model(array $row)
+            public function model(array $row): Model|array|null
             {
                 $user = new User([
                     'name'     => $row[0],
@@ -223,7 +223,7 @@ class ToModelTest extends TestCase
             /**
              * @return Model|Model[]|null
              */
-            public function model(array $row)
+            public function model(array $row): Model|array|null
             {
                 $user = new User([
                     'name'     => $row[0],

--- a/tests/Concerns/WithBackgroundColorTest.php
+++ b/tests/Concerns/WithBackgroundColorTest.php
@@ -16,7 +16,7 @@ class WithBackgroundColorTest extends TestCase
         {
             use Exportable;
 
-            public function backgroundColor()
+            public function backgroundColor(): string|array|Color
             {
                 return '000000';
             }
@@ -37,7 +37,7 @@ class WithBackgroundColorTest extends TestCase
         {
             use Exportable;
 
-            public function backgroundColor()
+            public function backgroundColor(): string|array|Color
             {
                 return [
                     'fillType'   => Fill::FILL_GRADIENT_LINEAR,
@@ -61,7 +61,7 @@ class WithBackgroundColorTest extends TestCase
         {
             use Exportable;
 
-            public function backgroundColor()
+            public function backgroundColor(): string|array|Color
             {
                 return new Color(Color::COLOR_BLUE);
             }

--- a/tests/Concerns/WithBatchInsertsTest.php
+++ b/tests/Concerns/WithBatchInsertsTest.php
@@ -32,10 +32,7 @@ class WithBatchInsertsTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -74,10 +71,7 @@ class WithBatchInsertsTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new Group([
                     'name' => $row[0],
@@ -107,7 +101,7 @@ class WithBatchInsertsTest extends TestCase
             /**
              * @return Model|Model[]|null
              */
-            public function model(array $row)
+            public function model(array $row): Model|array|null
             {
                 $user = new User([
                     'name'     => $row[0],
@@ -148,7 +142,7 @@ class WithBatchInsertsTest extends TestCase
             /**
              * @return Model|Model[]|null
              */
-            public function model(array $row)
+            public function model(array $row): Model|array|null
             {
                 return new User([
                     'name'     => $row[0],

--- a/tests/Concerns/WithCalculatedFormulasTest.php
+++ b/tests/Concerns/WithCalculatedFormulasTest.php
@@ -66,10 +66,7 @@ class WithCalculatedFormulasTest extends TestCase
 
             public $called = false;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 $this->called = true;
 
@@ -92,10 +89,7 @@ class WithCalculatedFormulasTest extends TestCase
 
             public $called = false;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 $this->called = true;
 
@@ -184,10 +178,7 @@ class WithCalculatedFormulasTest extends TestCase
 
             public $called = false;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 $this->called = true;
 

--- a/tests/Concerns/WithChunkReadingTest.php
+++ b/tests/Concerns/WithChunkReadingTest.php
@@ -51,10 +51,7 @@ class WithChunkReadingTest extends TestCase
 
             public $after = 0;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -100,10 +97,7 @@ class WithChunkReadingTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new Group([
                     'name' => $row[0],
@@ -135,10 +129,7 @@ class WithChunkReadingTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new Group([
                     'name' => $row['name'],
@@ -170,10 +161,7 @@ class WithChunkReadingTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new Group([
                     'name' => $row[0],
@@ -205,10 +193,7 @@ class WithChunkReadingTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new Group([
                     'name' => $row[0],
@@ -276,10 +261,7 @@ class WithChunkReadingTest extends TestCase
                 return [
                     new class implements ToModel, WithBatchInserts
                     {
-                        /**
-                         * @return Model|null
-                         */
-                        public function model(array $row)
+                        public function model(array $row): ?Model
                         {
                             return new Group([
                                 'name' => $row[0],
@@ -294,10 +276,7 @@ class WithChunkReadingTest extends TestCase
 
                     new class implements ToModel, WithBatchInserts
                     {
-                        /**
-                         * @return Model|null
-                         */
-                        public function model(array $row)
+                        public function model(array $row): ?Model
                         {
                             return new Group([
                                 'name' => $row[0],
@@ -337,10 +316,7 @@ class WithChunkReadingTest extends TestCase
                 return [
                     'Worksheet' => new class implements ToModel, WithBatchInserts
                     {
-                        /**
-                         * @return Model|null
-                         */
-                        public function model(array $row)
+                        public function model(array $row): ?Model
                         {
                             return new Group([
                                 'name' => $row[0],
@@ -355,10 +331,7 @@ class WithChunkReadingTest extends TestCase
 
                     'Worksheet2' => new class implements ToModel, WithBatchInserts
                     {
-                        /**
-                         * @return Model|null
-                         */
-                        public function model(array $row)
+                        public function model(array $row): ?Model
                         {
                             return new Group([
                                 'name' => $row[0],
@@ -388,10 +361,7 @@ class WithChunkReadingTest extends TestCase
 
             public $failed = false;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 throw new Exception('Something went wrong in the chunk');
             }

--- a/tests/Concerns/WithColumnFormattingTest.php
+++ b/tests/Concerns/WithColumnFormattingTest.php
@@ -20,10 +20,7 @@ class WithColumnFormattingTest extends TestCase
         {
             use Exportable;
 
-            /**
-             * @return Collection
-             */
-            public function collection()
+            public function collection(): Collection
             {
                 return collect([
                     [Carbon::createFromDate(2018, 3, 6)],
@@ -33,10 +30,7 @@ class WithColumnFormattingTest extends TestCase
                 ]);
             }
 
-            /**
-             * @param  mixed  $row
-             */
-            public function map($row): array
+            public function map(mixed $row): array
             {
                 return [
                     Date::dateTimeToExcel($row[0]),

--- a/tests/Concerns/WithCustomCsvSettingsTest.php
+++ b/tests/Concerns/WithCustomCsvSettingsTest.php
@@ -13,10 +13,7 @@ use PHPUnit\Framework\Assert;
 
 class WithCustomCsvSettingsTest extends TestCase
 {
-    /**
-     * @var Excel
-     */
-    protected $SUT;
+    protected Excel $SUT;
 
     protected function setUp(): void
     {
@@ -29,10 +26,7 @@ class WithCustomCsvSettingsTest extends TestCase
     {
         $export = new class implements FromCollection, WithCustomCsvSettings
         {
-            /**
-             * @return Collection
-             */
-            public function collection()
+            public function collection(): Collection
             {
                 return collect([
                     ['A1', 'B1'],
@@ -68,10 +62,7 @@ class WithCustomCsvSettingsTest extends TestCase
     {
         $export = new class implements FromCollection, WithCustomCsvSettings
         {
-            /**
-             * @return Collection
-             */
-            public function collection()
+            public function collection(): Collection
             {
                 return collect([
                     ['A1', '€ŠšŽžŒœŸ'],

--- a/tests/Concerns/WithCustomStartCellTest.php
+++ b/tests/Concerns/WithCustomStartCellTest.php
@@ -10,10 +10,7 @@ use Maatwebsite\Excel\Tests\TestCase;
 
 class WithCustomStartCellTest extends TestCase
 {
-    /**
-     * @var Excel
-     */
-    protected $SUT;
+    protected Excel $SUT;
 
     protected function setUp(): void
     {
@@ -26,10 +23,7 @@ class WithCustomStartCellTest extends TestCase
     {
         $export = new class implements FromCollection, WithCustomStartCell
         {
-            /**
-             * @return Collection
-             */
-            public function collection()
+            public function collection(): Collection
             {
                 return collect([
                     ['A1', 'B1'],

--- a/tests/Concerns/WithCustomValueBinderTest.php
+++ b/tests/Concerns/WithCustomValueBinderTest.php
@@ -24,10 +24,7 @@ class WithCustomValueBinderTest extends TestCase
         {
             use Exportable;
 
-            /**
-             * @return Collection
-             */
-            public function collection()
+            public function collection(): Collection
             {
                 return collect([
                     [Carbon::now(), '10%'],

--- a/tests/Concerns/WithDefaultStylesTest.php
+++ b/tests/Concerns/WithDefaultStylesTest.php
@@ -17,7 +17,7 @@ class WithDefaultStylesTest extends TestCase
         {
             use Exportable;
 
-            public function defaultStyles(Style $defaultStyle)
+            public function defaultStyles(Style $defaultStyle): ?array
             {
                 return [
                     'fill' => [

--- a/tests/Concerns/WithFormatDataTest.php
+++ b/tests/Concerns/WithFormatDataTest.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
@@ -87,11 +88,7 @@ class WithFormatDataTest extends TestCase
 
             public $called = false;
 
-            /**
-             * @param  array  $row
-             * @return Model|null
-             */
-            public function collection(Collection $collection)
+            public function collection(Collection $collection): ?Model
             {
                 $this->called = true;
 
@@ -115,11 +112,7 @@ class WithFormatDataTest extends TestCase
 
             public $called = false;
 
-            /**
-             * @param  array  $row
-             * @return Model|null
-             */
-            public function collection(Collection $collection)
+            public function collection(Collection $collection): ?Model
             {
                 $this->called = true;
 
@@ -142,10 +135,7 @@ class WithFormatDataTest extends TestCase
 
             public $called = false;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 $this->called = true;
 
@@ -169,10 +159,7 @@ class WithFormatDataTest extends TestCase
 
             public $called = false;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 $this->called = true;
 

--- a/tests/Concerns/WithHeadingsTest.php
+++ b/tests/Concerns/WithHeadingsTest.php
@@ -17,10 +17,7 @@ class WithHeadingsTest extends TestCase
         {
             use Exportable;
 
-            /**
-             * @return Collection
-             */
-            public function collection()
+            public function collection(): Collection
             {
                 return collect([
                     ['A1', 'B1', 'C1'],
@@ -55,10 +52,7 @@ class WithHeadingsTest extends TestCase
         {
             use Exportable;
 
-            /**
-             * @return Collection
-             */
-            public function collection()
+            public function collection(): Collection
             {
                 return collect([
                     ['A1', 'B1', 'C1'],
@@ -97,10 +91,7 @@ class WithHeadingsTest extends TestCase
         {
             use Exportable;
 
-            /**
-             * @return Collection
-             */
-            public function collection()
+            public function collection(): Collection
             {
                 return collect([
                     ['A1', 'B1', 'C1'],

--- a/tests/Concerns/WithMappedCellsTest.php
+++ b/tests/Concerns/WithMappedCellsTest.php
@@ -101,10 +101,7 @@ class WithMappedCellsTest extends TestCase
                 ];
             }
 
-            /**
-             * @return User
-             */
-            public function model(array $array)
+            public function model(array $array): User
             {
                 Assert::assertEquals([
                     'name'  => 'Patrick Brouwers',

--- a/tests/Concerns/WithMappingTest.php
+++ b/tests/Concerns/WithMappingTest.php
@@ -51,10 +51,7 @@ class WithMappingTest extends TestCase
                 ];
             }
 
-            /**
-             * @param  mixed  $row
-             */
-            public function map($row): array
+            public function map(mixed $row): array
             {
                 return [
                     [$row['id']],

--- a/tests/Concerns/WithMultipleSheetsTest.php
+++ b/tests/Concerns/WithMultipleSheetsTest.php
@@ -53,14 +53,9 @@ class WithMultipleSheetsTest extends TestCase
         {
             use Exportable;
 
-            /**
-             * @var Collection
-             */
-            protected $users;
-
-            public function __construct(Collection $users)
-            {
-                $this->users = $users;
+            public function __construct(
+                protected Collection $users,
+            ) {
             }
 
             /**

--- a/tests/Concerns/WithSkipDuplicatesTest.php
+++ b/tests/Concerns/WithSkipDuplicatesTest.php
@@ -37,10 +37,7 @@ class WithSkipDuplicatesTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -49,10 +46,7 @@ class WithSkipDuplicatesTest extends TestCase
                 ]);
             }
 
-            /**
-             * @return string|array
-             */
-            public function uniqueBy()
+            public function uniqueBy(): string|array
             {
                 return 'email';
             }
@@ -100,7 +94,7 @@ class WithSkipDuplicatesTest extends TestCase
             /**
              * @return Model|Model[]|null
              */
-            public function model(array $row)
+            public function model(array $row): Model|array|null
             {
                 return new User([
                     'name'     => $row[0],
@@ -109,10 +103,7 @@ class WithSkipDuplicatesTest extends TestCase
                 ]);
             }
 
-            /**
-             * @return string|array
-             */
-            public function uniqueBy()
+            public function uniqueBy(): string|array
             {
                 return 'email';
             }

--- a/tests/Concerns/WithStrictNullComparisonTest.php
+++ b/tests/Concerns/WithStrictNullComparisonTest.php
@@ -17,10 +17,7 @@ class WithStrictNullComparisonTest extends TestCase
         {
             use Exportable;
 
-            /**
-             * @return Collection
-             */
-            public function collection()
+            public function collection(): Collection
             {
                 return collect([
                     ['string', '0', 0, 0.0, 'string'],
@@ -53,10 +50,7 @@ class WithStrictNullComparisonTest extends TestCase
         {
             use Exportable;
 
-            /**
-             * @return Collection
-             */
-            public function collection()
+            public function collection(): Collection
             {
                 return collect([
                     ['string', 0, 0.0, 'string'],
@@ -89,10 +83,7 @@ class WithStrictNullComparisonTest extends TestCase
         {
             use Exportable;
 
-            /**
-             * @return Collection
-             */
-            public function collection()
+            public function collection(): Collection
             {
                 return collect([
                     ['a1', '', '', 'd1', ''],
@@ -128,10 +119,7 @@ class WithStrictNullComparisonTest extends TestCase
         {
             use Exportable;
 
-            /**
-             * @return Collection
-             */
-            public function collection()
+            public function collection(): Collection
             {
                 return collect([
                     ['a1', '', '', 'd1', ''],

--- a/tests/Concerns/WithUpsertsTest.php
+++ b/tests/Concerns/WithUpsertsTest.php
@@ -43,10 +43,7 @@ class WithUpsertsTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -55,10 +52,7 @@ class WithUpsertsTest extends TestCase
                 ]);
             }
 
-            /**
-             * @return string|array
-             */
-            public function uniqueBy()
+            public function uniqueBy(): string|array
             {
                 return 'email';
             }
@@ -106,7 +100,7 @@ class WithUpsertsTest extends TestCase
             /**
              * @return Model|Model[]|null
              */
-            public function model(array $row)
+            public function model(array $row): Model|array|null
             {
                 return new User([
                     'name'     => $row[0],
@@ -115,10 +109,7 @@ class WithUpsertsTest extends TestCase
                 ]);
             }
 
-            /**
-             * @return string|array
-             */
-            public function uniqueBy()
+            public function uniqueBy(): string|array
             {
                 return 'email';
             }
@@ -158,10 +149,7 @@ class WithUpsertsTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -170,18 +158,12 @@ class WithUpsertsTest extends TestCase
                 ]);
             }
 
-            /**
-             * @return string|array
-             */
-            public function uniqueBy()
+            public function uniqueBy(): string|array
             {
                 return 'email';
             }
 
-            /**
-             * @return array
-             */
-            public function upsertColumns()
+            public function upsertColumns(): array
             {
                 return ['name'];
             }
@@ -229,7 +211,7 @@ class WithUpsertsTest extends TestCase
             /**
              * @return Model|Model[]|null
              */
-            public function model(array $row)
+            public function model(array $row): Model|array|null
             {
                 return new User([
                     'name'     => $row[0],
@@ -238,18 +220,12 @@ class WithUpsertsTest extends TestCase
                 ]);
             }
 
-            /**
-             * @return string|array
-             */
-            public function uniqueBy()
+            public function uniqueBy(): string|array
             {
                 return 'email';
             }
 
-            /**
-             * @return array
-             */
-            public function upsertColumns()
+            public function upsertColumns(): array
             {
                 return ['name'];
             }

--- a/tests/Concerns/WithValidationTest.php
+++ b/tests/Concerns/WithValidationTest.php
@@ -41,10 +41,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -63,6 +60,7 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 2, '1', [
                 'The selected 1(field)? is invalid.',
@@ -73,8 +71,6 @@ class WithValidationTest extends TestCase
                 $e->errors()[0][0]
             );
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_validate_rows_with_closure_validation_rules(): void
@@ -83,10 +79,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -109,6 +102,7 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 2, '1', [
                 'Value in column 1 is not an allowed e-mail.',
@@ -119,8 +113,6 @@ class WithValidationTest extends TestCase
                 $e->errors()[0][0]
             );
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_validate_rows_with_custom_validation_rule_objects(): void
@@ -129,10 +121,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -148,20 +137,16 @@ class WithValidationTest extends TestCase
                     {
                         /**
                          * @param  string  $attribute
-                         * @param  mixed  $value
-                         * @return bool
                          */
-                        public function passes($attribute, $value)
+                        public function passes($attribute, mixed $value): bool
                         {
                             return $value === 'patrick@maatwebsite.nl';
                         }
 
                         /**
                          * Get the validation error message.
-                         *
-                         * @return string|array
                          */
-                        public function message()
+                        public function message(): string|array
                         {
                             return 'Value is not an allowed e-mail.';
                         }
@@ -172,6 +157,7 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 2, '1', [
                 'Value is not an allowed e-mail.',
@@ -182,8 +168,6 @@ class WithValidationTest extends TestCase
                 $e->errors()[0][0]
             );
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_validate_rows_with_conditionality(): void
@@ -192,10 +176,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -214,13 +195,12 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 1, 'conditional_required_column', [
                 'The conditional_required_column field is required when 1.1 is patrick@maatwebsite.nl.',
             ]);
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_validate_rows_with_unless_conditionality(): void
@@ -229,10 +209,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -251,13 +228,12 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 2, 'conditional_required_unless_column', [
                 'The conditional_required_unless_column field is required unless 2.1 is in patrick@maatwebsite.nl.',
             ]);
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_validate_rows_with_combined_rules_with_colons(): void
@@ -266,10 +242,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -294,13 +267,12 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 1, '1', [
                 'The 1 has already been taken.',
             ]);
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_validate_with_custom_attributes(): void
@@ -309,10 +281,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -328,10 +297,7 @@ class WithValidationTest extends TestCase
                 ];
             }
 
-            /**
-             * @return array
-             */
-            public function customValidationAttributes()
+            public function customValidationAttributes(): array
             {
                 return ['1' => 'email'];
             }
@@ -339,13 +305,12 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 2, 'email', [
                 'The selected email is invalid.',
             ]);
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_validate_with_custom_attributes_pointing_to_another_attribute(): void
@@ -354,10 +319,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -374,10 +336,7 @@ class WithValidationTest extends TestCase
                 ];
             }
 
-            /**
-             * @return array
-             */
-            public function customValidationAttributes()
+            public function customValidationAttributes(): array
             {
                 return ['1' => 'email', '2' => 'password'];
             }
@@ -385,13 +344,12 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 1, 'password', [
                 'The password field is required when email is present.',
             ]);
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_validate_with_custom_message(): void
@@ -400,10 +358,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -419,10 +374,7 @@ class WithValidationTest extends TestCase
                 ];
             }
 
-            /**
-             * @return array
-             */
-            public function customValidationMessages()
+            public function customValidationMessages(): array
             {
                 return [
                     '1.in' => 'Custom message for :attribute.',
@@ -432,13 +384,12 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 2, '1', [
                 'Custom message for 1.',
             ]);
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_validate_rows_with_headings(): void
@@ -447,10 +398,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row['name'],
@@ -469,13 +417,12 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users-with-headings.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 3, 'email', [
                 'The selected email is invalid.',
             ]);
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_validate_rows_with_grouped_headings(): void
@@ -486,10 +433,8 @@ class WithValidationTest extends TestCase
 
             /**
              * Prepare the data for validation.
-             *
-             * @return array
              */
-            public function prepareForValidation(array $row, int $index)
+            public function prepareForValidation(array $row, int $index): array
             {
                 if ($index === 2) {
                     Assert::assertIsArray($row['options']);
@@ -499,10 +444,7 @@ class WithValidationTest extends TestCase
                 return $row;
             }
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row['name'],
@@ -522,13 +464,12 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users-with-grouped-headers.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 2, 'options', [
                 'The options( field)? must be an array.',
             ]);
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_validate_rows_in_batches(): void
@@ -537,10 +478,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row['name'],
@@ -564,13 +502,12 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users-with-headings.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 3, 'email', [
                 'The selected email is invalid.',
             ]);
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_validate_using_oneachrow(): void
@@ -579,10 +516,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function onRow(Row $row)
+            public function onRow(Row $row): ?Model
             {
                 $values = $row->toArray();
 
@@ -603,13 +537,12 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users-with-headings.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 3, 'email', [
                 'The selected email is invalid.',
             ]);
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_validate_using_collection(): void
@@ -633,13 +566,12 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users-with-headings.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 3, 'email', [
                 'The selected email is invalid.',
             ]);
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_validate_using_array(): void
@@ -663,13 +595,12 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users-with-headings.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 3, 'email', [
                 'The selected email is invalid.',
             ]);
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_configure_validator(): void
@@ -678,10 +609,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([
                     'name'     => $row[0],
@@ -710,6 +638,7 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 2, '1', [
                 'The selected 1 is invalid.',
@@ -720,8 +649,6 @@ class WithValidationTest extends TestCase
                 $e->errors()[0][0]
             );
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_prepare_using_toarray(): void
@@ -739,10 +666,8 @@ class WithValidationTest extends TestCase
 
             /**
              * Prepare the data for validation.
-             *
-             * @return array
              */
-            public function prepareForValidation(array $row, int $index)
+            public function prepareForValidation(array $row, int $index): array
             {
                 if ($index === 2) {
                     $row[1] = 'not an email';
@@ -751,10 +676,7 @@ class WithValidationTest extends TestCase
                 return $row;
             }
 
-            /**
-             * @return array
-             */
-            public function array(array $array)
+            public function array(array $array): array
             {
                 return [];
             }
@@ -762,6 +684,7 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 2, '1', [
                 'The 1( field)? must be a valid email address.',
@@ -772,8 +695,6 @@ class WithValidationTest extends TestCase
                 $e->errors()[0][0]
             );
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_prepare_using_tocollection(): void
@@ -791,10 +712,8 @@ class WithValidationTest extends TestCase
 
             /**
              * Prepare the data for validation.
-             *
-             * @return array
              */
-            public function prepareForValidation(array $row, int $index)
+            public function prepareForValidation(array $row, int $index): array
             {
                 if ($index === 2) {
                     $row[1] = 'not an email';
@@ -803,10 +722,7 @@ class WithValidationTest extends TestCase
                 return $row;
             }
 
-            /**
-             * @return mixed
-             */
-            public function collection(Collection $collection)
+            public function collection(Collection $collection): mixed
             {
                 return collect();
             }
@@ -814,6 +730,7 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 2, '1', [
                 'The 1( field)? must be a valid email address.',
@@ -824,8 +741,6 @@ class WithValidationTest extends TestCase
                 $e->errors()[0][0]
             );
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_prepare_using_tomodel(): void
@@ -843,10 +758,8 @@ class WithValidationTest extends TestCase
 
             /**
              * Prepare the data for validation.
-             *
-             * @return array
              */
-            public function prepareForValidation(array $row, int $index)
+            public function prepareForValidation(array $row, int $index): array
             {
                 if ($index === 2) {
                     $row[1] = 'not an email';
@@ -858,7 +771,7 @@ class WithValidationTest extends TestCase
             /**
              * @return Model|Model[]|null
              */
-            public function model(array $row)
+            public function model(array $row): Model|array|null
             {
                 return new User([
                     'name'     => $row[0],
@@ -870,6 +783,7 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 2, '1', [
                 'The 1( field)? must be a valid email address.',
@@ -880,8 +794,6 @@ class WithValidationTest extends TestCase
                 $e->errors()[0][0]
             );
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_prepare_using_oneachrow(): void
@@ -899,10 +811,8 @@ class WithValidationTest extends TestCase
 
             /**
              * Prepare the data for validation.
-             *
-             * @return array
              */
-            public function prepareForValidation(array $row, int $index)
+            public function prepareForValidation(array $row, int $index): array
             {
                 if ($index === 2) {
                     $row[1] = 'not an email';
@@ -923,6 +833,7 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 2, '1', [
                 'The 1( field)? must be a valid email address.',
@@ -933,8 +844,6 @@ class WithValidationTest extends TestCase
                 $e->errors()[0][0]
             );
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     public function test_can_prepare_using_skipsemptyrows(): void
@@ -952,10 +861,8 @@ class WithValidationTest extends TestCase
 
             /**
              * Prepare the data for validation.
-             *
-             * @return array
              */
-            public function prepareForValidation(array $row, int $index)
+            public function prepareForValidation(array $row, int $index): array
             {
                 if ($index === 2) {
                     $row[1] = 'not an email';
@@ -976,6 +883,7 @@ class WithValidationTest extends TestCase
 
         try {
             $import->import('import-users.xlsx');
+            static::fail();
         } catch (ValidationException $e) {
             $this->validateFailure($e, 2, '1', [
                 'The 1( field)? must be a valid email address.',
@@ -986,8 +894,6 @@ class WithValidationTest extends TestCase
                 $e->errors()[0][0]
             );
         }
-
-        $this->assertInstanceOf(ValidationException::class, $e ?? null);
     }
 
     private function validateFailure(ValidationException $e, int $row, string $attribute, array $messages): void

--- a/tests/Data/Stubs/AfterQueueExportJob.php
+++ b/tests/Data/Stubs/AfterQueueExportJob.php
@@ -10,8 +10,9 @@ class AfterQueueExportJob implements ShouldQueue
 {
     use Queueable;
 
-    public function __construct(private string $filePath)
-    {
+    public function __construct(
+        private string $filePath,
+    ) {
     }
 
     public function handle(): void

--- a/tests/Data/Stubs/AfterQueueImportJob.php
+++ b/tests/Data/Stubs/AfterQueueImportJob.php
@@ -11,8 +11,9 @@ class AfterQueueImportJob implements ShouldQueue
 {
     use Queueable;
 
-    public function __construct(private int $totalRows)
-    {
+    public function __construct(
+        private int $totalRows,
+    ) {
     }
 
     public function handle(): void

--- a/tests/Data/Stubs/CustomTransactionHandler.php
+++ b/tests/Data/Stubs/CustomTransactionHandler.php
@@ -6,7 +6,7 @@ use Maatwebsite\Excel\Transactions\TransactionHandler;
 
 class CustomTransactionHandler implements TransactionHandler
 {
-    public function __invoke(callable $callback)
+    public function __invoke(callable $callback): mixed
     {
         return $callback();
     }

--- a/tests/Data/Stubs/Database/Group.php
+++ b/tests/Data/Stubs/Database/Group.php
@@ -7,6 +7,11 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\Factories\GroupFactory;
 
+/**
+ * @property int $id
+ * @property string $name
+ * @property int $number_of_users
+ */
 class Group extends Model
 {
     use HasFactory;
@@ -15,6 +20,9 @@ class Group extends Model
 
     protected $guarded = [];
 
+    /**
+     * @return BelongsToMany<User, $this>
+     */
     public function users(): BelongsToMany
     {
         return $this->belongsToMany(User::class);

--- a/tests/Data/Stubs/Database/User.php
+++ b/tests/Data/Stubs/Database/User.php
@@ -14,19 +14,19 @@ use Maatwebsite\Excel\Tests\Concerns\FromQueryTest;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\Factories\UserFactory;
 use Maatwebsite\Excel\Tests\QueuedQueryExportTest;
 
+/**
+ * @property string $email
+ * @property string $name
+ * @property string $firstname
+ * @property string $lastname
+ */
 class User extends Model
 {
     use HasFactory;
     use Searchable;
 
-    /**
-     * @var array
-     */
     protected $guarded = [];
 
-    /**
-     * @var array
-     */
     protected $hidden = ['password', 'email_verified_at', 'options', 'group_id'];
 
     public function groups(): BelongsToMany

--- a/tests/Data/Stubs/EloquentCollectionWithMappingExport.php
+++ b/tests/Data/Stubs/EloquentCollectionWithMappingExport.php
@@ -2,20 +2,20 @@
 
 namespace Maatwebsite\Excel\Tests\Data\Stubs;
 
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\WithMapping;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 
+/**
+ * @implements WithMapping<User>
+ */
 class EloquentCollectionWithMappingExport implements FromCollection, WithMapping
 {
     use Exportable;
 
-    /**
-     * @return Collection
-     */
-    public function collection()
+    public function collection(): Collection
     {
         return collect([
             new User([
@@ -25,9 +25,6 @@ class EloquentCollectionWithMappingExport implements FromCollection, WithMapping
         ]);
     }
 
-    /**
-     * @param  User  $user
-     */
     public function map($user): array
     {
         return [

--- a/tests/Data/Stubs/ExportWithEvents.php
+++ b/tests/Data/Stubs/ExportWithEvents.php
@@ -14,22 +14,22 @@ class ExportWithEvents implements WithEvents
     use Exportable;
 
     /**
-     * @var callable
+     * @var ?callable
      */
     public $beforeExport;
 
     /**
-     * @var callable
+     * @var ?callable
      */
     public $beforeWriting;
 
     /**
-     * @var callable
+     * @var ?callable
      */
     public $beforeSheet;
 
     /**
-     * @var callable
+     * @var ?callable
      */
     public $afterSheet;
 

--- a/tests/Data/Stubs/FromGroupUsersQueuedQueryExport.php
+++ b/tests/Data/Stubs/FromGroupUsersQueuedQueryExport.php
@@ -11,23 +11,21 @@ use Maatwebsite\Excel\Concerns\FromQuery;
 use Maatwebsite\Excel\Concerns\WithCustomChunkSize;
 use Maatwebsite\Excel\Concerns\WithMapping;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 
+/**
+ * @implements WithMapping<User>
+ */
 class FromGroupUsersQueuedQueryExport implements FromQuery, ShouldQueue, WithCustomChunkSize, WithMapping
 {
     use Exportable;
 
-    /**
-     * @return Builder|EloquentBuilder|Relation
-     */
-    public function query()
+    public function query(): Builder|EloquentBuilder|Relation
     {
         return Group::first()->users();
     }
 
-    /**
-     * @param  mixed  $row
-     */
-    public function map($row): array
+    public function map(mixed $row): array
     {
         return [
             $row->name,

--- a/tests/Data/Stubs/FromNestedArraysQueryExport.php
+++ b/tests/Data/Stubs/FromNestedArraysQueryExport.php
@@ -14,10 +14,7 @@ class FromNestedArraysQueryExport implements FromQuery, WithMapping
 {
     use Exportable;
 
-    /**
-     * @return Builder|EloquentBuilder|Relation
-     */
-    public function query()
+    public function query(): Builder|EloquentBuilder|Relation
     {
         $query = Group::with('users');
 
@@ -27,7 +24,7 @@ class FromNestedArraysQueryExport implements FromQuery, WithMapping
     /**
      * @param  Group  $row
      */
-    public function map($row): array
+    public function map(mixed $row): array
     {
         $rows    = [];
         $sub_row = [$row->name, ''];

--- a/tests/Data/Stubs/FromNonEloquentQueryExport.php
+++ b/tests/Data/Stubs/FromNonEloquentQueryExport.php
@@ -14,10 +14,7 @@ class FromNonEloquentQueryExport implements FromQuery, WithCustomChunkSize
 {
     use Exportable;
 
-    /**
-     * @return Builder|EloquentBuilder|Relation
-     */
-    public function query()
+    public function query(): Builder|EloquentBuilder|Relation
     {
         return DB::table('users')->select('name')->orderBy('id');
     }

--- a/tests/Data/Stubs/FromQueryWithCustomQuerySize.php
+++ b/tests/Data/Stubs/FromQueryWithCustomQuerySize.php
@@ -13,14 +13,14 @@ use Maatwebsite\Excel\Concerns\WithCustomQuerySize;
 use Maatwebsite\Excel\Concerns\WithMapping;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
 
+/**
+ * @implements WithMapping<Group>
+ */
 class FromQueryWithCustomQuerySize implements FromQuery, ShouldQueue, WithCustomQuerySize, WithMapping
 {
     use Exportable;
 
-    /**
-     * @return Builder|EloquentBuilder|Relation
-     */
-    public function query()
+    public function query(): Builder|EloquentBuilder|Relation
     {
         $query = Group::with('users')
             ->join('group_user', 'groups.id', '=', 'group_user.group_id')
@@ -36,10 +36,7 @@ class FromQueryWithCustomQuerySize implements FromQuery, ShouldQueue, WithCustom
         return Group::has('users')->count();
     }
 
-    /**
-     * @param  Group  $row
-     */
-    public function map($row): array
+    public function map(mixed $row): array
     {
         return [
             $row->id,

--- a/tests/Data/Stubs/FromUsersQueryExport.php
+++ b/tests/Data/Stubs/FromUsersQueryExport.php
@@ -14,10 +14,7 @@ class FromUsersQueryExport implements FromQuery, WithCustomChunkSize
 {
     use Exportable;
 
-    /**
-     * @return Builder|EloquentBuilder|Relation
-     */
-    public function query()
+    public function query(): Builder|EloquentBuilder|Relation
     {
         return User::query();
     }

--- a/tests/Data/Stubs/FromUsersQueryExportWithEagerLoad.php
+++ b/tests/Data/Stubs/FromUsersQueryExportWithEagerLoad.php
@@ -14,10 +14,7 @@ class FromUsersQueryExportWithEagerLoad implements FromQuery, WithMapping
 {
     use Exportable;
 
-    /**
-     * @return Builder|EloquentBuilder|Relation
-     */
-    public function query()
+    public function query(): Builder|EloquentBuilder|Relation
     {
         return User::query()->with([
             'groups' => function ($query): void {
@@ -26,10 +23,7 @@ class FromUsersQueryExportWithEagerLoad implements FromQuery, WithMapping
         ])->withCount('groups');
     }
 
-    /**
-     * @param  mixed  $row
-     */
-    public function map($row): array
+    public function map(mixed $row): array
     {
         return [
             $row->name,

--- a/tests/Data/Stubs/FromUsersQueryExportWithMapping.php
+++ b/tests/Data/Stubs/FromUsersQueryExportWithMapping.php
@@ -16,10 +16,7 @@ class FromUsersQueryExportWithMapping implements FromQuery, WithEvents, WithMapp
 {
     use Exportable;
 
-    /**
-     * @return Builder|EloquentBuilder|Relation
-     */
-    public function query()
+    public function query(): Builder|EloquentBuilder|Relation
     {
         return User::query();
     }
@@ -36,7 +33,7 @@ class FromUsersQueryExportWithMapping implements FromQuery, WithEvents, WithMapp
     /**
      * @param  User  $row
      */
-    public function map($row): array
+    public function map(mixed $row): array
     {
         return [
             'name' => $row->name,

--- a/tests/Data/Stubs/FromUsersQueryExportWithPrepareRows.php
+++ b/tests/Data/Stubs/FromUsersQueryExportWithPrepareRows.php
@@ -15,10 +15,7 @@ class FromUsersQueryExportWithPrepareRows implements FromQuery, WithCustomChunkS
 {
     use Exportable;
 
-    /**
-     * @return Builder|EloquentBuilder|Relation
-     */
-    public function query()
+    public function query(): Builder|EloquentBuilder|Relation
     {
         return User::query();
     }
@@ -30,9 +27,8 @@ class FromUsersQueryExportWithPrepareRows implements FromQuery, WithCustomChunkS
 
     /**
      * @param  iterable  $rows
-     * @return iterable
      */
-    public function prepareRows($rows)
+    public function prepareRows($rows): iterable
     {
         return (new Collection($rows))->map(function ($user) {
             $user->name .= '_prepared_name';

--- a/tests/Data/Stubs/FromUsersQueryWithJoinExport.php
+++ b/tests/Data/Stubs/FromUsersQueryWithJoinExport.php
@@ -21,10 +21,7 @@ class FromUsersQueryWithJoinExport implements FromQuery, WithCustomChunkSize
         $this->query = User::query();
     }
 
-    /**
-     * @return Builder|EloquentBuilder|Relation
-     */
-    public function query()
+    public function query(): Builder|EloquentBuilder|Relation
     {
         return $this->query
             ->join(

--- a/tests/Data/Stubs/FromUsersScoutExport.php
+++ b/tests/Data/Stubs/FromUsersScoutExport.php
@@ -15,10 +15,7 @@ class FromUsersScoutExport implements FromQuery, WithCustomChunkSize
 {
     use Exportable;
 
-    /**
-     * @return Builder|EloquentBuilder|Relation|ScoutBuilder
-     */
-    public function query()
+    public function query(): Builder|EloquentBuilder|Relation|ScoutBuilder
     {
         return new ScoutBuilder(new User, '');
     }

--- a/tests/Data/Stubs/FromViewExportWithMultipleSheets.php
+++ b/tests/Data/Stubs/FromViewExportWithMultipleSheets.php
@@ -10,14 +10,9 @@ class FromViewExportWithMultipleSheets implements WithMultipleSheets
 {
     use Exportable;
 
-    /**
-     * @var Collection
-     */
-    protected $users;
-
-    public function __construct(Collection $users)
-    {
-        $this->users = $users;
+    public function __construct(
+        protected Collection $users,
+    ) {
     }
 
     /**

--- a/tests/Data/Stubs/ImportWithEvents.php
+++ b/tests/Data/Stubs/ImportWithEvents.php
@@ -14,22 +14,22 @@ class ImportWithEvents implements WithEvents
     use Importable;
 
     /**
-     * @var callable
+     * @var ?callable
      */
     public $beforeImport;
 
     /**
-     * @var callable
+     * @var ?callable
      */
     public $afterImport;
 
     /**
-     * @var callable
+     * @var ?callable
      */
     public $beforeSheet;
 
     /**
-     * @var callable
+     * @var ?callable
      */
     public $afterSheet;
 

--- a/tests/Data/Stubs/ImportWithEventsChunksAndBatches.php
+++ b/tests/Data/Stubs/ImportWithEventsChunksAndBatches.php
@@ -11,12 +11,12 @@ use Maatwebsite\Excel\Events\AfterChunk;
 class ImportWithEventsChunksAndBatches extends ImportWithEvents implements ToModel, WithBatchInserts, WithChunkReading
 {
     /**
-     * @var callable
+     * @var ?callable
      */
     public $afterBatch;
 
     /**
-     * @var callable
+     * @var ?callable
      */
     public $afterChunk;
 
@@ -31,8 +31,9 @@ class ImportWithEventsChunksAndBatches extends ImportWithEvents implements ToMod
         ];
     }
 
-    public function model(array $row): void
+    public function model(array $row): null
     {
+        return null;
     }
 
     public function batchSize(): int

--- a/tests/Data/Stubs/QueueImportWithoutJobChaining.php
+++ b/tests/Data/Stubs/QueueImportWithoutJobChaining.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\Excel\Tests\Data\Stubs;
 
+use Illuminate\Database\Eloquent\Model;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ShouldQueueWithoutChain;
 use Maatwebsite\Excel\Concerns\ToModel;
@@ -23,10 +24,7 @@ class QueueImportWithoutJobChaining implements ShouldQueueWithoutChain, ToModel,
 
     public $after = false;
 
-    /**
-     * @return Model|null
-     */
-    public function model(array $row)
+    public function model(array $row): ?Model
     {
         return new User([
             'name'     => $row[0],

--- a/tests/Data/Stubs/QueuedExportWithFailedHook.php
+++ b/tests/Data/Stubs/QueuedExportWithFailedHook.php
@@ -3,7 +3,7 @@
 namespace Maatwebsite\Excel\Tests\Data\Stubs;
 
 use Exception;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\WithMapping;
@@ -14,15 +14,9 @@ class QueuedExportWithFailedHook implements FromCollection, WithMapping
 {
     use Exportable;
 
-    /**
-     * @var bool
-     */
-    public $failed = false;
+    public bool $failed = false;
 
-    /**
-     * @return Collection
-     */
-    public function collection()
+    public function collection(): Collection
     {
         return collect([
             new User([

--- a/tests/Data/Stubs/QueuedExportWithLocalePreferences.php
+++ b/tests/Data/Stubs/QueuedExportWithLocalePreferences.php
@@ -14,22 +14,14 @@ class QueuedExportWithLocalePreferences implements FromCollection, HasLocalePref
     use Exportable;
 
     /**
-     * @var string
-     */
-    protected $locale;
-
-    /**
      * QueuedExportWithLocalePreferences constructor.
      */
-    public function __construct(string $locale)
-    {
-        $this->locale = $locale;
+    public function __construct(
+        protected string $locale,
+    ) {
     }
 
-    /**
-     * @return Collection
-     */
-    public function collection()
+    public function collection(): Collection
     {
         return collect([
             new User([
@@ -39,19 +31,15 @@ class QueuedExportWithLocalePreferences implements FromCollection, HasLocalePref
         ]);
     }
 
-    /**
-     * @return string|null
-     */
-    public function preferredLocale()
+    public function preferredLocale(): ?string
     {
         return $this->locale;
     }
 
     /**
      * @param  iterable  $rows
-     * @return iterable
      */
-    public function prepareRows($rows)
+    public function prepareRows($rows): iterable
     {
         Assert::assertEquals('ru', app()->getLocale());
 

--- a/tests/Data/Stubs/QueuedImport.php
+++ b/tests/Data/Stubs/QueuedImport.php
@@ -14,10 +14,7 @@ class QueuedImport implements ShouldQueue, ToModel, WithBatchInserts, WithChunkR
 {
     use Importable;
 
-    /**
-     * @return Model|null
-     */
-    public function model(array $row)
+    public function model(array $row): ?Model
     {
         return new Group([
             'name' => $row[0],

--- a/tests/Data/Stubs/QueuedImportWithFailure.php
+++ b/tests/Data/Stubs/QueuedImportWithFailure.php
@@ -7,22 +7,16 @@ use Illuminate\Database\Eloquent\Model;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithChunkReading;
-use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
 
 class QueuedImportWithFailure implements ShouldQueue, ToModel, WithChunkReading
 {
     use Importable;
 
-    /**
-     * @return Model|null
-     */
-    public function model(array $row)
+    public ?int $maxExceptions = null;
+
+    public function model(array $row): ?Model
     {
         throw new \Exception('Something went wrong in the chunk');
-
-        return new Group([
-            'name' => $row[0],
-        ]);
     }
 
     public function chunkSize(): int

--- a/tests/Data/Stubs/QueuedImportWithMiddleware.php
+++ b/tests/Data/Stubs/QueuedImportWithMiddleware.php
@@ -13,10 +13,7 @@ class QueuedImportWithMiddleware implements ShouldQueue, ToModel, WithChunkReadi
 {
     use Importable;
 
-    /**
-     * @return Model|null
-     */
-    public function model(array $row)
+    public function model(array $row): ?Model
     {
         return new Group([
             'name' => $row[0],

--- a/tests/Data/Stubs/QueuedImportWithRetryUntil.php
+++ b/tests/Data/Stubs/QueuedImportWithRetryUntil.php
@@ -13,10 +13,7 @@ class QueuedImportWithRetryUntil implements ShouldQueue, ToModel, WithChunkReadi
 {
     use Importable;
 
-    /**
-     * @return Model|null
-     */
-    public function model(array $row)
+    public function model(array $row): ?Model
     {
         return new Group([
             'name' => $row[0],
@@ -30,13 +27,9 @@ class QueuedImportWithRetryUntil implements ShouldQueue, ToModel, WithChunkReadi
 
     /**
      * Determine the time at which the job should timeout.
-     *
-     * @return \DateTime
      */
-    public function retryUntil()
+    public function retryUntil(): \DateTime
     {
         throw new \Exception('Job reached retryUntil method');
-
-        return now()->addSeconds(5);
     }
 }

--- a/tests/Data/Stubs/SheetForUsersFromView.php
+++ b/tests/Data/Stubs/SheetForUsersFromView.php
@@ -11,14 +11,9 @@ class SheetForUsersFromView implements FromView
 {
     use Exportable;
 
-    /**
-     * @var Collection
-     */
-    protected $users;
-
-    public function __construct(Collection $users)
-    {
-        $this->users = $users;
+    public function __construct(
+        protected Collection $users,
+    ) {
     }
 
     public function view(): View

--- a/tests/Data/Stubs/SheetWith100Rows.php
+++ b/tests/Data/Stubs/SheetWith100Rows.php
@@ -13,21 +13,26 @@ use Maatwebsite\Excel\Events\BeforeWriting;
 use Maatwebsite\Excel\Tests\TestCase;
 use Maatwebsite\Excel\Writer;
 
+/**
+ * @implements FromCollection<int, Collection<int, string>>
+ */
 class SheetWith100Rows implements FromCollection, ShouldAutoSize, WithEvents, WithTitle
 {
     use Exportable, RegistersEventListeners;
 
-    public function __construct(private string $title)
-    {
+    public function __construct(
+        private string $title,
+    ) {
     }
 
     /**
-     * @return Collection
+     * @return Collection<int, Collection<int, string>>
      */
-    public function collection()
+    public function collection(): Collection
     {
         $collection = new Collection;
         for ($i = 0; $i < 100; $i++) {
+            /** @var Collection<int, string> */
             $row = new Collection;
             for ($j = 0; $j < 5; $j++) {
                 $row[] = $this->title() . '-' . $i . '-' . $j;

--- a/tests/Data/Stubs/ShouldBatchImport.php
+++ b/tests/Data/Stubs/ShouldBatchImport.php
@@ -15,10 +15,7 @@ class ShouldBatchImport implements ShouldBatch, ShouldQueue, ToModel, WithBatchI
 {
     use Importable;
 
-    /**
-     * @return Model|null
-     */
-    public function model(array $row)
+    public function model(array $row): ?Model
     {
         return new Group([
             'name' => $row[0],

--- a/tests/Data/Stubs/WithMappingExport.php
+++ b/tests/Data/Stubs/WithMappingExport.php
@@ -7,14 +7,17 @@ use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\WithMapping;
 
+/**
+ * @implements WithMapping<array<int, string>>
+ */
 class WithMappingExport implements FromCollection, WithMapping
 {
     use Exportable;
 
     /**
-     * @return Collection
+     * @return Collection<int, array{string, string, string}>
      */
-    public function collection()
+    public function collection(): Collection
     {
         return collect([
             ['A1', 'B1', 'C1'],
@@ -22,10 +25,7 @@ class WithMappingExport implements FromCollection, WithMapping
         ]);
     }
 
-    /**
-     * @param  mixed  $row
-     */
-    public function map($row): array
+    public function map(mixed $row): array
     {
         return [
             'mapped-' . $row[0],

--- a/tests/ExcelFakeTest.php
+++ b/tests/ExcelFakeTest.php
@@ -227,68 +227,44 @@ class ExcelFakeTest extends TestCase
         ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/');
     }
 
-    /**
-     * @return FromCollection
-     */
-    private function givenExport()
+    private function givenExport(): FromCollection
     {
         return new class implements FromCollection
         {
-            /**
-             * @return Collection
-             */
-            public function collection()
+            public function collection(): Collection
             {
                 return collect(['foo', 'bar']);
             }
         };
     }
 
-    /**
-     * @return FromCollection
-     */
-    private function givenQueuedExport()
+    private function givenQueuedExport(): FromCollection
     {
         return new class implements FromCollection, ShouldQueue
         {
-            /**
-             * @return Collection
-             */
-            public function collection()
+            public function collection(): Collection
             {
                 return collect(['foo', 'bar']);
             }
         };
     }
 
-    /**
-     * @return object
-     */
-    private function givenImport()
+    private function givenImport(): object
     {
         return new class implements ToModel
         {
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([]);
             }
         };
     }
 
-    /**
-     * @return object
-     */
-    private function givenQueuedImport()
+    private function givenQueuedImport(): object
     {
         return new class implements ShouldQueue, ToModel
         {
-            /**
-             * @return Model|null
-             */
-            public function model(array $row)
+            public function model(array $row): ?Model
             {
                 return new User([]);
             }

--- a/tests/ExcelTest.php
+++ b/tests/ExcelTest.php
@@ -25,10 +25,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class ExcelTest extends TestCase
 {
-    /**
-     * @var Excel
-     */
-    protected $SUT;
+    protected Excel $SUT;
 
     protected function setUp(): void
     {
@@ -136,10 +133,7 @@ class ExcelTest extends TestCase
         {
             use RegistersEventListeners;
 
-            /**
-             * @return Collection
-             */
-            public function collection()
+            public function collection(): Collection
             {
                 return collect([
                     ['A1', 'B1'],
@@ -177,10 +171,7 @@ class ExcelTest extends TestCase
         {
             use Exportable;
 
-            /**
-             * @return Collection
-             */
-            public function collection()
+            public function collection(): Collection
             {
                 return collect();
             }

--- a/tests/PhpSpreadsheetV5CompatibilityTest.php
+++ b/tests/PhpSpreadsheetV5CompatibilityTest.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\Excel\Tests;
 
+use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\Importable;
@@ -232,7 +233,7 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
         {
             use Exportable;
 
-            public function collection()
+            public function collection(): Collection
             {
                 return collect([
                     [['nested' => 'value'], 'plain'],

--- a/tests/QueuedImportTest.php
+++ b/tests/QueuedImportTest.php
@@ -154,7 +154,7 @@ class QueuedImportTest extends TestCase
     public function test_can_automatically_delete_temp_file_on_failure_when_using_remote_disk(): void
     {
         config()->set('excel.temporary_files.remote_disk', 'test');
-        $tempFile = '';
+        $tempFile = null;
 
         Queue::exceptionOccurred(function (JobExceptionOccurred $event) use (&$tempFile): void {
             if ($event->job->resolveName() === ReadChunk::class) {
@@ -168,13 +168,13 @@ class QueuedImportTest extends TestCase
             $this->assertEquals('Something went wrong in the chunk', $e->getMessage());
         }
 
-        $this->assertFalse($tempFile->existsLocally());
-        $this->assertTrue($tempFile->exists());
+        $this->assertFalse($tempFile?->existsLocally());
+        $this->assertTrue($tempFile?->exists());
     }
 
     public function test_cannot_automatically_delete_temp_file_on_failure_when_using_local_disk(): void
     {
-        $tempFile = '';
+        $tempFile = null;
 
         Queue::exceptionOccurred(function (JobExceptionOccurred $event) use (&$tempFile): void {
             if ($event->job->resolveName() === ReadChunk::class) {
@@ -188,7 +188,7 @@ class QueuedImportTest extends TestCase
             $this->assertEquals('Something went wrong in the chunk', $e->getMessage());
         }
 
-        $this->assertTrue($tempFile->exists());
+        $this->assertTrue($tempFile?->exists());
     }
 
     public function test_can_force_remote_download_and_deletion_for_each_chunk_on_queue(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,11 +15,9 @@ use PHPUnit\Framework\Constraint\StringContains;
 class TestCase extends OrchestraTestCase
 {
     /**
-     * @return Spreadsheet
-     *
      * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception
      */
-    public function read(string $filePath, string $writerType)
+    public function read(string $filePath, string $writerType): Spreadsheet
     {
         $reader = IOFactory::createReader($writerType);
 
@@ -40,11 +38,9 @@ class TestCase extends OrchestraTestCase
     }
 
     /**
-     * @return array
-     *
      * @throws Exception
      */
-    protected function readAsArray(string $filePath, string $writerType, ?int $sheetIndex = null)
+    protected function readAsArray(string $filePath, string $writerType, ?int $sheetIndex = null): array
     {
         $spreadsheet = $this->read($filePath, $writerType);
 
@@ -59,9 +55,8 @@ class TestCase extends OrchestraTestCase
 
     /**
      * @param  Application  $app
-     * @return array
      */
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [
             ExcelServiceProvider::class,
@@ -94,10 +89,7 @@ class TestCase extends OrchestraTestCase
         ]);
     }
 
-    /**
-     * @return mixed
-     */
-    protected function inspectJobProperty(Job $job, string $property)
+    protected function inspectJobProperty(Job $job, string $property): mixed
     {
         $dict  = (array) unserialize($job->payload()['data']['command']);
         $class = $job->resolveName();
@@ -118,8 +110,10 @@ class TestCase extends OrchestraTestCase
     {
         if (method_exists($this, 'assertFileDoesNotExist')) {
             $this->assertFileDoesNotExist($path);
-        } else {
+        } elseif (method_exists($this, 'assertFileNotExists')) {
             $this->assertFileNotExists($path);
+        } else {
+            throw new Exception('Missing file assert type');
         }
     }
 
@@ -127,8 +121,10 @@ class TestCase extends OrchestraTestCase
     {
         if (method_exists($this, 'assertMatchesRegularExpression')) {
             $this->assertMatchesRegularExpression($pattern, $string);
-        } else {
+        } elseif (method_exists($this, 'assertRegExp')) {
             $this->assertRegExp($pattern, $string);
+        } else {
+            throw new Exception('Missing regex assert type');
         }
     }
 }

--- a/tests/Validators/RowValidatorTest.php
+++ b/tests/Validators/RowValidatorTest.php
@@ -79,10 +79,8 @@ class RowValidatorTest extends TestCase
 
     /**
      * Call a private function.
-     *
-     * @return mixed
      */
-    public function callPrivateMethod(string $name, array $args)
+    public function callPrivateMethod(string $name, array $args): mixed
     {
         $method = new \ReflectionMethod(RowValidator::class, $name);
 


### PR DESCRIPTION
This was made using PHP-cs-fixers to do a mostly automated conversion of PHPDoc to native type hints, but I still had to correct several and apply them manually to classes (mostly tests) that extends the base classes and fix existing type errors in the lib.

I did also apply a few bugfixes here as there as I hit them, mostly invalid types (null where null isn't allowed by the native type) / syntax error and accessing private methods though `static::`, some missing imports, accessing collection method on array, interface with different return types from implementation.

Followed by fixing many, many type issues (missing nullable, no default, type that doesn't apply yet).

I also had to introduce `MemoryInterface` that extends `CacheInterface` since `CacheInterface` doesn't suficiently describe the features used by the two implementations.

The over all result of the manual changes is to make the types consistent though the application since making them native requires that. I have tried to keep the effective types, rather then what might have been the architectural intent, since the other option would have required larger refactoring and rethinking of some features. If that is preferred I would suggest it should be done as a later refactoring rather then as part of the type clean up.

As icing on top PHPStan now passes on level 0 and has been added to the CI.