### PR TITLE
[4.0] Fix WithProgressBar regression

### DIFF
--- a/src/Concerns/Importable.php
+++ b/src/Concerns/Importable.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 trait Importable
 {
-    protected ?OutputStyle $output;
+    protected OutputStyle $output;
 
     protected ?string $disk = null;
 
@@ -96,11 +96,7 @@ trait Importable
 
     public function getConsoleOutput(): OutputStyle
     {
-        if (!$this->output instanceof OutputStyle) {
-            $this->output = new OutputStyle(new StringInput(''), new NullOutput);
-        }
-
-        return $this->output;
+        return $this->output ??= new OutputStyle(new StringInput(''), new NullOutput);
     }
 
     /**

--- a/src/Factories/ReaderFactory.php
+++ b/src/Factories/ReaderFactory.php
@@ -28,13 +28,8 @@ class ReaderFactory
             $readerType ?: self::identify($file)
         );
 
-        if (method_exists($reader, 'setReadDataOnly')) {
-            $reader->setReadDataOnly(config('excel.imports.read_only', true));
-        }
-
-        if (method_exists($reader, 'setReadEmptyCells')) {
-            $reader->setReadEmptyCells(!config('excel.imports.ignore_empty', false));
-        }
+        $reader->setReadDataOnly(config('excel.imports.read_only', true));
+        $reader->setReadEmptyCells(!config('excel.imports.ignore_empty', false));
 
         if ($reader instanceof Csv) {
             static::applyCsvSettings(config('excel.imports.csv', []));
@@ -48,9 +43,7 @@ class ReaderFactory
             $reader->setEscapeCharacter(static::$escapeCharacter);
             $reader->setContiguous(static::$contiguous);
             $reader->setInputEncoding(static::$inputEncoding);
-            if (method_exists($reader, 'setTestAutoDetect')) {
-                $reader->setTestAutoDetect(static::$testAutoDetect);
-            }
+            $reader->setTestAutoDetect(static::$testAutoDetect);
         }
 
         if ($import instanceof WithReadFilter) {

--- a/src/Jobs/ExtendedQueueable.php
+++ b/src/Jobs/ExtendedQueueable.php
@@ -16,7 +16,7 @@ trait ExtendedQueueable
     public function chain($chain)
     {
         collect($chain)->each(function ($job): void {
-            $serialized      = method_exists($this, 'serializeJob') ? $this->serializeJob($job) : serialize($job);
+            $serialized      = $this->serializeJob($job);
             $this->chained[] = $serialized;
         });
 

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -273,11 +273,9 @@ class Reader
             }
 
             // Load specific sheets.
-            if (method_exists($this->reader, 'setLoadSheetsOnly')) {
-                $this->reader->setLoadSheetsOnly(
-                    collect($worksheetNames)->intersect(array_keys($worksheets))->values()->all()
-                );
-            }
+            $this->reader->setLoadSheetsOnly(
+                collect($worksheetNames)->intersect(array_keys($worksheets))->values()->all()
+            );
         } else {
             // Each worksheet the same import class.
             foreach ($worksheetNames as $name) {
@@ -334,16 +332,11 @@ class Reader
 
             // When only sheet names are given and the reader has
             // an option to load only the selected sheets.
-            if (
-                method_exists($this->reader, 'setLoadSheetsOnly')
-                && count(array_filter(array_keys($sheetImports), is_numeric(...))) === 0
-            ) {
+            if (count(array_filter(array_keys($sheetImports), is_numeric(...))) === 0) {
                 $this->reader->setLoadSheetsOnly(array_keys($sheetImports));
             }
 
-            if (method_exists($this->reader, 'setCreateBlankSheetIfNoneRead')) {
-                $this->reader->setCreateBlankSheetIfNoneRead(true);
-            }
+            $this->reader->setCreateBlankSheetIfNoneRead(true);
         }
 
         return $sheetImports;

--- a/tests/Concerns/ImportableTest.php
+++ b/tests/Concerns/ImportableTest.php
@@ -9,6 +9,7 @@ use Maatwebsite\Excel\Excel;
 use Maatwebsite\Excel\Importer;
 use Maatwebsite\Excel\Tests\TestCase;
 use PHPUnit\Framework\Assert;
+use Symfony\Component\Console\Output\NullOutput;
 
 class ImportableTest extends TestCase
 {
@@ -128,5 +129,16 @@ class ImportableTest extends TestCase
         };
 
         $import->import('doesnotexistanywhere.xlsx');
+    }
+
+    public function test_default_output_style_is_set(): void
+    {
+        $import = new class
+        {
+            use Importable;
+        };
+
+        $style = $import->getConsoleOutput();
+        $this->assertInstanceOf(NullOutput::class, $style->getOutput());
     }
 }

--- a/tests/Concerns/WithProgressBarTest.php
+++ b/tests/Concerns/WithProgressBarTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Maatwebsite\Excel\Tests\Concerns;
+
+use Illuminate\Console\OutputStyle;
+use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\ToModel;
+use Maatwebsite\Excel\Concerns\WithProgressBar;
+use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
+use Maatwebsite\Excel\Tests\TestCase;
+use Mockery;
+
+class WithProgressBarTest extends TestCase
+{
+    /**
+     * Setup the test environment.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadLaravelMigrations(['--database' => 'testing']);
+        $this->loadMigrationsFrom(dirname(__DIR__) . '/Data/Stubs/Database/Migrations');
+    }
+
+    public function test_reports_progress(): void
+    {
+        $import = new class implements ToModel, WithProgressBar
+        {
+            use Importable;
+
+            public function model(array $row): User
+            {
+                return new User([
+                    'name'     => $row[0],
+                    'email'    => $row[1],
+                    'password' => 'secret',
+                ]);
+            }
+        };
+
+        $output = Mockery::mock(OutputStyle::class);
+        $output->shouldReceive('progressStart')
+            ->once()
+            ->with(2)
+            ->andReturnSelf();
+        $output->shouldReceive('progressAdvance')
+            ->twice()
+            ->andReturnSelf();
+        $output->shouldReceive('progressFinish')
+            ->once()
+            ->andReturnSelf();
+
+        $import->withOutput($output);
+        $import->import('import-users.xlsx');
+        $this->assertEquals(2, User::count());
+    }
+}


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?

Adding native types in #4371 introduced a regression reported in https://github.com/SpartnerNL/Laravel-Excel/issues/4345#issuecomment-4555931797 due to `instanceof` check. 
Non-typed properties default to `null` when unset, allowing `=== null` or `instanceof` checks but typed ones default to being uninitialized, where only `isset` is allowed. 

This change hardens the type to not allow `null` at all and adds tests to cover this regression. It also adds tests for `WithProgressBar` itself.

Cherry-picking #4393 as a minor improvement as well.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No

3️⃣  Does it include tests, if possible?

Yes + regression test.

4️⃣  Any drawbacks? Possible breaking changes?

No.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
