### PR TITLE
fix: append sheets instead of inserting at explicit index in queued multi-sheet exports

### DIFF
--- a/src/Jobs/QueueExport.php
+++ b/src/Jobs/QueueExport.php
@@ -56,8 +56,8 @@ class QueueExport implements ShouldQueue
             }
 
             // Pre-create the worksheets
-            foreach ($sheetExports as $sheetIndex => $sheetExport) {
-                $sheet = $writer->addNewSheet($sheetIndex);
+            foreach ($sheetExports as $sheetExport) {
+                $sheet = $writer->addNewSheet();
                 $sheet->open($sheetExport);
             }
 


### PR DESCRIPTION
Fixes #4365

In `QueueExport::handle()`, passing `$sheetIndex` to `addNewSheet()` causes `Spreadsheet::createSheet($index)` to increment `activeSheetIndex` in PhpSpreadsheet 5, leaving it out of bounds. Appending without explicit index preserves order since `disconnectWorksheets()` was already called.