### PR TITLE
4.x: Resolve PHPStan level 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
     "driftingly/rector-laravel": "^2.3",
     "phpstan/phpstan": "^2.1",
     "larastan/larastan": "^3.0",
-    "phpstan/extension-installer": "^1.4"
+    "phpstan/extension-installer": "^1.4",
+    "phpstan/phpstan-mockery": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 0
+    level: 2
     paths:
         - ./src
         - ./tests

--- a/src/Concerns/FromCollection.php
+++ b/src/Concerns/FromCollection.php
@@ -6,8 +6,7 @@ use Illuminate\Support\Enumerable;
 
 /**
  * @template TKey of array-key
- *
- * @template-covariant TValue
+ * @template TValue
  */
 interface FromCollection
 {

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -16,7 +16,6 @@ use Maatwebsite\Excel\Exporter;
 use Maatwebsite\Excel\Importer;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\ExpectationFailedException;
-use SebastianBergmann\RecursionContext\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
@@ -281,7 +280,6 @@ class ExcelFake implements Exporter, Importer
      * @see matchByRegex for more information about file path matching
      *
      * @throws ExpectationFailedException
-     * @throws InvalidArgumentException
      * @throws Exception
      */
     protected function assertArrayHasKey(string $key, array $disk, string $message = ''): string

--- a/src/Imports/ModelManager.php
+++ b/src/Imports/ModelManager.php
@@ -62,7 +62,7 @@ class ModelManager
      */
     public function toModels(ToModel $import, array $attributes, ?int $rowNumber = null): Collection
     {
-        if ($this->remembersRowNumber) {
+        if ($this->remembersRowNumber && method_exists($import, 'rememberRowNumber')) {
             $import->rememberRowNumber($rowNumber);
         }
 

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -288,6 +288,7 @@ class Reader
 
     public function getTotalRows(): array
     {
+        assert(method_exists($this->reader, 'listWorksheetInfo'));
         $info = $this->reader->listWorksheetInfo($this->currentFile->getLocalPath());
 
         $totalRows = [];

--- a/src/RegistersCustomConcerns.php
+++ b/src/RegistersCustomConcerns.php
@@ -10,6 +10,8 @@ use Maatwebsite\Excel\Events\Event;
 
 trait RegistersCustomConcerns
 {
+    use HasEventBus;
+
     private static array $eventMap = [
         BeforeWriting::class => Writer::class,
         BeforeExport::class  => Writer::class,
@@ -19,8 +21,7 @@ trait RegistersCustomConcerns
 
     public static function extend(string $concern, callable $handler, string $event = BeforeWriting::class): void
     {
-        /** @var HasEventBus $delegate */
-        $delegate = static::$eventMap[$event] ?? BeforeWriting::class;
+        $delegate = self::$eventMap[$event] ?? BeforeWriting::class;
 
         $delegate::listen($event, function (Event $event) use ($concern, $handler): void {
             if ($event->appliesToConcern($concern)) {

--- a/tests/Concerns/ShouldQueueWithoutChainTest.php
+++ b/tests/Concerns/ShouldQueueWithoutChainTest.php
@@ -73,6 +73,7 @@ class ShouldQueueWithoutChainTest extends TestCase
 
         $import->import('import-users.xlsx');
 
+        /** @phpstan-ignore staticMethod.notFound */
         $jobs   = Queue::pushedJobs();
         $chunks = collect($jobs[ReadChunk::class])->pluck('job');
         $chunks->each(function (ReadChunk $chunk): void {

--- a/tests/Concerns/SkipsEmptyRowsTest.php
+++ b/tests/Concerns/SkipsEmptyRowsTest.php
@@ -148,9 +148,6 @@ class SkipsEmptyRowsTest extends TestCase
 
             public $called = false;
 
-            /**
-             * @param  array  $row
-             */
             public function onRow(Row $row): void
             {
                 Assert::assertEquals('Not empty', $row[0]);

--- a/tests/Concerns/SkipsOnFailureTest.php
+++ b/tests/Concerns/SkipsOnFailureTest.php
@@ -55,9 +55,6 @@ class SkipsOnFailureTest extends TestCase
                 ];
             }
 
-            /**
-             * @param  Failure[]  $failures
-             */
             public function onFailure(Failure ...$failures): void
             {
                 $failure = $failures[0];
@@ -114,9 +111,6 @@ class SkipsOnFailureTest extends TestCase
                 ];
             }
 
-            /**
-             * @param  Failure[]  $failures
-             */
             public function onFailure(Failure ...$failures): void
             {
                 $failure = $failures[0];

--- a/tests/Data/Stubs/Database/User.php
+++ b/tests/Data/Stubs/Database/User.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Carbon;
 use Laravel\Scout\Engines\DatabaseEngine;
 use Laravel\Scout\Engines\Engine;
 use Laravel\Scout\Engines\NullEngine;
@@ -19,6 +20,8 @@ use Maatwebsite\Excel\Tests\QueuedQueryExportTest;
  * @property string $name
  * @property string $firstname
  * @property string $lastname
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
  */
 class User extends Model
 {

--- a/tests/DelegatedMacroableTest.php
+++ b/tests/DelegatedMacroableTest.php
@@ -43,6 +43,7 @@ class DelegatedMacroableTest extends TestCase
             public static function beforeExport(BeforeExport $event): void
             {
                 // call macro method
+                /** @phpstan-ignore method.notFound */
                 $event->writer->test();
             }
         };
@@ -66,6 +67,7 @@ class DelegatedMacroableTest extends TestCase
             public static function beforeSheet(BeforeSheet $event): void
             {
                 // call macro method
+                /** @phpstan-ignore method.notFound */
                 $event->sheet->test();
             }
         };

--- a/tests/Mixins/DownloadCollectionTest.php
+++ b/tests/Mixins/DownloadCollectionTest.php
@@ -17,6 +17,7 @@ class DownloadCollectionTest extends TestCase
             ['column_1' => 'test2', 'column_2' => 'test2'],
         ]);
 
+        /** @phpstan-ignore method.notFound */
         $response = $collection->downloadExcel('collection-download.xlsx', Excel::XLSX);
 
         $array = $this->readAsArray($response->getFile()->getPathName(), Excel::XLSX);
@@ -39,6 +40,7 @@ class DownloadCollectionTest extends TestCase
             ['column_1' => 'test', 'column_2' => 'test'],
         ]);
 
+        /** @phpstan-ignore method.notFound */
         $response = $collection->downloadExcel('collection-headers-download.xlsx', Excel::XLSX, true);
 
         $array = $this->readAsArray($response->getFile()->getPathName(), Excel::XLSX);
@@ -52,6 +54,7 @@ class DownloadCollectionTest extends TestCase
             new User(['name' => 'Patrick', 'password' => 'my_password']),
         ]);
 
+        /** @phpstan-ignore method.notFound */
         $response = $collection->downloadExcel('collection-headers-download.xlsx', Excel::XLSX, true);
 
         $array = $this->readAsArray($response->getFile()->getPathName(), Excel::XLSX);
@@ -68,6 +71,7 @@ class DownloadCollectionTest extends TestCase
             $user,
         ]);
 
+        /** @phpstan-ignore method.notFound */
         $response = $collection->downloadExcel('collection-headers-download.xlsx', Excel::XLSX, true);
 
         $array = $this->readAsArray($response->getFile()->getPathName(), Excel::XLSX);
@@ -86,8 +90,9 @@ class DownloadCollectionTest extends TestCase
             'CUSTOMER-HEADER-1' => 'CUSTOMER-HEADER1-VAL',
             'CUSTOMER-HEADER-2' => 'CUSTOMER-HEADER2-VAL',
         ];
-        /** @var BinaryFileResponse $response */
+        /** @phpstan-ignore method.notFound */
         $response = $collection->downloadExcel('collection-download.xlsx', Excel::XLSX, false, $responseHeaders);
+        static::assertInstanceOf(BinaryFileResponse::class, $response);
         $this->assertTrue($response->headers->contains('CUSTOMER-HEADER-1', 'CUSTOMER-HEADER1-VAL'));
         $this->assertTrue($response->headers->contains('CUSTOMER-HEADER-2', 'CUSTOMER-HEADER2-VAL'));
     }

--- a/tests/Mixins/DownloadQueryMacroTest.php
+++ b/tests/Mixins/DownloadQueryMacroTest.php
@@ -23,6 +23,7 @@ class DownloadQueryMacroTest extends TestCase
 
     public function test_can_download_a_query_as_excel(): void
     {
+        /** @phpstan-ignore staticMethod.notFound */
         $response = User::downloadExcel('query-download.xlsx', Excel::XLSX);
 
         $array = $this->readAsArray($response->getFile()->getPathName(), Excel::XLSX);
@@ -37,6 +38,7 @@ class DownloadQueryMacroTest extends TestCase
 
     public function test_can_download_a_collection_with_headers_as_excel(): void
     {
+        /** @phpstan-ignore staticMethod.notFound */
         $response = User::downloadExcel('collection-headers-download.xlsx', Excel::XLSX, true);
 
         $array = $this->readAsArray($response->getFile()->getPathName(), Excel::XLSX);

--- a/tests/Mixins/ImportAsMacroTest.php
+++ b/tests/Mixins/ImportAsMacroTest.php
@@ -21,6 +21,7 @@ class ImportAsMacroTest extends TestCase
     {
         User::query()->truncate();
 
+        /** @phpstan-ignore staticMethod.notFound */
         User::importAs('import-users.xlsx', fn (array $row) => [
             'name'     => $row[0],
             'email'    => $row[1],

--- a/tests/Mixins/ImportMacroTest.php
+++ b/tests/Mixins/ImportMacroTest.php
@@ -24,6 +24,7 @@ class ImportMacroTest extends TestCase
             $user->password = 'secret';
         });
 
+        /** @phpstan-ignore staticMethod.notFound */
         User::import('import-users-with-headings.xlsx');
 
         $this->assertCount(2, User::all());

--- a/tests/Mixins/StoreCollectionTest.php
+++ b/tests/Mixins/StoreCollectionTest.php
@@ -16,6 +16,7 @@ class StoreCollectionTest extends TestCase
             ['test', 'test'],
         ]);
 
+        /** @phpstan-ignore method.notFound */
         $response = $collection->storeExcel('collection-store.xlsx');
 
         $this->assertTrue($response);
@@ -29,6 +30,7 @@ class StoreCollectionTest extends TestCase
             ['column_1' => 'test2', 'column_2' => 'test2'],
         ]);
 
+        /** @phpstan-ignore method.notFound */
         $response = $collection->storeExcel('collection-store.xlsx', null, Excel::XLSX);
 
         $file = __DIR__ . '/../Data/Disks/Local/collection-store.xlsx';
@@ -55,6 +57,7 @@ class StoreCollectionTest extends TestCase
             ['column_1' => 'test', 'column_2' => 'test'],
         ]);
 
+        /** @phpstan-ignore method.notFound */
         $response = $collection->storeExcel('collection-headers-store.xlsx', null, Excel::XLSX, true);
 
         $file = __DIR__ . '/../Data/Disks/Local/collection-headers-store.xlsx';
@@ -75,6 +78,7 @@ class StoreCollectionTest extends TestCase
     {
         $collection = User::factory()->count(2)->make();
 
+        /** @phpstan-ignore method.notFound */
         $response = $collection->storeExcel('model-collection-headers-store.xlsx', null, Excel::XLSX, true);
 
         $file = __DIR__ . '/../Data/Disks/Local/model-collection-headers-store.xlsx';

--- a/tests/Mixins/StoreQueryMacroTest.php
+++ b/tests/Mixins/StoreQueryMacroTest.php
@@ -22,6 +22,7 @@ class StoreQueryMacroTest extends TestCase
 
     public function test_can_download_a_query_as_excel(): void
     {
+        /** @phpstan-ignore staticMethod.notFound */
         $response = User::storeExcel('query-store.xlsx', null, Excel::XLSX);
 
         $this->assertTrue($response);
@@ -33,6 +34,7 @@ class StoreQueryMacroTest extends TestCase
 
     public function test_can_download_a_query_as_excel_on_different_disk(): void
     {
+        /** @phpstan-ignore staticMethod.notFound */
         $response = User::storeExcel('query-store.xlsx', 'test', Excel::XLSX);
 
         $this->assertTrue($response);
@@ -44,6 +46,7 @@ class StoreQueryMacroTest extends TestCase
 
     public function test_can_store_a_query_with_headers_as_excel(): void
     {
+        /** @phpstan-ignore staticMethod.notFound */
         $response = User::storeExcel('query-headers-store.xlsx', null, Excel::XLSX, true);
 
         $this->assertTrue($response);


### PR DESCRIPTION
This resolve PHPStan level 1 and 2 issues.

I have created an issue with PHPOffice regarding `listWorksheetInfo()` missing from there interface:
-  https://github.com/PHPOffice/PhpSpreadsheet/issues/4883
For now I'm adding an `assert()` to catch anyone that might not have implemented the method.

Similarly `rememberRowNumber()` is a method that isn't documented by any interface in Laravel-Excel it self.

HasEventBus isn't a classs/interface so can't be used for typing, the solution I went for was to have RegistersCustomConcerns extend it, the alternative is to create a new interface that documents `listen()`.

Macros are Laravel at it's most magical, I don't think there is any good solutions other then `@phpstan-ignore` and later `@var type` on top.

Other then that it's just a few missing or wrong types from PHPDoc that where easy to resolve.