### PR TITLE
fix comment indentation in Cell Middleware config being 1 space off

### DIFF
--- a/config/excel.php
+++ b/config/excel.php
@@ -152,13 +152,13 @@ return [
         ],
 
         /*
-       |--------------------------------------------------------------------------
-       | Cell Middleware
-       |--------------------------------------------------------------------------
-       |
-       | Configure middleware that is executed on getting a cell value
-       |
-       */
+        |--------------------------------------------------------------------------
+        | Cell Middleware
+        |--------------------------------------------------------------------------
+        |
+        | Configure middleware that is executed on getting a cell value
+        |
+        */
         'cells'        => [
             'middleware' => [
                 //\Maatwebsite\Excel\Middleware\TrimCellValue::class,


### PR DESCRIPTION
The comment for Cell Middleware in the `excel.php` publishable config file were one space off.

The rest of the comments in the file are indented properly. Only this one was off.

- [X] Checked the codebase to ensure that your feature doesn't already exist.
- [X] Take note of the contributing guidelines.
- [X] Checked the pull requests to ensure that another person hasn't already submitted a fix.
~~- [X] Added tests to ensure against regression.~~