### PR TITLE
Revert typed CacheInterface methods on deprecated cache drivers

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,3 +9,8 @@ parameters:
     configDirectories:
         - ./tests
         - ./config
+    # MemoryCacheDeprecated / BatchCacheDeprecated use untyped CacheInterface methods for psr/simple-cache ^1|^2.
+    # PHPStan (with ^3 installed) would require native types there and break runtime compatibility — do not add them.
+    excludePaths:
+        - src/Cache/MemoryCacheDeprecated.php
+        - src/Cache/BatchCacheDeprecated.php

--- a/src/Cache/BatchCacheDeprecated.php
+++ b/src/Cache/BatchCacheDeprecated.php
@@ -5,6 +5,12 @@ namespace Maatwebsite\Excel\Cache;
 use Illuminate\Support\Facades\Cache;
 use Psr\SimpleCache\CacheInterface;
 
+/**
+ * Used when psr/simple-cache is ^1.0 or ^2.0.
+ *
+ * CacheInterface method signatures must stay untyped so they remain compatible
+ * with all supported psr/simple-cache major versions. Do not add native types here.
+ */
 class BatchCacheDeprecated implements CacheInterface
 {
     /**
@@ -35,7 +41,7 @@ class BatchCacheDeprecated implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function get(string $key, mixed $default = null): mixed
+    public function get($key, $default = null)
     {
         if ($this->memory->has($key)) {
             return $this->memory->get($key);
@@ -47,7 +53,7 @@ class BatchCacheDeprecated implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null): bool
+    public function set($key, $value, $ttl = null)
     {
         if (func_num_args() === 2) {
             $ttl = value($this->defaultTTL);
@@ -65,7 +71,7 @@ class BatchCacheDeprecated implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function delete(string $key): bool
+    public function delete($key)
     {
         if ($this->memory->has($key)) {
             return $this->memory->delete($key);
@@ -77,7 +83,7 @@ class BatchCacheDeprecated implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function clear(): bool
+    public function clear()
     {
         $this->memory->clear();
 
@@ -87,7 +93,7 @@ class BatchCacheDeprecated implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    public function getMultiple($keys, $default = null)
     {
         // Check if all keys are still in memory
         $memory              = $this->memory->getMultiple($keys, $default);
@@ -115,7 +121,7 @@ class BatchCacheDeprecated implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function setMultiple(iterable $values, null|int|\DateInterval $ttl = null): bool
+    public function setMultiple($values, $ttl = null)
     {
         if (func_num_args() === 1) {
             $ttl = value($this->defaultTTL);
@@ -133,7 +139,7 @@ class BatchCacheDeprecated implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function deleteMultiple(iterable $keys): bool
+    public function deleteMultiple($keys)
     {
         $keys = is_array($keys) ? $keys : iterator_to_array($keys);
 
@@ -145,7 +151,7 @@ class BatchCacheDeprecated implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function has(string $key): bool
+    public function has($key)
     {
         if ($this->memory->has($key)) {
             return true;

--- a/src/Cache/MemoryCacheDeprecated.php
+++ b/src/Cache/MemoryCacheDeprecated.php
@@ -4,6 +4,12 @@ namespace Maatwebsite\Excel\Cache;
 
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 
+/**
+ * Used when psr/simple-cache is ^1.0 or ^2.0.
+ *
+ * CacheInterface method signatures must stay untyped so they remain compatible
+ * with all supported psr/simple-cache major versions. Do not add native types here.
+ */
 class MemoryCacheDeprecated implements MemoryInterface
 {
     protected array $cache = [];
@@ -16,7 +22,7 @@ class MemoryCacheDeprecated implements MemoryInterface
     /**
      * {@inheritdoc}
      */
-    public function clear(): bool
+    public function clear()
     {
         $this->cache = [];
 
@@ -26,7 +32,7 @@ class MemoryCacheDeprecated implements MemoryInterface
     /**
      * {@inheritdoc}
      */
-    public function delete(string $key): bool
+    public function delete($key)
     {
         unset($this->cache[$key]);
 
@@ -36,7 +42,7 @@ class MemoryCacheDeprecated implements MemoryInterface
     /**
      * {@inheritdoc}
      */
-    public function deleteMultiple(iterable $keys): bool
+    public function deleteMultiple($keys)
     {
         foreach ($keys as $key) {
             $this->delete($key);
@@ -48,7 +54,7 @@ class MemoryCacheDeprecated implements MemoryInterface
     /**
      * {@inheritdoc}
      */
-    public function get(string $key, mixed $default = null): mixed
+    public function get($key, $default = null)
     {
         if ($this->has($key)) {
             return $this->cache[$key];
@@ -60,7 +66,7 @@ class MemoryCacheDeprecated implements MemoryInterface
     /**
      * {@inheritdoc}
      */
-    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    public function getMultiple($keys, $default = null)
     {
         $results = [];
         foreach ($keys as $key) {
@@ -73,7 +79,7 @@ class MemoryCacheDeprecated implements MemoryInterface
     /**
      * {@inheritdoc}
      */
-    public function has(string $key): bool
+    public function has($key)
     {
         return isset($this->cache[$key]);
     }
@@ -81,7 +87,7 @@ class MemoryCacheDeprecated implements MemoryInterface
     /**
      * {@inheritdoc}
      */
-    public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null): bool
+    public function set($key, $value, $ttl = null)
     {
         $this->cache[$key] = $value;
 
@@ -91,7 +97,7 @@ class MemoryCacheDeprecated implements MemoryInterface
     /**
      * {@inheritdoc}
      */
-    public function setMultiple(iterable $values, null|int|\DateInterval $ttl = null): bool
+    public function setMultiple($values, $ttl = null)
     {
         foreach ($values as $key => $value) {
             $this->set($key, $value);


### PR DESCRIPTION
## Problem

Commit [9173150](https://github.com/SpartnerNL/Laravel-Excel/commit/9173150877bec0f1fabb6dfe2b26be1fad8a4ac4) (PR #4359) added PSR-16 3.0 native types to `MemoryCacheDeprecated` and `BatchCacheDeprecated` while `composer.json` still allows `psr/simple-cache` `^1.0||^2.0||^3.0`.

`CacheManager` already uses those deprecated classes when `psr/simple-cache` is **not** ^3.0. With typed methods on those classes, Composer resolving 1.x or 2.x (e.g. `prefer-lowest`) causes a fatal error on boot:

```
PHP Fatal error: Declaration of Maatwebsite\Excel\Cache\MemoryCacheDeprecated::get(string $key, mixed $default = null): mixed must be compatible with Psr\SimpleCache\CacheInterface::get($key, $default = null)
```

Dropping `^1.0||^2.0` from `composer.json` is not ideal either — Laravel and PhpSpreadsheet still support all three majors.

## Solution

- Revert `CacheInterface` method signatures on `MemoryCacheDeprecated` and `BatchCacheDeprecated` to untyped (compatible with psr/simple-cache ^1|^2).
- Exclude those files from PHPStan analysis with a comment explaining why native types must not be added there (PHPStan level 0 would otherwise require them when ^3 is installed in dev).

Typed implementations remain on `MemoryCache` / `BatchCache` for `psr/simple-cache` ^3.0.

## Reproduction (before)

```bash
composer update --prefer-lowest
php vendor/bin/testbench package:purge-skeleton
```