### PR TITLE
Fix: `AfterChunk` event raised after `sheet disconnect`

### DIFF
--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -160,11 +160,11 @@ class ReadChunk implements ShouldQueue
                 $this->startRow
             );
 
+            $sheet->raise(new AfterChunk($sheet, $this->import, $this->startRow));
+
             $sheet->disconnect();
 
             $this->cleanUpTempFile();
-
-            $sheet->raise(new AfterChunk($sheet, $this->import, $this->startRow));
         });
     }
 

--- a/tests/Concerns/WithEventsTest.php
+++ b/tests/Concerns/WithEventsTest.php
@@ -28,6 +28,7 @@ use Maatwebsite\Excel\Tests\Data\Stubs\ImportWithEvents;
 use Maatwebsite\Excel\Tests\Data\Stubs\ImportWithEventsChunksAndBatches;
 use Maatwebsite\Excel\Tests\TestCase;
 use Maatwebsite\Excel\Writer;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 final class WithEventsTest extends TestCase
@@ -164,6 +165,18 @@ final class WithEventsTest extends TestCase
         $this->assertSame(10, $beforeSheet);
         $this->assertSame(50, $afterBatch);
         $this->assertSame(10, $afterChunk);
+    }
+
+    public function test_after_chunk_event_sheet_delegate_is_accessible(): void
+    {
+        $import = new ImportWithEventsChunksAndBatches();
+
+        $import->afterChunk = function (AfterChunk $event): void {
+            $this->assertInstanceOf(Sheet::class, $event->getSheet());
+            $this->assertInstanceOf(Worksheet::class, $event->getSheet()->getDelegate());
+        };
+
+        $import->import('import-batches.xlsx');
     }
 
     public function test_can_have_invokable_class_as_listener(): void

--- a/tests/Concerns/WithEventsTest.php
+++ b/tests/Concerns/WithEventsTest.php
@@ -169,7 +169,7 @@ final class WithEventsTest extends TestCase
 
     public function test_after_chunk_event_sheet_delegate_is_accessible(): void
     {
-        $import = new ImportWithEventsChunksAndBatches();
+        $import = new ImportWithEventsChunksAndBatches;
 
         $import->afterChunk = function (AfterChunk $event): void {
             $this->assertInstanceOf(Sheet::class, $event->getSheet());


### PR DESCRIPTION
## 1️⃣Why should it be added? What are the benefits of this change?

`AfterChunk` was fired **after** `Sheet::disconnect()` in `ReadChunk::handle()`.
`disconnect()` calls `unset($this->worksheet)`, so any event handler that accesses `$event->getSheet()->getDelegate()` would encounter an undefined property and receive `null` instead of the expected `Worksheet` instance.
Moving `raise(AfterChunk)` before `disconnect()` ensures the worksheet is still accessible inside event handlers, which is the naturally expected behavior.

## 2️⃣Does it contain multiple, unrelated changes?

No. 
This PR contains a single focused fix: reordering `raise(AfterChunk)` and `disconnect()` in `ReadChunk::handle()`.

## 3️⃣Does it include tests, if possible?

Yes. 
`test_after_chunk_event_sheet_delegate_is_accessible` has been added to `WithEventsTest`, asserting that `$event->getSheet()->getDelegate()` returns a `Worksheet` instance within an `AfterChunk` handler.
  
## 4️⃣Any drawbacks? Possible breaking changes?

No breaking changes. 
The fix only corrects the order of two operations. Event handlers that do not access `getDelegate()` are unaffected.

## 5️⃣Tasks

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

### Test Results
<img width="645" height="188" alt="screen capture 2026-06-06 0 21 49" src="https://github.com/user-attachments/assets/8c20ed3e-88e5-485c-9e9a-bb34894c7310" />
