### PR TITLE
Add detailed Laravel Excel Boost skill references

### DIFF
--- a/resources/boost/skills/laravel-excel/SKILL.md
+++ b/resources/boost/skills/laravel-excel/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: laravel-excel
+description: "Activate when the user works on spreadsheet imports or exports in Laravel with maatwebsite/excel. Use for Excel::download(), Excel::store(), Excel::raw(), Excel::import(), Excel::queue(), Excel::queueImport(), export and import classes, make:export, make:import, collection/query/view exports, ToModel imports, heading rows, mapping, validation, chunk reading, batch inserts, queued imports or exports, multiple sheets, column formatting, CSV settings, temporary file configuration, Excel::fake() assertions, or config/excel.php."
+license: MIT
+metadata:
+  author: laravel
+---
+
+# Laravel Excel
+
+Use this skill when a Laravel task involves `maatwebsite/excel` exports, imports, queueing, formatting, or package configuration.
+
+## Documentation
+
+Use `search-docs` first when it is available for Laravel-side integration patterns. For package-specific behavior, inspect:
+
+- `src/Excel.php`
+- `src/ExcelServiceProvider.php`
+- `src/Concerns/*`
+- `src/Console/ExportMakeCommand.php`
+- `src/Console/ImportMakeCommand.php`
+- `config/excel.php`
+- `tests/*` for expected behavior and supported concern combinations
+- `references/package.md` for a compact package reference covering concerns, macros, queueing, config, and test patterns
+
+Load `references/package.md` when the task needs package-specific detail beyond the core workflow in this file.
+
+## Package Surface
+
+The package auto-discovers:
+
+- Service provider: `Maatwebsite\Excel\ExcelServiceProvider`
+- Facade alias: `Maatwebsite\Excel\Facades\Excel`
+
+The service provider also registers:
+
+- `make:export`
+- `make:import`
+- collection macros for download and store
+- query builder macros for download, store, and import
+
+## Installation And Setup
+
+Install the package with Composer:
+
+```bash
+composer require maatwebsite/excel
+```
+
+Publish config when the app needs local overrides:
+
+```bash
+php artisan vendor:publish --provider="Maatwebsite\\Excel\\ExcelServiceProvider" --tag=config
+```
+
+Publish the generator stubs when the app wants to customize generated import or export classes:
+
+```bash
+php artisan vendor:publish --provider="Maatwebsite\\Excel\\ExcelServiceProvider" --tag=stubs
+```
+
+## Generate Classes
+
+Prefer the package generators instead of hand-writing the initial class:
+
+```bash
+php artisan make:export UsersExport
+php artisan make:export UsersExport --model=User
+php artisan make:export UsersExport --model=User --query
+
+php artisan make:import UsersImport
+php artisan make:import UsersImport --model=User
+```
+
+Generated classes live in:
+
+- `app/Exports`
+- `app/Imports`
+
+## Core Working Pattern
+
+1. Start with `make:export` or `make:import`.
+2. Pick the smallest concern set that matches the use case.
+3. Keep data shaping inside the export or import class, not the controller.
+4. Queue large workloads instead of processing them inline.
+5. Test with `Excel::fake()` when the goal is verifying dispatch behavior, filenames, disks, and class wiring.
+
+## Exports
+
+Choose the export source concern based on the data shape:
+
+- `FromCollection` for already materialized Laravel collections
+- `FromArray` for small ad hoc arrays
+- `FromQuery` for large Eloquent or query builder datasets
+- `FromView` when a Blade table is the source of truth
+- `FromGenerator` or `FromIterator` for streamed or memory-sensitive data
+
+Common export concerns:
+
+- `Exportable` for fluent `download()`, `store()`, and `queue()` on the export object
+- `WithHeadings` to add header rows
+- `WithMapping` to transform each row
+- `WithColumnFormatting` for Excel number or date formats
+- `ShouldAutoSize` or `WithColumnWidths` for column sizing
+- `WithStyles`, `WithDefaultStyles`, and `WithBackgroundColor` for styling
+- `WithProperties` for workbook metadata
+- `WithMultipleSheets` and `WithTitle` for multi-sheet files
+- `WithEvents` or `RegistersEventListeners` for workbook and sheet hooks
+- `WithDrawings` or `WithCharts` when spreadsheet assets are required
+- `WithStrictNullComparison` when empty strings must remain explicit cells
+- `WithCustomCsvSettings` for CSV delimiter, BOM, encoding, and related output settings
+- `WithCustomStartCell` or `WithMappedCells` for precise worksheet positioning
+
+Typical export response:
+
+```php
+use App\Exports\UsersExport;
+use Maatwebsite\Excel\Facades\Excel;
+
+return Excel::download(new UsersExport(), 'users.xlsx');
+```
+
+Prefer `FromQuery` for large datasets. The package chunks query exports automatically using `config('excel.exports.chunk_size')`.
+
+## Imports
+
+Choose the import target concern based on how rows should be consumed:
+
+- `ToModel` to turn rows into Eloquent models
+- `ToCollection` for in-memory row processing
+- `ToArray` for raw array access
+- `OnEachRow` when each row needs imperative handling
+
+Common import concerns:
+
+- `Importable` for fluent `import()` and `queue()` on the import object
+- `WithHeadingRow` or `WithGroupedHeadingRow` for heading-based row keys
+- `WithValidation` for row validation rules
+- `WithChunkReading` for large files
+- `WithBatchInserts` for efficient `ToModel` imports
+- `WithUpserts` and `WithUpsertColumns` for idempotent writes
+- `WithStartRow` to skip preamble rows
+- `WithReadFilter` or `WithLimit` to narrow input
+- `SkipsEmptyRows`, `SkipsOnFailure`, `SkipsFailures`, `SkipsOnError`, and `SkipsErrors` for fault-tolerant imports
+- `WithCalculatedFormulas` when formula values must be evaluated during import
+- `WithCustomCsvSettings` for delimiter, escape character, and encoding overrides
+- `WithCustomValueBinder` when cell type coercion must change
+- `RemembersRowNumber` or `RemembersChunkOffset` when row-level diagnostics matter
+- `SkipsUnknownSheets` and `WithMultipleSheets` for workbook imports with sheet selection
+
+Typical import:
+
+```php
+use App\Imports\UsersImport;
+use Maatwebsite\Excel\Facades\Excel;
+
+Excel::import(new UsersImport(), $request->file('spreadsheet'));
+```
+
+For `ToModel` imports, keep `model(array $row)` focused on turning one row into one model instance. Use batch inserts and chunk reading for larger files.
+
+## Queueing And Large Files
+
+Large exports and imports should usually be queued.
+
+Important package behavior:
+
+- Queued imports must implement `ShouldQueue`
+- Queued exports can be triggered explicitly with `Excel::queue()` or fluently via `Exportable`
+- Some flows are implicitly queued depending on the export or import class behavior
+- Query exports and chunk-reading imports already expose package-level chunk processing primitives
+
+Typical queued import:
+
+```php
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithChunkReading;
+
+class UsersImport implements ToModel, WithChunkReading, ShouldQueue
+{
+    use Importable;
+
+    public function model(array $row): User
+    {
+        return new User([
+            'name' => $row[0],
+        ]);
+    }
+
+    public function chunkSize(): int
+    {
+        return 1000;
+    }
+}
+```
+
+Remote temporary file support is configured under `excel.temporary_files.*`. Use a shared remote disk for multi-worker queue setups.
+
+## Configuration
+
+Package configuration lives in `config/excel.php`. Important areas:
+
+- `exports.chunk_size` for `FromQuery` export chunk size
+- `exports.pre_calculate_formulas`
+- `exports.strict_null_comparison`
+- `exports.csv.*` for CSV output
+- `imports.read_only`
+- `imports.ignore_empty`
+- `imports.heading_row.formatter`
+- `imports.csv.*` for CSV input
+- `imports.cells.middleware` for cell value preprocessing
+- `extension_detector` for file type guessing
+- `value_binder.default`
+- `cache.driver` and `cache.batch.memory_limit`
+- `temporary_files.*` for local and remote temp file handling
+- `transactions.*` for import transaction behavior
+
+If an import or export behaves unexpectedly, check config first before changing application code.
+
+## Testing
+
+Prefer `Excel::fake()` when verifying interaction with the package:
+
+```php
+use Maatwebsite\Excel\Facades\Excel;
+
+Excel::fake();
+
+Excel::download(new UsersExport(), 'users.xlsx');
+
+Excel::assertDownloaded('users.xlsx');
+```
+
+The fake supports assertions for:
+
+- `assertDownloaded()`
+- `assertStored()`
+- `assertQueued()`
+- `assertQueuedWithChain()`
+- `assertImported()`
+- `assertExportedInRaw()`
+- regex filename matching via `matchByRegex()`
+
+Use full file assertions only when the spreadsheet contents themselves are the behavior under test.
+
+## Query And Collection Macros
+
+The service provider registers convenience macros:
+
+- collection download and store helpers
+- query builder `downloadExcel`
+- query builder `storeExcel`
+- query builder `import`
+- query builder `importAs`
+
+Prefer these only when they fit existing project conventions. For non-trivial workflows, dedicated import and export classes are usually clearer.
+
+## Best Practices
+
+- Prefer dedicated export and import classes over controllers filled with spreadsheet logic.
+- Prefer `FromQuery` plus queueing for large exports.
+- Pair `ToModel` imports with `WithBatchInserts` and `WithChunkReading` for large files.
+- Use `WithHeadingRow` when the input file is business-managed and columns are named.
+- Keep `WithMapping` and `model()` deterministic and side-effect light.
+- Use `WithValidation` instead of ad hoc row guards when validation rules can express the constraint.
+- Use `WithCustomCsvSettings` instead of hand-parsing CSV files.
+- Keep sheet formatting concerns inside the export class, not post-processing controller code.
+
+## Common Pitfalls
+
+- Queuing an import that does not implement `ShouldQueue`
+- Using `FromCollection` for very large datasets that should be query-driven
+- Forgetting `WithHeadingRow` while treating row keys as headings
+- Expecting empty strings to survive export without `WithStrictNullComparison`
+- Missing a shared remote temp disk in distributed queued imports
+- Hand-coding imports or exports instead of using concerns that already express the behavior
+- Testing only the HTTP status while ignoring the generated file interaction

--- a/resources/boost/skills/laravel-excel/references/package.md
+++ b/resources/boost/skills/laravel-excel/references/package.md
@@ -1,0 +1,244 @@
+# Laravel Excel Reference
+
+Use this reference when the task needs package-specific detail that would make `SKILL.md` too large.
+
+## Entry Points
+
+- Facade: `Maatwebsite\Excel\Facades\Excel`
+- Service provider: `Maatwebsite\Excel\ExcelServiceProvider`
+- Core classes:
+  - `src/Excel.php`
+  - `src/Reader.php`
+  - `src/Writer.php`
+  - `src/QueuedWriter.php`
+  - `src/ChunkReader.php`
+
+The service provider registers:
+
+- `make:export`
+- `make:import`
+- collection macros for spreadsheet download and storage
+- query builder macros for spreadsheet download, storage, and import
+
+## Generator Commands
+
+Prefer generator commands for the initial class shape:
+
+```bash
+php artisan make:export ReportExport
+php artisan make:export ReportExport --model=User
+php artisan make:export ReportExport --model=User --query
+
+php artisan make:import UsersImport
+php artisan make:import UsersImport --model=User
+```
+
+Command implementation details:
+
+- `make:export --model=Model --query` generates a query-based export stub
+- `make:import --model=Model` generates a model import stub
+- default namespaces are `App\Exports` and `App\Imports`
+
+## Export Source Concerns
+
+Choose one primary export source concern:
+
+- `FromArray`
+- `FromCollection`
+- `FromGenerator`
+- `FromIterator`
+- `FromQuery`
+- `FromView`
+
+Typical selection:
+
+- use `FromCollection` when the rows already exist in memory
+- use `FromQuery` for large datasets and queue-heavy workflows
+- use `FromView` when the spreadsheet shape follows a Blade table
+- use `FromGenerator` or `FromIterator` when memory pressure matters
+
+## Export Behavior Concerns
+
+Common export concerns in this package:
+
+- `Exportable`
+- `ShouldAutoSize`
+- `WithBackgroundColor`
+- `WithCharts`
+- `WithColumnFormatting`
+- `WithColumnLimit`
+- `WithColumnWidths`
+- `WithConditionalSheets`
+- `WithCustomCsvSettings`
+- `WithCustomQuerySize`
+- `WithCustomStartCell`
+- `WithCustomValueBinder`
+- `WithDefaultStyles`
+- `WithDrawings`
+- `WithEvents`
+- `WithHeadings`
+- `WithLimit`
+- `WithMappedCells`
+- `WithMapping`
+- `WithMultipleSheets`
+- `WithPreCalculateFormulas`
+- `WithProperties`
+- `WithStrictNullComparison`
+- `WithStyles`
+- `WithTitle`
+
+Practical guidance:
+
+- pair `FromQuery` with `WithMapping` when rows need transformation
+- use `WithHeadings` instead of manually prepending a heading row
+- use `WithMultipleSheets` when each sheet has a separate export object
+- use `WithColumnFormatting` for dates, currency, percentages, and IDs that should remain numeric
+- use `WithCustomCsvSettings` for delimiter, encoding, BOM, or Excel compatibility changes
+
+## Import Target Concerns
+
+Choose one primary import target concern:
+
+- `ToArray`
+- `ToCollection`
+- `ToModel`
+- `OnEachRow`
+
+Typical selection:
+
+- use `ToModel` when each row maps cleanly to one persisted model
+- use `OnEachRow` when rows trigger imperative workflows or service calls
+- use `ToCollection` or `ToArray` when the import is validated or transformed before persistence
+
+## Import Behavior Concerns
+
+Common import concerns in this package:
+
+- `Importable`
+- `RegistersEventListeners`
+- `RemembersChunkOffset`
+- `RemembersRowNumber`
+- `ShouldQueueWithoutChain`
+- `SkipsEmptyRows`
+- `SkipsErrors`
+- `SkipsFailures`
+- `SkipsOnError`
+- `SkipsOnFailure`
+- `SkipsUnknownSheets`
+- `WithBatchInserts`
+- `WithCalculatedFormulas`
+- `WithChunkReading`
+- `WithCustomCsvSettings`
+- `WithCustomValueBinder`
+- `WithGroupedHeadingRow`
+- `WithHeadingRow`
+- `WithLimit`
+- `WithReadFilter`
+- `WithSkipDuplicates`
+- `WithStartRow`
+- `WithUpserts`
+- `WithUpsertColumns`
+- `WithValidation`
+
+Practical guidance:
+
+- pair `ToModel` with `WithBatchInserts` and `WithChunkReading` for large files
+- use `WithHeadingRow` when business users control the spreadsheet columns
+- use `WithValidation` and skip concerns instead of custom row guards where possible
+- use `WithUpserts` for repeatable imports keyed by a natural or unique key
+- use `RemembersRowNumber` when validation or audit errors need exact row references
+
+## Queueing Notes
+
+Queue-related behavior is part of the package surface:
+
+- queued imports must implement `Illuminate\Contracts\Queue\ShouldQueue`
+- exports may be queued explicitly with `Excel::queue()` or by using `Exportable`
+- imports may be queued with `Excel::queueImport()` or `Importable::queue()`
+- queued imports and exports use temporary files and chunk jobs internally
+
+For distributed workers:
+
+- configure `excel.temporary_files.remote_disk`
+- use a shared disk accessible by all workers
+- consider `excel.temporary_files.remote_prefix`
+- review `force_resync_remote` behavior when troubleshooting temp-file sync issues
+
+## Macros
+
+The package adds convenience macros:
+
+- collection download helper
+- collection store helper
+- query builder `downloadExcel`
+- query builder `storeExcel`
+- query builder `import`
+- query builder `importAs`
+
+Prefer dedicated import and export classes when the spreadsheet workflow contains mapping, validation, formatting, or queueing logic.
+
+## Configuration Map
+
+Important `config/excel.php` sections:
+
+- `exports.chunk_size`
+- `exports.pre_calculate_formulas`
+- `exports.strict_null_comparison`
+- `exports.csv.*`
+- `exports.properties.*`
+- `imports.read_only`
+- `imports.ignore_empty`
+- `imports.heading_row.formatter`
+- `imports.csv.*`
+- `imports.cells.middleware`
+- `imports.properties.*`
+- `extension_detector.*`
+- `value_binder.default`
+- `cache.driver`
+- `cache.batch.memory_limit`
+- `cache.illuminate.store`
+- `temporary_files.local_path`
+- `temporary_files.remote_disk`
+- `temporary_files.remote_prefix`
+- `temporary_files.force_resync_remote`
+- `transactions.handler`
+
+When behavior is surprising, inspect config before rewriting application logic.
+
+## Testing Reference
+
+The package fake supports assertions for:
+
+- `assertDownloaded()`
+- `assertStored()`
+- `assertQueued()`
+- `assertQueuedWithChain()`
+- `assertImported()`
+- `assertExportedInRaw()`
+- regex matching after `matchByRegex()`
+
+Use the fake when testing:
+
+- controller actions returning spreadsheet downloads
+- storage dispatch to the right disk and filename
+- queued spreadsheet jobs
+- import dispatch with the correct import class
+
+Use deeper content assertions only when the workbook bytes or transformed sheet structure are the feature under test.
+
+## Good Defaults
+
+- default to `FromQuery` over `FromCollection` for large exports
+- default to `WithHeadingRow` for user-provided spreadsheets with named columns
+- default to queueing for large imports and exports
+- default to package concerns before writing custom spreadsheet plumbing
+- default to `Excel::fake()` for workflow tests
+
+## Common Failure Modes
+
+- queuing an import without `ShouldQueue`
+- reading heading keys without `WithHeadingRow`
+- loading too much data into memory with `FromCollection`
+- missing shared temporary storage in a distributed queue setup
+- hand-parsing CSV instead of using package CSV settings
+- skipping validation and then debugging database exceptions later


### PR DESCRIPTION
Adds package-specific Boost skill references for Laravel Excel.

This change keeps `resources/boost/skills/laravel-excel/SKILL.md` focused on the core workflow and adds `references/package.md` for deeper package guidance. The reference covers generator commands, export/import concerns, queueing, config, macros, testing patterns, and common failure modes so agents can load detailed context only when needed.

1. Why should it be added? What are the benefits of this change?

It improves the Laravel Excel Boost skill by separating the quick-start guidance from deeper package reference material. That reduces context bloat in `SKILL.md` while giving agents better package-specific detail when working on imports, exports, queueing, and testing.

2. Does it contain multiple, unrelated changes? Please separate the PRs out.

No. This PR only adds Laravel Excel skill documentation and its related reference file.

3. Does it include tests, if possible?

No runtime code changed, so no package tests were added. The added files were checked for required Boost skill structure and reference linking.

4. Any drawbacks? Possible breaking changes?

No breaking changes expected. This only adds documentation files under `resources/boost/skills/laravel-excel/`.

5. Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.