### PR TITLE
Support the #[Queue] and #[Connection] attributes on imports

### DIFF
--- a/src/ChunkReader.php
+++ b/src/ChunkReader.php
@@ -15,6 +15,7 @@ use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Concerns\WithLimit;
 use Maatwebsite\Excel\Concerns\WithProgressBar;
 use Maatwebsite\Excel\Files\TemporaryFile;
+use Maatwebsite\Excel\Helpers\QueueResolver;
 use Maatwebsite\Excel\Imports\HeadingRowExtractor;
 use Maatwebsite\Excel\Jobs\AfterImportJob;
 use Maatwebsite\Excel\Jobs\QueueImport;
@@ -48,7 +49,7 @@ class ChunkReader
         $chunkSize    = $import->chunkSize();
         $totalRows    = $reader->getTotalRows();
         $worksheets   = $reader->getWorksheets($import);
-        $queue        = property_exists($import, 'queue') ? $import->queue : null;
+        $queue        = QueueResolver::queue($import);
         $delayCleanup = property_exists($import, 'cleanupInterval') ? $import->cleanupInterval : 60;
 
         if ($import instanceof WithProgressBar) {

--- a/src/Helpers/QueueResolver.php
+++ b/src/Helpers/QueueResolver.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Maatwebsite\Excel\Helpers;
+
+use Illuminate\Queue\Attributes\Connection;
+use Illuminate\Queue\Attributes\Queue;
+use Illuminate\Queue\Attributes\ReadsQueueAttributes;
+
+class QueueResolver
+{
+    /**
+     * Resolve the queue an import should be dispatched on. Honours a #[Queue]
+     * attribute exactly like Laravel resolves it for regular jobs (including
+     * backed-enum values), falling back to a plain `queue` property.
+     *
+     * @param  object  $import
+     * @return mixed
+     */
+    public static function queue($import)
+    {
+        return self::resolve($import, Queue::class, 'queue');
+    }
+
+    /**
+     * Resolve the connection an import should be dispatched on. Honours a
+     * #[Connection] attribute, falling back to a plain `connection` property.
+     *
+     * @param  object  $import
+     * @return mixed
+     */
+    public static function connection($import)
+    {
+        return self::resolve($import, Connection::class, 'connection');
+    }
+
+    /**
+     * @param  object  $import
+     * @param  string  $attribute
+     * @param  string  $property
+     * @return mixed
+     */
+    private static function resolve($import, string $attribute, string $property)
+    {
+        // Laravel only reads these attributes off the job it dispatches, never
+        // off the import, so we have to read them ourselves. When the framework
+        // provides its attribute reader we reuse it, so resolution (including
+        // backed-enum values) matches how regular queued jobs are dispatched.
+        // Older versions without the reader fall back to a plain property.
+        if (trait_exists(ReadsQueueAttributes::class)) {
+            return self::reader()->read($import, $attribute, $property);
+        }
+
+        return property_exists($import, $property) ? $import->{$property} : null;
+    }
+
+    /**
+     * @return object
+     */
+    private static function reader()
+    {
+        return new class
+        {
+            use ReadsQueueAttributes;
+
+            /**
+             * @param  object  $target
+             * @param  string  $attribute
+             * @param  string  $property
+             * @return mixed
+             */
+            public function read($target, string $attribute, string $property)
+            {
+                return $this->getAttributeValue($target, $attribute, $property);
+            }
+        };
+    }
+}

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -15,6 +15,7 @@ use Maatwebsite\Excel\Files\RemoteTemporaryFile;
 use Maatwebsite\Excel\Files\TemporaryFile;
 use Maatwebsite\Excel\Filters\ChunkReadFilter;
 use Maatwebsite\Excel\HasEventBus;
+use Maatwebsite\Excel\Helpers\QueueResolver;
 use Maatwebsite\Excel\Imports\HeadingRowExtractor;
 use Maatwebsite\Excel\Sheet;
 use Maatwebsite\Excel\Transactions\TransactionHandler;
@@ -118,8 +119,8 @@ class ReadChunk implements ShouldQueue
         $this->tries         = $import->tries ?? null;
         $this->maxExceptions = $import->maxExceptions ?? null;
         $this->backoff       = method_exists($import, 'backoff') ? $import->backoff() : ($import->backoff ?? null);
-        $this->connection    = property_exists($import, 'connection') ? $import->connection : null;
-        $this->queue         = property_exists($import, 'queue') ? $import->queue : null;
+        $this->connection    = QueueResolver::connection($import);
+        $this->queue         = QueueResolver::queue($import);
     }
 
     public function getUniqueId(): string

--- a/tests/Concerns/ShouldQueueWithoutChainTest.php
+++ b/tests/Concerns/ShouldQueueWithoutChainTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Queue;
 use Maatwebsite\Excel\Jobs\AfterImportJob;
 use Maatwebsite\Excel\Jobs\QueueImport;
 use Maatwebsite\Excel\Jobs\ReadChunk;
+use Maatwebsite\Excel\Tests\Data\Stubs\QueuedImportWithQueueAttribute;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueueImportWithoutJobChaining;
 use Maatwebsite\Excel\Tests\TestCase;
 
@@ -60,6 +61,21 @@ class ShouldQueueWithoutChainTest extends TestCase
 
         Queue::assertPushedOn('queue-name', ReadChunk::class);
         Queue::assertPushedOn('queue-name', AfterImportJob::class);
+    }
+
+    public function test_a_queue_attribute_is_used_when_importing()
+    {
+        if (!class_exists(\Illuminate\Queue\Attributes\Queue::class)) {
+            $this->markTestSkipped('The #[Queue] attribute is not available on this Laravel version');
+        }
+
+        Queue::fake();
+
+        $import = new QueuedImportWithQueueAttribute();
+        $import->import('import-users.xlsx');
+
+        Queue::assertPushedOn('excel-imports', ReadChunk::class);
+        Queue::assertPushedOn('excel-imports', AfterImportJob::class);
     }
 
     public function test_the_cleanup_only_runs_when_all_jobs_are_done()

--- a/tests/Data/Stubs/Enums/QueueChannel.php
+++ b/tests/Data/Stubs/Enums/QueueChannel.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs\Enums;
+
+enum QueueChannel: string
+{
+    case EXCEL_IMPORTS = 'excel-imports';
+}

--- a/tests/Data/Stubs/QueuedImportWithQueueAttribute.php
+++ b/tests/Data/Stubs/QueuedImportWithQueueAttribute.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Illuminate\Queue\Attributes\Connection;
+use Illuminate\Queue\Attributes\Queue;
+use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\ShouldQueueWithoutChain;
+use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithChunkReading;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
+use Maatwebsite\Excel\Tests\Data\Stubs\Enums\QueueChannel;
+
+#[Queue(QueueChannel::EXCEL_IMPORTS)]
+#[Connection('redis')]
+class QueuedImportWithQueueAttribute implements ToModel, WithChunkReading, ShouldQueueWithoutChain
+{
+    use Importable;
+
+    /**
+     * @param  array  $row
+     * @return User
+     */
+    public function model(array $row)
+    {
+        return new User([
+            'name'     => $row[0],
+            'email'    => $row[1],
+            'password' => 'secret',
+        ]);
+    }
+
+    /**
+     * @return int
+     */
+    public function chunkSize(): int
+    {
+        return 1;
+    }
+}

--- a/tests/Jobs/ReadChunkTest.php
+++ b/tests/Jobs/ReadChunkTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Jobs;
+
+use Maatwebsite\Excel\Concerns\WithChunkReading;
+use Maatwebsite\Excel\Files\LocalTemporaryFile;
+use Maatwebsite\Excel\Jobs\ReadChunk;
+use Maatwebsite\Excel\Tests\Data\Stubs\QueuedImportWithQueueAttribute;
+use Maatwebsite\Excel\Tests\TestCase;
+use PhpOffice\PhpSpreadsheet\Reader\Xlsx;
+
+class ReadChunkTest extends TestCase
+{
+    public function test_resolves_the_queue_and_connection_from_attributes()
+    {
+        if (!class_exists(\Illuminate\Queue\Attributes\Queue::class)) {
+            $this->markTestSkipped('The #[Queue] attribute is not available on this Laravel version');
+        }
+
+        $job = $this->readChunkFor(new QueuedImportWithQueueAttribute());
+
+        $this->assertSame('excel-imports', $job->queue);
+        $this->assertSame('redis', $job->connection);
+    }
+
+    public function test_keeps_a_string_queue_property()
+    {
+        $import = new class implements WithChunkReading {
+            public $queue = 'plain-queue';
+
+            public function chunkSize(): int
+            {
+                return 100;
+            }
+        };
+
+        $job = $this->readChunkFor($import);
+
+        $this->assertSame('plain-queue', $job->queue);
+    }
+
+    public function test_resolves_to_null_without_a_queue()
+    {
+        $import = new class implements WithChunkReading {
+            public function chunkSize(): int
+            {
+                return 100;
+            }
+        };
+
+        $job = $this->readChunkFor($import);
+
+        $this->assertNull($job->queue);
+    }
+
+    private function readChunkFor(WithChunkReading $import): ReadChunk
+    {
+        return new ReadChunk(
+            $import,
+            new Xlsx(),
+            new LocalTemporaryFile(tempnam(sys_get_temp_dir(), 'laravel-excel')),
+            'Worksheet',
+            $import,
+            1,
+            100
+        );
+    }
+}


### PR DESCRIPTION
## What

Resolve an import's queue and connection from the native Laravel `#[Queue(...)]` and `#[Connection(...)]` attributes, in addition to the existing `queue`/`connection` properties.

```php
use Illuminate\Queue\Attributes\Queue;

#[Queue('imports')]   // string or backed enum
class UsersImport implements ToModel, WithChunkReading, ShouldQueue
{
    // ...
}
```

## Why

Laravel reads these attributes off the *job it dispatches* — but a Laravel-Excel import isn't that job (the package dispatches its own `ReadChunk` / `AfterImportJob`). So today putting `#[Queue]` on an import is silently ignored; only the `public $queue` property works. This bridges that gap so imports get the same attribute-based API as regular queued jobs.

It also means backed-enum queue names work out of the box: the framework's attribute resolves the enum to its value for us (no property-default gymnastics, no custom enum handling in this package).

## How

A small `QueueResolver` helper reuses Laravel's own `ReadsQueueAttributes` reader, so precedence and enum resolution match the framework exactly. The two existing read sites (`ChunkReader`, `ReadChunk`) now go through it.

## Compatibility

- Fully backward compatible — the `queue`/`connection` properties behave exactly as before.
- Safe across the whole supported range (`php: ^7.0||^8.0`, Laravel 5.8–13): a `trait_exists()` guard falls back to the original property read on versions without the attribute reader, and the trait-using code is only loaded when available. No new dependencies.
