### PR TITLE
[4.0] Add FromScout interface

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -1,0 +1,28 @@
+UPGRADE FROM 3.1 to 4.0
+=======================
+
+## Minimum dependency versions
+
+Laravel-Excel 4.0 requires PHP 8.3 or higher, and Laravel 12 or higher. 
+If you are using an older version of PHP or Laravel, you will need to upgrade those first before upgrading to Laravel-Excel 4.0.
+
+## Fully typed code base
+
+Native PHP types were added across entire code base, including public methods and interfaces. 
+If you are implementing any of the interfaces or overriding any methods, 
+you will need to update your code to match the new method signatures to include native types:
+
+
+```php
+class MyExport implements FromArray
+{
+    public function array(): array
+    {
+    }
+}
+```
+
+## FromScout
+
+To keep laravel/scout an optional dependency, `FromQuery` no longer supports returning a Scout `Builder` instance. 
+Use the new `FromScout` export interface instead.

--- a/src/Concerns/FromQuery.php
+++ b/src/Concerns/FromQuery.php
@@ -5,7 +5,6 @@ namespace Maatwebsite\Excel\Concerns;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder;
-use Laravel\Scout\Builder as ScoutBuilder;
 
 interface FromQuery
 {
@@ -38,5 +37,5 @@ interface FromQuery
      * still works as a tie-breaker — there's no special handling needed,
      * just always set one.
      */
-    public function query(): Builder|EloquentBuilder|Relation|ScoutBuilder;
+    public function query(): Builder|EloquentBuilder|Relation;
 }

--- a/src/Concerns/FromScout.php
+++ b/src/Concerns/FromScout.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Maatwebsite\Excel\Concerns;
+
+use Laravel\Scout\Builder;
+
+interface FromScout
+{
+    public function scout(): Builder;
+}

--- a/src/Exceptions/ConcernConflictException.php
+++ b/src/Exceptions/ConcernConflictException.php
@@ -8,6 +8,6 @@ final class ConcernConflictException extends LogicException implements LaravelEx
 {
     public static function queryOrCollectionAndView(): ConcernConflictException
     {
-        return new self('Cannot use FromQuery, FromArray or FromCollection and FromView on the same sheet.');
+        return new self('Cannot use FromQuery, FromScout, FromArray or FromCollection and FromView on the same sheet.');
     }
 }

--- a/src/Jobs/AppendPaginatedToSheet.php
+++ b/src/Jobs/AppendPaginatedToSheet.php
@@ -5,13 +5,10 @@ namespace Maatwebsite\Excel\Jobs;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
-use Laravel\Scout\Builder as ScoutBuilder;
 use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\FromScout;
 use Maatwebsite\Excel\Files\TemporaryFile;
 use Maatwebsite\Excel\Jobs\Middleware\LocalizeJob;
 use Maatwebsite\Excel\Writer;
@@ -22,7 +19,7 @@ class AppendPaginatedToSheet implements ShouldQueue
     use Batchable, Dispatchable, InteractsWithQueue, ProxyFailures, Queueable;
 
     public function __construct(
-        public FromQuery $sheetExport,
+        public FromQuery|FromScout $sheetExport,
         public TemporaryFile $temporaryFile,
         public string $writerType,
         public int $sheetIndex,
@@ -55,19 +52,19 @@ class AppendPaginatedToSheet implements ShouldQueue
 
             $sheet = $writer->getSheetByIndex($this->sheetIndex);
 
-            $sheet->appendRows($this->chunk($this->sheetExport->query()), $this->sheetExport);
+            $sheet->appendRows($this->chunk(), $this->sheetExport);
 
             $writer->write($this->sheetExport, $this->temporaryFile, $this->writerType);
         });
     }
 
-    protected function chunk(Builder|Relation|EloquentBuilder|ScoutBuilder $query)
+    protected function chunk(): iterable
     {
-        if ($query instanceof ScoutBuilder) {
-            return $query->paginate($this->perPage, 'page', $this->page)->items();
+        if ($this->sheetExport instanceof FromScout) {
+            return $this->sheetExport->scout()->paginate($this->perPage, 'page', $this->page)->items();
         }
 
         // Fallback
-        return $query->forPage($this->page, $this->perPage)->get();
+        return $this->sheetExport->query()->forPage($this->page, $this->perPage)->get();
     }
 }

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -7,9 +7,9 @@ use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
 use Illuminate\Support\Facades\Bus;
-use Laravel\Scout\Builder;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\FromScout;
 use Maatwebsite\Excel\Concerns\FromView;
 use Maatwebsite\Excel\Concerns\ShouldBatch;
 use Maatwebsite\Excel\Concerns\WithCustomChunkSize;
@@ -79,6 +79,8 @@ class QueuedWriter
                 $jobs = $jobs->merge($this->exportCollection($sheetExport, $temporaryFile, $writerType, $sheetIndex));
             } elseif ($sheetExport instanceof FromQuery) {
                 $jobs = $jobs->merge($this->exportQuery($sheetExport, $temporaryFile, $writerType, $sheetIndex));
+            } elseif ($sheetExport instanceof FromScout) {
+                $jobs = $jobs->merge($this->exportScout($sheetExport, $temporaryFile, $writerType, $sheetIndex));
             } elseif ($sheetExport instanceof FromView) {
                 $jobs = $jobs->merge($this->exportView($sheetExport, $temporaryFile, $writerType, $sheetIndex));
             }
@@ -120,11 +122,6 @@ class QueuedWriter
         int $sheetIndex
     ): Collection {
         $query = $export->query();
-
-        if ($query instanceof Builder) {
-            return $this->exportScout($export, $temporaryFile, $writerType, $sheetIndex);
-        }
-
         $count = $export instanceof WithCustomQuerySize ? $export->querySize() : $query->count();
         $spins = ceil($count / $this->getChunkSize($export));
 
@@ -145,14 +142,14 @@ class QueuedWriter
     }
 
     private function exportScout(
-        FromQuery $export,
+        FromScout $export,
         TemporaryFile $temporaryFile,
         string $writerType,
         int $sheetIndex
     ): Collection {
         $jobs = new Collection;
 
-        $chunk = $export->query()->paginate($this->getChunkSize($export));
+        $chunk = $export->scout()->paginate($this->getChunkSize($export));
         // Append first page
         $jobs->push(new AppendDataToSheet(
             $export,

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -6,12 +6,12 @@ use Closure;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
-use Laravel\Scout\Builder;
 use Maatwebsite\Excel\Concerns\FromArray;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\FromGenerator;
 use Maatwebsite\Excel\Concerns\FromIterator;
 use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\FromScout;
 use Maatwebsite\Excel\Concerns\FromView;
 use Maatwebsite\Excel\Concerns\OnEachRow;
 use Maatwebsite\Excel\Concerns\ShouldAutoSize;
@@ -148,7 +148,11 @@ class Sheet
             $this->worksheet->setTitle($title);
         }
 
-        if (($sheetExport instanceof FromQuery || $sheetExport instanceof FromCollection || $sheetExport instanceof FromArray) && $sheetExport instanceof FromView) {
+        if (($sheetExport instanceof FromQuery
+                || $sheetExport instanceof FromCollection
+                || $sheetExport instanceof FromArray
+                || $sheetExport instanceof FromScout)
+            && $sheetExport instanceof FromView) {
             throw ConcernConflictException::queryOrCollectionAndView();
         }
 
@@ -178,6 +182,12 @@ class Sheet
         } else {
             if ($sheetExport instanceof FromQuery) {
                 $this->fromQuery($sheetExport, $this->worksheet);
+            }
+
+            if ($sheetExport instanceof FromScout) {
+                $this->fromScout($sheetExport, $this->worksheet);
+
+                return;
             }
 
             if ($sheetExport instanceof FromCollection) {
@@ -424,11 +434,6 @@ class Sheet
     public function fromQuery(FromQuery $sheetExport, Worksheet $worksheet): void
     {
         $query = $sheetExport->query();
-        if ($query instanceof Builder) {
-            $this->fromScout($sheetExport, $worksheet);
-
-            return;
-        }
 
         // Operate on a clone to avoid altering the original
         // and use the clone operator directly to support old versions of Laravel
@@ -439,9 +444,9 @@ class Sheet
         });
     }
 
-    public function fromScout(FromQuery $sheetExport, Worksheet $worksheet): void
+    public function fromScout(FromScout $sheetExport, Worksheet $worksheet): void
     {
-        $scout     = $sheetExport->query();
+        $scout     = $sheetExport->scout();
         $chunkSize = $this->getChunkSize($sheetExport);
 
         $chunk = $scout->paginate($chunkSize);

--- a/tests/Concerns/FromQueryTest.php
+++ b/tests/Concerns/FromQueryTest.php
@@ -3,7 +3,6 @@
 namespace Maatwebsite\Excel\Tests\Concerns;
 
 use Illuminate\Support\Facades\DB;
-use Laravel\Scout\Engines\DatabaseEngine;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromGroupUsersQueuedQueryExport;
@@ -13,7 +12,6 @@ use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersQueryExport;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersQueryExportWithEagerLoad;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersQueryExportWithPrepareRows;
 use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersQueryWithJoinExport;
-use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersScoutExport;
 use Maatwebsite\Excel\Tests\TestCase;
 
 class FromQueryTest extends TestCase
@@ -202,25 +200,6 @@ class FromQueryTest extends TestCase
 
             return array_values($user->toArray());
         })->toArray();
-
-        $this->assertEquals($allUsers, $contents);
-    }
-
-    public function test_can_export_from_scout(): void
-    {
-        if (!class_exists(DatabaseEngine::class)) {
-            $this->markTestSkipped('Laravel Scout is too old');
-        }
-
-        $export = new FromUsersScoutExport;
-
-        $response = $export->store('from-scout-store.xlsx');
-
-        $this->assertTrue($response);
-
-        $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-scout-store.xlsx', 'Xlsx');
-
-        $allUsers = $export->query()->get()->map(fn (User $user) => array_values($user->toArray()))->toArray();
 
         $this->assertEquals($allUsers, $contents);
     }

--- a/tests/Concerns/FromScoutTest.php
+++ b/tests/Concerns/FromScoutTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Concerns;
+
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
+use Maatwebsite\Excel\Tests\Data\Stubs\FromUsersScoutExport;
+use Maatwebsite\Excel\Tests\TestCase;
+
+class FromScoutTest extends TestCase
+{
+    /**
+     * Setup the test environment.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadLaravelMigrations(['--database' => 'testing']);
+        $this->loadMigrationsFrom(dirname(__DIR__) . '/Data/Stubs/Database/Migrations');
+
+        User::factory()->has(Group::factory(['name' => 'Group 1']))->count(100)->create();
+        User::factory()->has(Group::factory(['name' => 'Group 2']))->count(5)->create();
+    }
+
+    public function test_can_export_from_scout(): void
+    {
+        $export = new FromUsersScoutExport;
+
+        $response = $export->store('from-scout-store.xlsx');
+
+        $this->assertTrue($response);
+
+        $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-scout-store.xlsx', 'Xlsx');
+
+        $allUsers = $export->scout()->get()->map(fn (User $user) => array_values($user->toArray()))->toArray();
+
+        $this->assertEquals($allUsers, $contents);
+    }
+}

--- a/tests/Data/Stubs/Database/User.php
+++ b/tests/Data/Stubs/Database/User.php
@@ -9,7 +9,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Carbon;
 use Laravel\Scout\Engines\DatabaseEngine;
 use Laravel\Scout\Engines\Engine;
-use Laravel\Scout\Engines\NullEngine;
 use Laravel\Scout\Searchable;
 use Maatwebsite\Excel\Tests\Concerns\FromQueryTest;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\Factories\UserFactory;
@@ -43,20 +42,12 @@ class User extends Model
     }
 
     /**
-     * Laravel Scout under <=8 provides only
-     * — NullEngine, that is searches nothing and not applicable for tests and
-     * — AlgoliaEngine, that is 3-d party dependent and not applicable for tests too.
-     *
-     * The only test-ready engine is DatabaseEngine that comes with Scout >8
-     *
-     * Then running tests we will examine engine and skip test until DatabaseEngine is provided.
-     *
      * @see QueuedQueryExportTest::can_queue_scout_export()
      * @see FromQueryTest::can_export_from_scout()
      */
     public function searchableUsing(): Engine
     {
-        return class_exists(DatabaseEngine::class) ? new DatabaseEngine : new NullEngine;
+        return new DatabaseEngine;
     }
 
     protected static function newFactory(): UserFactory

--- a/tests/Data/Stubs/FromUsersScoutExport.php
+++ b/tests/Data/Stubs/FromUsersScoutExport.php
@@ -2,22 +2,19 @@
 
 namespace Maatwebsite\Excel\Tests\Data\Stubs;
 
-use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Database\Query\Builder;
-use Laravel\Scout\Builder as ScoutBuilder;
+use Laravel\Scout\Builder;
 use Maatwebsite\Excel\Concerns\Exportable;
-use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\FromScout;
 use Maatwebsite\Excel\Concerns\WithCustomChunkSize;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 
-class FromUsersScoutExport implements FromQuery, WithCustomChunkSize
+class FromUsersScoutExport implements FromScout, WithCustomChunkSize
 {
     use Exportable;
 
-    public function query(): Builder|EloquentBuilder|Relation|ScoutBuilder
+    public function scout(): Builder
     {
-        return new ScoutBuilder(new User, '');
+        return new Builder(new User, '');
     }
 
     public function chunkSize(): int

--- a/tests/ExcelTest.php
+++ b/tests/ExcelTest.php
@@ -165,7 +165,7 @@ class ExcelTest extends TestCase
     public function test_cannot_use_from_collection_and_from_view_on_same_export(): void
     {
         $this->expectException(ConcernConflictException::class);
-        $this->expectExceptionMessage('Cannot use FromQuery, FromArray or FromCollection and FromView on the same sheet');
+        $this->expectExceptionMessage('Cannot use FromQuery, FromScout, FromArray or FromCollection and FromView on the same sheet.');
 
         $export = new class implements FromCollection, FromView
         {

--- a/tests/QueuedQueryExportTest.php
+++ b/tests/QueuedQueryExportTest.php
@@ -2,7 +2,6 @@
 
 namespace Maatwebsite\Excel\Tests;
 
-use Laravel\Scout\Engines\DatabaseEngine;
 use Maatwebsite\Excel\SettingsProvider;
 use Maatwebsite\Excel\Tests\Data\Stubs\AfterQueueExportJob;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
@@ -80,10 +79,6 @@ class QueuedQueryExportTest extends TestCase
 
     public function test_can_queue_scout_export(): void
     {
-        if (!class_exists(DatabaseEngine::class)) {
-            $this->markTestSkipped('Laravel Scout is too old');
-        }
-
         $export = new FromUsersScoutExport;
 
         $export->queue('queued-scout-export.xlsx')->chain([


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?

Adding native return types in `FromQuery` makes laravel/scout mandatory to avoid missing class errors. Introducing a new `FromScout` interface allows keeping Scout as optional dependency and separates a few branches in our code base, keeping it neat.

Addresses comment: https://github.com/SpartnerNL/Laravel-Excel/issues/4345#issuecomment-4528235353

Also removed some checks for Scout <8 as it's not supported anyway.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣  Does it include tests, if possible?

Tests updated

4️⃣  Any drawbacks? Possible breaking changes?

Breaking change: yes, documented in `UPGRADE.md`

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
