### PR TITLE
PHPStan level 3

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
     - phpstan-baseline.neon.php
 
 parameters:
-    level: 2
+    level: 3
     paths:
         - ./src
         - ./tests

--- a/src/Cache/BatchCache.php
+++ b/src/Cache/BatchCache.php
@@ -90,8 +90,26 @@ class BatchCache implements CacheInterface
     public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
         // Check if all keys are still in memory
-        $memory              = $this->memory->getMultiple($keys, $default);
-        $actualItemsInMemory = count(array_filter($memory));
+        $memory = $this->memory->getMultiple($keys, $default);
+        if (is_array($memory)) {
+            $actualItemsInMemory = count(array_filter($memory));
+        } else {
+            $actualItemsInMemory = 0;
+            foreach ($memory as $value) {
+                if ($value) {
+                    $actualItemsInMemory++;
+                }
+            }
+        }
+
+        if (is_countable($keys)) {
+            $keyCount = count($keys);
+        } else {
+            $keyCount = 0;
+            foreach ($keys as $key) {
+                $keyCount++;
+            }
+        }
 
         if ($actualItemsInMemory === count($keys)) {
             return $memory;

--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -34,7 +34,7 @@ class CacheManager extends Manager
     }
 
     /**
-     * @return MemoryCache
+     * @return MemoryInterface
      */
     public function createMemoryDriver(): CacheInterface
     {
@@ -49,9 +49,6 @@ class CacheManager extends Manager
         );
     }
 
-    /**
-     * @return BatchCache
-     */
     public function createBatchDriver(): CacheInterface
     {
         if (!InstalledVersions::satisfies(new VersionParser, 'psr/simple-cache', '^3.0')) {

--- a/src/Concerns/Importable.php
+++ b/src/Concerns/Importable.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use Maatwebsite\Excel\Exceptions\NoFilePathGivenException;
 use Maatwebsite\Excel\Importer;
+use Maatwebsite\Excel\Validators\ValidationException;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -25,6 +26,7 @@ trait Importable
     protected string|UploadedFile|null $filePath = null;
 
     /**
+     * @throws ValidationException
      * @throws NoFilePathGivenException
      */
     public function import(string|UploadedFile|null $filePath = null, ?string $disk = null, ?string $readerType = null): Importer|PendingDispatch|PendingBatch

--- a/src/Excel.php
+++ b/src/Excel.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Traits\Macroable;
 use Maatwebsite\Excel\Files\Filesystem;
 use Maatwebsite\Excel\Files\TemporaryFile;
 use Maatwebsite\Excel\Helpers\FileTypeDetector;
+use Maatwebsite\Excel\Validators\ValidationException;
 use PhpOffice\PhpSpreadsheet\Exception;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
@@ -113,6 +114,9 @@ class Excel implements Exporter, Importer
         return $contents;
     }
 
+    /**
+     * @throws ValidationException
+     */
     public function import($import, $filePath, ?string $disk = null, ?string $readerType = null): static|Reader|PendingDispatch|PendingBatch
     {
         $readerType = FileTypeDetector::detect($filePath, $readerType);

--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -61,7 +61,7 @@ class ExcelFake implements Exporter, Importer
         return true;
     }
 
-    public function queue($export, string $filePath, ?string $disk = null, ?string $writerType = null, $diskOptions = []): PendingDispatch
+    public function queue($export, string $filePath, ?string $disk = null, ?string $writerType = null, $diskOptions = []): PendingDispatch|PendingBatch
     {
         Queue::fake();
 

--- a/src/Files/Disk.php
+++ b/src/Files/Disk.php
@@ -5,7 +5,7 @@ namespace Maatwebsite\Excel\Files;
 use Illuminate\Contracts\Filesystem\Filesystem as IlluminateFilesystem;
 
 /**
- * @method bool get(string $filename)
+ * @method string get(string $filename)
  * @method resource readStream(string $filename)
  * @method bool delete(string $filename)
  * @method bool exists(string $filename)

--- a/src/Importer.php
+++ b/src/Importer.php
@@ -6,10 +6,14 @@ use Illuminate\Bus\PendingBatch;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 interface Importer
 {
+    /**
+     * @throws ValidationException
+     */
     public function import(object $import, string|UploadedFile $filePath, ?string $disk = null, ?string $readerType = null): static|Reader|PendingDispatch|PendingBatch;
 
     public function toArray(object $import, string|UploadedFile $filePath, ?string $disk = null, ?string $readerType = null): array;

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -5,8 +5,8 @@ namespace Maatwebsite\Excel;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Enumerable;
 use Illuminate\Support\Facades\Bus;
-use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\FromQuery;
@@ -94,7 +94,7 @@ class QueuedWriter
         TemporaryFile $temporaryFile,
         string $writerType,
         int $sheetIndex
-    ): Collection|LazyCollection {
+    ): Enumerable {
         return $export
             ->collection()
             ->chunk($this->getChunkSize($export))

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -24,6 +24,7 @@ use Maatwebsite\Excel\Factories\ReaderFactory;
 use Maatwebsite\Excel\Files\TemporaryFile;
 use Maatwebsite\Excel\Files\TemporaryFileFactory;
 use Maatwebsite\Excel\Transactions\TransactionHandler;
+use Maatwebsite\Excel\Validators\ValidationException;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Reader\Exception;
 use PhpOffice\PhpSpreadsheet\Reader\IReader;
@@ -71,6 +72,7 @@ class Reader
     /**
      * @return PendingDispatch|$this
      *
+     * @throws ValidationException
      * @throws NoTypeDetectedException
      * @throws FileNotFoundException
      * @throws Exception

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -52,6 +52,7 @@ use Maatwebsite\Excel\Imports\EndRowFinder;
 use Maatwebsite\Excel\Imports\HeadingRowExtractor;
 use Maatwebsite\Excel\Imports\ModelImporter;
 use Maatwebsite\Excel\Validators\RowValidator;
+use Maatwebsite\Excel\Validators\ValidationException;
 use PhpOffice\PhpSpreadsheet\Cell\Cell as SpreadsheetCell;
 use PhpOffice\PhpSpreadsheet\Chart\Chart;
 use PhpOffice\PhpSpreadsheet\Exception;
@@ -199,6 +200,9 @@ class Sheet
         $this->close($sheetExport);
     }
 
+    /**
+     * @throws ValidationException
+     */
     public function import(object $import, int $startRow = 1): void
     {
         if ($import instanceof WithEvents) {

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -562,7 +562,7 @@ class Sheet
         }
     }
 
-    public function hasConcern(string $concern): string
+    public function hasConcern(string $concern): bool
     {
         return $this->exportable instanceof $concern;
     }

--- a/src/Validators/ValidationException.php
+++ b/src/Validators/ValidationException.php
@@ -15,7 +15,7 @@ class ValidationException extends IlluminateValidationException
     }
 
     /**
-     * @return string[]
+     * @return array<int, list<string>>
      */
     #[\Override]
     public function errors(): array

--- a/tests/Concerns/FromCollectionTest.php
+++ b/tests/Concerns/FromCollectionTest.php
@@ -50,8 +50,6 @@ class FromCollectionTest extends TestCase
     {
         if (!class_exists(LazyCollection::class)) {
             $this->markTestSkipped('Skipping test because LazyCollection is not supported');
-
-            return;
         }
 
         $export = new EloquentLazyCollectionExport;
@@ -72,8 +70,6 @@ class FromCollectionTest extends TestCase
     {
         if (!class_exists(LazyCollection::class)) {
             $this->markTestSkipped('Skipping test because LazyCollection is not supported');
-
-            return;
         }
 
         $export = new EloquentLazyCollectionQueuedExport;

--- a/tests/Concerns/FromQueryTest.php
+++ b/tests/Concerns/FromQueryTest.php
@@ -191,8 +191,6 @@ class FromQueryTest extends TestCase
     {
         $export = new FromUsersQueryExportWithPrepareRows;
 
-        $this->assertTrue(method_exists($export, 'prepareRows'));
-
         $response = $export->store('from-query-store.xlsx');
 
         $this->assertTrue($response);
@@ -212,8 +210,6 @@ class FromQueryTest extends TestCase
     {
         if (!class_exists(DatabaseEngine::class)) {
             $this->markTestSkipped('Laravel Scout is too old');
-
-            return;
         }
 
         $export = new FromUsersScoutExport;

--- a/tests/Concerns/OnEachRowTest.php
+++ b/tests/Concerns/OnEachRowTest.php
@@ -50,7 +50,7 @@ class OnEachRowTest extends TestCase
                 // Accessing a row as an array calls toArray() without an end
                 // column. This saves the row in the cache, so we have to
                 // invalidate the cache once the end column changes
-                $row[0];
+                Assert::assertIsString($row[0]);
 
                 Assert::assertEquals([
                     'test',

--- a/tests/Concerns/ShouldQueueWithoutChainTest.php
+++ b/tests/Concerns/ShouldQueueWithoutChainTest.php
@@ -65,10 +65,6 @@ class ShouldQueueWithoutChainTest extends TestCase
     {
         $fake = Queue::fake();
 
-        if (method_exists($fake, 'serializeAndRestore')) {
-            $fake->serializeAndRestore(); // More realism
-        }
-
         $import = new QueueImportWithoutJobChaining;
 
         $import->import('import-users.xlsx');
@@ -82,13 +78,8 @@ class ShouldQueueWithoutChainTest extends TestCase
         self::assertCount(2, $chunks);
         $afterImport = $jobs[AfterImportJob::class][0]['job'];
 
-        if (!method_exists($fake, 'except')) {
-            /** @var SyncQueue $fake */
-            $fake = app(SyncQueue::class);
-            $fake->setContainer(app());
-        } else {
-            $fake->except([AfterImportJob::class, ReadChunk::class]);
-        }
+        $fake = app(SyncQueue::class);
+        $fake->setContainer(app());
         $fake->push($chunks->first());
         self::assertTrue(ReadChunk::isComplete($chunks->first()->getUniqueId()));
         self::assertFalse(ReadChunk::isComplete($chunks->last()->getUniqueId()));

--- a/tests/Concerns/SkipsEmptyRowsTest.php
+++ b/tests/Concerns/SkipsEmptyRowsTest.php
@@ -2,7 +2,6 @@
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\OnEachRow;
@@ -69,10 +68,7 @@ class SkipsEmptyRowsTest extends TestCase
 
             public $rows = 0;
 
-            /**
-             * @return Model|Model[]|null
-             */
-            public function model(array $row): Model|array|null
+            public function model(array $row): null
             {
                 $this->rows++;
 

--- a/tests/Concerns/SkipsOnErrorTest.php
+++ b/tests/Concerns/SkipsOnErrorTest.php
@@ -2,7 +2,6 @@
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\QueryException;
 use Illuminate\Validation\Rule;
 use Maatwebsite\Excel\Concerns\Importable;
@@ -38,7 +37,7 @@ class SkipsOnErrorTest extends TestCase
 
             public $errors = 0;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -77,7 +76,7 @@ class SkipsOnErrorTest extends TestCase
         {
             use Importable, SkipsErrors;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],

--- a/tests/Concerns/SkipsOnFailureTest.php
+++ b/tests/Concerns/SkipsOnFailureTest.php
@@ -2,7 +2,6 @@
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\Rule;
 use Maatwebsite\Excel\Concerns\Importable;
@@ -39,7 +38,7 @@ class SkipsOnFailureTest extends TestCase
 
             public $failures = 0;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -95,7 +94,7 @@ class SkipsOnFailureTest extends TestCase
 
             public $failures = 0;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -149,7 +148,7 @@ class SkipsOnFailureTest extends TestCase
         {
             use Importable, SkipsFailures;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -194,7 +193,7 @@ class SkipsOnFailureTest extends TestCase
         {
             use Importable, SkipsFailures;
 
-            public function onRow(Row $row): ?Model
+            public function onRow(Row $row): User
             {
                 $row = $row->toArray();
 

--- a/tests/Concerns/ToModelTest.php
+++ b/tests/Concerns/ToModelTest.php
@@ -34,10 +34,7 @@ class ToModelTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|Model[]|null
-             */
-            public function model(array $row): Model|array|null
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -69,10 +66,7 @@ class ToModelTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|Model[]|null
-             */
-            public function model(array $row): Model|array|null
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -99,9 +93,9 @@ class ToModelTest extends TestCase
             use Importable;
 
             /**
-             * @return Model|Model[]|null
+             * @return Model[]
              */
-            public function model(array $row): Model|array|null
+            public function model(array $row): array
             {
                 $user1 = new User([
                     'name'     => $row[0],
@@ -136,9 +130,9 @@ class ToModelTest extends TestCase
             use Importable;
 
             /**
-             * @return Model|Model[]|null
+             * @return Model[]
              */
-            public function model(array $row): Model|array|null
+            public function model(array $row): array
             {
                 $user = new User([
                     'name'     => $row[0],
@@ -173,10 +167,7 @@ class ToModelTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|Model[]|null
-             */
-            public function model(array $row): Model|array|null
+            public function model(array $row): User
             {
                 $user = new User([
                     'name'     => $row[0],
@@ -201,7 +192,6 @@ class ToModelTest extends TestCase
         $users = User::all();
         $users->each(function (User $user): void {
             $this->assertInstanceOf(Group::class, $user->group);
-            $this->assertIsInt($user->group->id);
         });
 
         $this->assertCount(2, $users);
@@ -220,10 +210,7 @@ class ToModelTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|Model[]|null
-             */
-            public function model(array $row): Model|array|null
+            public function model(array $row): User
             {
                 $user = new User([
                     'name'     => $row[0],

--- a/tests/Concerns/WithBackgroundColorTest.php
+++ b/tests/Concerns/WithBackgroundColorTest.php
@@ -16,7 +16,7 @@ class WithBackgroundColorTest extends TestCase
         {
             use Exportable;
 
-            public function backgroundColor(): string|array|Color
+            public function backgroundColor(): string
             {
                 return '000000';
             }
@@ -37,7 +37,7 @@ class WithBackgroundColorTest extends TestCase
         {
             use Exportable;
 
-            public function backgroundColor(): string|array|Color
+            public function backgroundColor(): array
             {
                 return [
                     'fillType'   => Fill::FILL_GRADIENT_LINEAR,
@@ -61,7 +61,7 @@ class WithBackgroundColorTest extends TestCase
         {
             use Exportable;
 
-            public function backgroundColor(): string|array|Color
+            public function backgroundColor(): Color
             {
                 return new Color(Color::COLOR_BLUE);
             }

--- a/tests/Concerns/WithBatchInsertsTest.php
+++ b/tests/Concerns/WithBatchInsertsTest.php
@@ -32,7 +32,7 @@ class WithBatchInsertsTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -71,7 +71,7 @@ class WithBatchInsertsTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): Group
             {
                 return new Group([
                     'name' => $row[0],
@@ -99,9 +99,9 @@ class WithBatchInsertsTest extends TestCase
             use Importable;
 
             /**
-             * @return Model|Model[]|null
+             * @return Model[]
              */
-            public function model(array $row): Model|array|null
+            public function model(array $row): array
             {
                 $user = new User([
                     'name'     => $row[0],
@@ -139,10 +139,7 @@ class WithBatchInsertsTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|Model[]|null
-             */
-            public function model(array $row): Model|array|null
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],

--- a/tests/Concerns/WithChunkReadingTest.php
+++ b/tests/Concerns/WithChunkReadingTest.php
@@ -51,7 +51,7 @@ class WithChunkReadingTest extends TestCase
 
             public $after = 0;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -97,7 +97,7 @@ class WithChunkReadingTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): Group
             {
                 return new Group([
                     'name' => $row[0],
@@ -129,7 +129,7 @@ class WithChunkReadingTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): Group
             {
                 return new Group([
                     'name' => $row['name'],
@@ -161,7 +161,7 @@ class WithChunkReadingTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): Group
             {
                 return new Group([
                     'name' => $row[0],
@@ -193,7 +193,7 @@ class WithChunkReadingTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): Group
             {
                 return new Group([
                     'name' => $row[0],
@@ -261,7 +261,7 @@ class WithChunkReadingTest extends TestCase
                 return [
                     new class implements ToModel, WithBatchInserts
                     {
-                        public function model(array $row): ?Model
+                        public function model(array $row): Group
                         {
                             return new Group([
                                 'name' => $row[0],
@@ -276,7 +276,7 @@ class WithChunkReadingTest extends TestCase
 
                     new class implements ToModel, WithBatchInserts
                     {
-                        public function model(array $row): ?Model
+                        public function model(array $row): Group
                         {
                             return new Group([
                                 'name' => $row[0],
@@ -316,7 +316,7 @@ class WithChunkReadingTest extends TestCase
                 return [
                     'Worksheet' => new class implements ToModel, WithBatchInserts
                     {
-                        public function model(array $row): ?Model
+                        public function model(array $row): Group
                         {
                             return new Group([
                                 'name' => $row[0],
@@ -331,7 +331,7 @@ class WithChunkReadingTest extends TestCase
 
                     'Worksheet2' => new class implements ToModel, WithBatchInserts
                     {
-                        public function model(array $row): ?Model
+                        public function model(array $row): Group
                         {
                             return new Group([
                                 'name' => $row[0],

--- a/tests/Concerns/WithDefaultStylesTest.php
+++ b/tests/Concerns/WithDefaultStylesTest.php
@@ -17,7 +17,7 @@ class WithDefaultStylesTest extends TestCase
         {
             use Exportable;
 
-            public function defaultStyles(Style $defaultStyle): ?array
+            public function defaultStyles(Style $defaultStyle): array
             {
                 return [
                     'fill' => [

--- a/tests/Concerns/WithGroupedHeadingRowTest.php
+++ b/tests/Concerns/WithGroupedHeadingRowTest.php
@@ -2,7 +2,6 @@
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\OnEachRow;
@@ -113,7 +112,7 @@ class WithGroupedHeadingRowTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row['name'],

--- a/tests/Concerns/WithHeadingRowTest.php
+++ b/tests/Concerns/WithHeadingRowTest.php
@@ -2,7 +2,6 @@
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ToArray;
@@ -31,7 +30,7 @@ class WithHeadingRowTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row['name'],
@@ -60,7 +59,7 @@ class WithHeadingRowTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row['name'],
@@ -133,7 +132,7 @@ class WithHeadingRowTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row['name'],

--- a/tests/Concerns/WithLimitTest.php
+++ b/tests/Concerns/WithLimitTest.php
@@ -2,7 +2,6 @@
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
-use Illuminate\Database\Eloquent\Model;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Concerns\ToModel;
@@ -31,7 +30,7 @@ class WithLimitTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],

--- a/tests/Concerns/WithReadFilterTest.php
+++ b/tests/Concerns/WithReadFilterTest.php
@@ -10,9 +10,12 @@ use PHPUnit\Framework\Assert;
 
 class WithReadFilterTest extends TestCase
 {
+    public static bool $spy = false;
+
     public function test_can_register_custom_read_filter(): void
     {
-        $export = new class implements WithReadFilter
+        WithReadFilterTest::$spy = false;
+        $export                  = new class implements WithReadFilter
         {
             use Importable;
 
@@ -22,10 +25,7 @@ class WithReadFilterTest extends TestCase
                 {
                     public function readCell(string $columnAddress, int $row, string $worksheetName = ''): bool
                     {
-                        // Assert read filter is being called.
-                        // If assertion is not called, test will fail due to
-                        // test having no other assertions.
-                        Assert::assertTrue(true);
+                        WithReadFilterTest::$spy = true;
 
                         return true;
                     }
@@ -34,5 +34,6 @@ class WithReadFilterTest extends TestCase
         };
 
         $export->toArray('import-users.xlsx');
+        Assert::assertTrue(WithReadFilterTest::$spy);
     }
 }

--- a/tests/Concerns/WithSkipDuplicatesTest.php
+++ b/tests/Concerns/WithSkipDuplicatesTest.php
@@ -2,7 +2,6 @@
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ToModel;
@@ -37,7 +36,7 @@ class WithSkipDuplicatesTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -46,7 +45,7 @@ class WithSkipDuplicatesTest extends TestCase
                 ]);
             }
 
-            public function uniqueBy(): string|array
+            public function uniqueBy(): string
             {
                 return 'email';
             }
@@ -91,10 +90,7 @@ class WithSkipDuplicatesTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|Model[]|null
-             */
-            public function model(array $row): Model|array|null
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -103,7 +99,7 @@ class WithSkipDuplicatesTest extends TestCase
                 ]);
             }
 
-            public function uniqueBy(): string|array
+            public function uniqueBy(): string
             {
                 return 'email';
             }

--- a/tests/Concerns/WithStartRowTest.php
+++ b/tests/Concerns/WithStartRowTest.php
@@ -2,7 +2,6 @@
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
-use Illuminate\Database\Eloquent\Model;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Concerns\ToModel;
@@ -29,7 +28,7 @@ class WithStartRowTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],

--- a/tests/Concerns/WithUpsertsTest.php
+++ b/tests/Concerns/WithUpsertsTest.php
@@ -2,8 +2,6 @@
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ToModel;
@@ -20,10 +18,6 @@ class WithUpsertsTest extends TestCase
      */
     protected function setUp(): void
     {
-        if (!method_exists(Builder::class, 'upsert')) {
-            $this->markTestSkipped('The upsert feature is available on Laravel 8.10+');
-        }
-
         parent::setUp();
 
         $this->loadLaravelMigrations(['--database' => 'testing']);
@@ -43,7 +37,7 @@ class WithUpsertsTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -52,7 +46,7 @@ class WithUpsertsTest extends TestCase
                 ]);
             }
 
-            public function uniqueBy(): string|array
+            public function uniqueBy(): string
             {
                 return 'email';
             }
@@ -97,10 +91,7 @@ class WithUpsertsTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|Model[]|null
-             */
-            public function model(array $row): Model|array|null
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -109,7 +100,7 @@ class WithUpsertsTest extends TestCase
                 ]);
             }
 
-            public function uniqueBy(): string|array
+            public function uniqueBy(): string
             {
                 return 'email';
             }
@@ -149,7 +140,7 @@ class WithUpsertsTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -158,7 +149,7 @@ class WithUpsertsTest extends TestCase
                 ]);
             }
 
-            public function uniqueBy(): string|array
+            public function uniqueBy(): string
             {
                 return 'email';
             }
@@ -208,10 +199,7 @@ class WithUpsertsTest extends TestCase
         {
             use Importable;
 
-            /**
-             * @return Model|Model[]|null
-             */
-            public function model(array $row): Model|array|null
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -220,7 +208,7 @@ class WithUpsertsTest extends TestCase
                 ]);
             }
 
-            public function uniqueBy(): string|array
+            public function uniqueBy(): string
             {
                 return 'email';
             }

--- a/tests/Concerns/WithValidationTest.php
+++ b/tests/Concerns/WithValidationTest.php
@@ -3,7 +3,6 @@
 namespace Maatwebsite\Excel\Tests\Concerns;
 
 use Illuminate\Contracts\Validation\Validator;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\Rule;
 use Maatwebsite\Excel\Concerns\Importable;
@@ -41,7 +40,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -79,7 +78,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -121,7 +120,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -146,7 +145,7 @@ class WithValidationTest extends TestCase
                         /**
                          * Get the validation error message.
                          */
-                        public function message(): string|array
+                        public function message(): string
                         {
                             return 'Value is not an allowed e-mail.';
                         }
@@ -176,7 +175,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -209,7 +208,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -242,7 +241,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -281,7 +280,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -319,7 +318,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -358,7 +357,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -398,7 +397,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row['name'],
@@ -444,7 +443,7 @@ class WithValidationTest extends TestCase
                 return $row;
             }
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row['name'],
@@ -478,7 +477,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row['name'],
@@ -516,7 +515,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            public function onRow(Row $row): ?Model
+            public function onRow(Row $row): User
             {
                 $values = $row->toArray();
 
@@ -609,7 +608,7 @@ class WithValidationTest extends TestCase
         {
             use Importable;
 
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],
@@ -768,10 +767,7 @@ class WithValidationTest extends TestCase
                 return $row;
             }
 
-            /**
-             * @return Model|Model[]|null
-             */
-            public function model(array $row): Model|array|null
+            public function model(array $row): User
             {
                 return new User([
                     'name'     => $row[0],

--- a/tests/Data/Stubs/Database/User.php
+++ b/tests/Data/Stubs/Database/User.php
@@ -20,8 +20,8 @@ use Maatwebsite\Excel\Tests\QueuedQueryExportTest;
  * @property string $name
  * @property string $firstname
  * @property string $lastname
- * @property Carbon $created_at
- * @property Carbon $updated_at
+ * @property ?Carbon $created_at
+ * @property ?Carbon $updated_at
  */
 class User extends Model
 {

--- a/tests/Data/Stubs/QueueImportWithoutJobChaining.php
+++ b/tests/Data/Stubs/QueueImportWithoutJobChaining.php
@@ -2,7 +2,6 @@
 
 namespace Maatwebsite\Excel\Tests\Data\Stubs;
 
-use Illuminate\Database\Eloquent\Model;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ShouldQueueWithoutChain;
 use Maatwebsite\Excel\Concerns\ToModel;
@@ -24,7 +23,7 @@ class QueueImportWithoutJobChaining implements ShouldQueueWithoutChain, ToModel,
 
     public $after = false;
 
-    public function model(array $row): ?Model
+    public function model(array $row): User
     {
         return new User([
             'name'     => $row[0],

--- a/tests/Data/Stubs/QueuedImport.php
+++ b/tests/Data/Stubs/QueuedImport.php
@@ -3,7 +3,6 @@
 namespace Maatwebsite\Excel\Tests\Data\Stubs;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Database\Eloquent\Model;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithBatchInserts;
@@ -14,7 +13,7 @@ class QueuedImport implements ShouldQueue, ToModel, WithBatchInserts, WithChunkR
 {
     use Importable;
 
-    public function model(array $row): ?Model
+    public function model(array $row): Group
     {
         return new Group([
             'name' => $row[0],

--- a/tests/Data/Stubs/QueuedImportWithMiddleware.php
+++ b/tests/Data/Stubs/QueuedImportWithMiddleware.php
@@ -3,7 +3,6 @@
 namespace Maatwebsite\Excel\Tests\Data\Stubs;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Database\Eloquent\Model;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithChunkReading;
@@ -13,7 +12,7 @@ class QueuedImportWithMiddleware implements ShouldQueue, ToModel, WithChunkReadi
 {
     use Importable;
 
-    public function model(array $row): ?Model
+    public function model(array $row): Group
     {
         return new Group([
             'name' => $row[0],

--- a/tests/Data/Stubs/QueuedImportWithRetryUntil.php
+++ b/tests/Data/Stubs/QueuedImportWithRetryUntil.php
@@ -3,7 +3,6 @@
 namespace Maatwebsite\Excel\Tests\Data\Stubs;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Database\Eloquent\Model;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithChunkReading;
@@ -13,7 +12,7 @@ class QueuedImportWithRetryUntil implements ShouldQueue, ToModel, WithChunkReadi
 {
     use Importable;
 
-    public function model(array $row): ?Model
+    public function model(array $row): Group
     {
         return new Group([
             'name' => $row[0],

--- a/tests/Data/Stubs/ShouldBatchImport.php
+++ b/tests/Data/Stubs/ShouldBatchImport.php
@@ -3,7 +3,6 @@
 namespace Maatwebsite\Excel\Tests\Data\Stubs;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Database\Eloquent\Model;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ShouldBatch;
 use Maatwebsite\Excel\Concerns\ToModel;
@@ -15,7 +14,7 @@ class ShouldBatchImport implements ShouldBatch, ShouldQueue, ToModel, WithBatchI
 {
     use Importable;
 
-    public function model(array $row): ?Model
+    public function model(array $row): Group
     {
         return new Group([
             'name' => $row[0],

--- a/tests/ExcelFakeTest.php
+++ b/tests/ExcelFakeTest.php
@@ -3,7 +3,6 @@
 namespace Maatwebsite\Excel\Tests;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\FromCollection;
@@ -136,8 +135,6 @@ class ExcelFakeTest extends TestCase
 
         $response = ExcelFacade::raw($this->givenExport(), Excel::XLSX);
 
-        $this->assertIsString($response);
-
         ExcelFacade::assertExportedInRaw($this->givenExport()::class);
         ExcelFacade::assertExportedInRaw($this->givenExport()::class, fn (FromCollection $export) => $export->collection()->contains('foo'));
     }
@@ -253,7 +250,7 @@ class ExcelFakeTest extends TestCase
     {
         return new class implements ToModel
         {
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([]);
             }
@@ -264,7 +261,7 @@ class ExcelFakeTest extends TestCase
     {
         return new class implements ShouldQueue, ToModel
         {
-            public function model(array $row): ?Model
+            public function model(array $row): User
             {
                 return new User([]);
             }

--- a/tests/PhpSpreadsheetV5CompatibilityTest.php
+++ b/tests/PhpSpreadsheetV5CompatibilityTest.php
@@ -181,16 +181,11 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
         // The test documents the current v5 behavior.
         $bindValueCalled = false;
 
-        $import = new class($bindValueCalled) extends DefaultValueBinder implements WithCustomValueBinder
+        $import = new class extends DefaultValueBinder implements WithCustomValueBinder
         {
             use Importable;
 
-            private $bindValueCalled;
-
-            public function __construct(&$bindValueCalled)
-            {
-                $this->bindValueCalled = &$bindValueCalled;
-            }
+            public bool $bindValueCalled = false;
 
             public function bindValue(Cell $cell, mixed $value): bool
             {
@@ -202,7 +197,7 @@ class PhpSpreadsheetV5CompatibilityTest extends TestCase
 
         $result = $import->toArray('value-binder-import.xlsx');
 
-        $this->assertFalse($bindValueCalled, 'PHPSpreadsheet v5 does not call value binders during import');
+        $this->assertFalse($import->bindValueCalled, 'PHPSpreadsheet v5 does not call value binders during import');
         $this->assertNotEmpty($result[0], 'Data should still be imported without the value binder');
     }
 

--- a/tests/QueuedImportTest.php
+++ b/tests/QueuedImportTest.php
@@ -169,7 +169,7 @@ class QueuedImportTest extends TestCase
         }
 
         $this->assertFalse($tempFile?->existsLocally());
-        $this->assertTrue($tempFile?->exists());
+        $this->assertTrue($tempFile->exists());
     }
 
     public function test_cannot_automatically_delete_temp_file_on_failure_when_using_local_disk(): void

--- a/tests/QueuedQueryExportTest.php
+++ b/tests/QueuedQueryExportTest.php
@@ -82,8 +82,6 @@ class QueuedQueryExportTest extends TestCase
     {
         if (!class_exists(DatabaseEngine::class)) {
             $this->markTestSkipped('Laravel Scout is too old');
-
-            return;
         }
 
         $export = new FromUsersScoutExport;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,7 +10,6 @@ use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use PhpOffice\PhpSpreadsheet\Exception;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
-use PHPUnit\Framework\Constraint\StringContains;
 
 class TestCase extends OrchestraTestCase
 {
@@ -95,32 +94,16 @@ class TestCase extends OrchestraTestCase
 
     protected function assertStringContains(string $needle, string $haystack, string $message = ''): void
     {
-        if (method_exists($this, 'assertStringContainsString')) {
-            $this->assertStringContainsString($needle, $haystack, $message);
-        } else {
-            static::assertThat($haystack, new StringContains($needle, false), $message);
-        }
+        $this->assertStringContainsString($needle, $haystack, $message);
     }
 
     protected function assertFileMissing(string $path): void
     {
-        if (method_exists($this, 'assertFileDoesNotExist')) {
-            $this->assertFileDoesNotExist($path);
-        } elseif (method_exists($this, 'assertFileNotExists')) {
-            $this->assertFileNotExists($path);
-        } else {
-            throw new Exception('Missing file assert type');
-        }
+        $this->assertFileDoesNotExist($path);
     }
 
     protected function assertRegex(string $pattern, string $string): void
     {
-        if (method_exists($this, 'assertMatchesRegularExpression')) {
-            $this->assertMatchesRegularExpression($pattern, $string);
-        } elseif (method_exists($this, 'assertRegExp')) {
-            $this->assertRegExp($pattern, $string);
-        } else {
-            throw new Exception('Missing regex assert type');
-        }
+        $this->assertMatchesRegularExpression($pattern, $string);
     }
 }


### PR DESCRIPTION
`BatchCache` was making an assumption that the keys would always be an array in, which isn't the case but handeling it is a lot of extra work.

PHPStan level 4 is also mostly handled here, it mostly deals with unreachable code and redundant checks which is especially true now that we have native types on things.