### PR TITLE
[4.0] Improve Tests

### DIFF
--- a/tests/Cache/BatchCacheTest.php
+++ b/tests/Cache/BatchCacheTest.php
@@ -33,12 +33,12 @@ class BatchCacheTest extends TestCase
 
         $cache = $this->givenCache($inMemory);
 
-        $this->assertEquals(
+        $this->assertSame(
             $inMemory,
             $cache->getMultiple(['A1', 'A2', 'A3'])
         );
 
-        $this->assertEquals('A3-value', $cache->get('A3'));
+        $this->assertSame('A3-value', $cache->get('A3'));
     }
 
     public function test_will_get_multiple_from_cache_if_cells_are_persisted(): void
@@ -52,12 +52,12 @@ class BatchCacheTest extends TestCase
 
         $cache = $this->givenCache($inMemory, $persisted);
 
-        $this->assertEquals(
+        $this->assertSame(
             $persisted,
             $cache->getMultiple(['A1', 'A2', 'A3'])
         );
 
-        $this->assertEquals('A3-value', $cache->get('A3'));
+        $this->assertSame('A3-value', $cache->get('A3'));
     }
 
     public function test_will_get_multiple_from_cache_and_persisted(): void
@@ -75,13 +75,13 @@ class BatchCacheTest extends TestCase
 
         $cache = $this->givenCache($inMemory, $persisted);
 
-        $this->assertEquals(
+        $this->assertSame(
             array_merge($inMemory, $persisted),
             $cache->getMultiple(['A1', 'A2', 'A3', 'A4', 'A5', 'A6'])
         );
 
-        $this->assertEquals('A3-value', $cache->get('A3'));
-        $this->assertEquals('A6-value', $cache->get('A6'));
+        $this->assertSame('A3-value', $cache->get('A3'));
+        $this->assertSame('A6-value', $cache->get('A6'));
     }
 
     public function test_it_persists_to_cache_when_memory_limit_reached_on_setting_a_value(): void
@@ -100,10 +100,10 @@ class BatchCacheTest extends TestCase
         $cache->set('A4', 'A4-value', 10000);
 
         // Nothing in memory anymore
-        $this->assertEquals([], array_filter($this->memory->getMultiple(['A1', 'A2', 'A3', 'A4'])));
+        $this->assertSame([], array_filter($this->memory->getMultiple(['A1', 'A2', 'A3', 'A4'])));
 
         // All 4 cells show be persisted
-        $this->assertEquals([
+        $this->assertSame([
             'A1' => 'A1-value',
             'A2' => 'A2-value',
             'A3' => 'A3-value',
@@ -111,7 +111,7 @@ class BatchCacheTest extends TestCase
         ], $this->cache->getMultiple(['A1', 'A2', 'A3', 'A4']));
 
         // Batch cache should return all 4 cells
-        $this->assertEquals([
+        $this->assertSame([
             'A1' => 'A1-value',
             'A2' => 'A2-value',
             'A3' => 'A3-value',
@@ -138,10 +138,10 @@ class BatchCacheTest extends TestCase
         ], 10000);
 
         // Nothing in memory anymore
-        $this->assertEquals([], array_filter($this->memory->getMultiple(['A1', 'A2', 'A3', 'A4', 'A5'])));
+        $this->assertSame([], array_filter($this->memory->getMultiple(['A1', 'A2', 'A3', 'A4', 'A5'])));
 
         // All 4 cells show be persisted
-        $this->assertEquals([
+        $this->assertSame([
             'A1' => 'A1-value',
             'A2' => 'A2-value',
             'A3' => 'A3-value',
@@ -150,7 +150,7 @@ class BatchCacheTest extends TestCase
         ], $this->cache->getMultiple(['A1', 'A2', 'A3', 'A4', 'A5']));
 
         // Batch cache should return all 4 cells
-        $this->assertEquals([
+        $this->assertSame([
             'A1' => 'A1-value',
             'A2' => 'A2-value',
             'A3' => 'A3-value',

--- a/tests/CellTest.php
+++ b/tests/CellTest.php
@@ -14,10 +14,10 @@ class CellTest extends TestCase
 
         $worksheet = $this->read(__DIR__ . '/Data/Disks/Local/import-middleware.xlsx', 'Xlsx');
 
-        $this->assertEquals('test', Cell::make($worksheet->getActiveSheet(), 'A1')->getValue());
+        $this->assertSame('test', Cell::make($worksheet->getActiveSheet(), 'A1')->getValue());
 
         // By default spaces are not removed
-        $this->assertEquals('       ', Cell::make($worksheet->getActiveSheet(), 'A2')->getValue());
+        $this->assertSame('       ', Cell::make($worksheet->getActiveSheet(), 'A2')->getValue());
     }
 
     public function test_can_trim_empty_cells(): void
@@ -28,7 +28,7 @@ class CellTest extends TestCase
 
         $worksheet = $this->read(__DIR__ . '/Data/Disks/Local/import-middleware.xlsx', 'Xlsx');
 
-        $this->assertEquals('', Cell::make($worksheet->getActiveSheet(), 'A2')->getValue());
+        $this->assertSame('', Cell::make($worksheet->getActiveSheet(), 'A2')->getValue());
 
         config()->set('excel.imports.cells.middleware', []);
     }
@@ -42,7 +42,7 @@ class CellTest extends TestCase
 
         $worksheet = $this->read(__DIR__ . '/Data/Disks/Local/import-middleware.xlsx', 'Xlsx');
 
-        $this->assertEquals(null, Cell::make($worksheet->getActiveSheet(), 'A2')->getValue());
+        $this->assertNull(Cell::make($worksheet->getActiveSheet(), 'A2')->getValue());
 
         config()->set('excel.imports.cells.middleware', []);
     }

--- a/tests/Concerns/ExportableTest.php
+++ b/tests/Concerns/ExportableTest.php
@@ -99,7 +99,7 @@ class ExportableTest extends TestCase
                 'Content-Type' => 'text/csv',
             ]
         );
-        $this->assertEquals('text/csv', $response->headers->get('Content-Type'));
+        $this->assertSame('text/csv', $response->headers->get('Content-Type'));
     }
 
     public function test_can_set_custom_headers_in_export_class(): void
@@ -117,7 +117,7 @@ class ExportableTest extends TestCase
         };
         $response = $export->toResponse(request());
 
-        $this->assertEquals('text/csv', $response->headers->get('Content-Type'));
+        $this->assertSame('text/csv', $response->headers->get('Content-Type'));
     }
 
     public function test_can_get_raw_export_contents(): void

--- a/tests/Concerns/FromArrayTest.php
+++ b/tests/Concerns/FromArrayTest.php
@@ -29,6 +29,6 @@ class FromArrayTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-array-store.xlsx', 'Xlsx');
 
-        $this->assertEquals($export->array(), $contents);
+        $this->assertSame($export->array(), $contents);
     }
 }

--- a/tests/Concerns/FromCollectionTest.php
+++ b/tests/Concerns/FromCollectionTest.php
@@ -22,7 +22,7 @@ class FromCollectionTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-collection-store.xlsx', 'Xlsx');
 
-        $this->assertEquals($export->collection()->toArray(), $contents);
+        $this->assertSame($export->collection()->toArray(), $contents);
     }
 
     public function test_can_export_with_multiple_sheets_from_collection(): void
@@ -41,8 +41,8 @@ class FromCollectionTest extends TestCase
 
             $worksheet = $spreadsheet->getSheet($sheetIndex);
 
-            $this->assertEquals($sheet->collection()->toArray(), $worksheet->toArray());
-            $this->assertEquals($sheet->title(), $worksheet->getTitle());
+            $this->assertSame($sheet->collection()->toArray(), $worksheet->toArray());
+            $this->assertSame($sheet->title(), $worksheet->getTitle());
         }
     }
 
@@ -58,7 +58,7 @@ class FromCollectionTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-lazy-collection-store.xlsx', 'Xlsx');
 
-        $this->assertEquals(
+        $this->assertSame(
             $export->collection()->map(
                 fn (array $item) => array_values($item)
             )->toArray(),
@@ -83,7 +83,7 @@ class FromCollectionTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-lazy-collection-store.xlsx', 'Xlsx');
 
-        $this->assertEquals(
+        $this->assertSame(
             $export->collection()->map(
                 fn (array $item) => array_values($item)
             )->toArray(),

--- a/tests/Concerns/FromGeneratorTest.php
+++ b/tests/Concerns/FromGeneratorTest.php
@@ -29,6 +29,6 @@ class FromGeneratorTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-generator-store.xlsx', 'Xlsx');
 
-        $this->assertEquals(iterator_to_array($export->generator()), $contents);
+        $this->assertSame(iterator_to_array($export->generator()), $contents);
     }
 }

--- a/tests/Concerns/FromIteratorTest.php
+++ b/tests/Concerns/FromIteratorTest.php
@@ -36,6 +36,6 @@ class FromIteratorTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-iterator-store.xlsx', 'Xlsx');
 
-        $this->assertEquals($export->array(), $contents);
+        $this->assertSame($export->array(), $contents);
     }
 }

--- a/tests/Concerns/FromViewTest.php
+++ b/tests/Concerns/FromViewTest.php
@@ -53,7 +53,7 @@ class FromViewTest extends TestCase
             $user->email,
         ])->prepend(['Name', 'Email'])->toArray();
 
-        $this->assertEquals($expected, $contents);
+        $this->assertSame($expected, $contents);
     }
 
     public function test_can_export_multiple_sheets_from_view(): void
@@ -94,8 +94,8 @@ class FromViewTest extends TestCase
             $user->email,
         ])->prepend(['Name', 'Email'])->toArray();
 
-        $this->assertEquals(101, count($contents));
-        $this->assertEquals($expected, $contents);
+        $this->assertSame(101, count($contents));
+        $this->assertSame($expected, $contents);
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/from-multiple-view.xlsx', 'Xlsx', 2);
 
@@ -104,7 +104,7 @@ class FromViewTest extends TestCase
             $user->email,
         ])->prepend(['Name', 'Email'])->toArray();
 
-        $this->assertEquals(101, count($contents));
-        $this->assertEquals($expected, $contents);
+        $this->assertSame(101, count($contents));
+        $this->assertSame($expected, $contents);
     }
 }

--- a/tests/Concerns/ImportableTest.php
+++ b/tests/Concerns/ImportableTest.php
@@ -20,7 +20,7 @@ class ImportableTest extends TestCase
 
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     ['test', 'test'],
                     ['test', 'test'],
                 ], $array);
@@ -40,7 +40,7 @@ class ImportableTest extends TestCase
 
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     ['test', 'test'],
                     ['test', 'test'],
                 ], $array);
@@ -58,7 +58,7 @@ class ImportableTest extends TestCase
 
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     ['key1', 'A', 'row1'],
                     ['key2', 'B', '<p>row2</p>'],
                     ['key3', 'C', 'row3'],
@@ -82,7 +82,7 @@ class ImportableTest extends TestCase
 
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     ['test', 'test'],
                     ['test', 'test'],
                 ], $array);
@@ -104,11 +104,11 @@ class ImportableTest extends TestCase
 
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     ['test', 'test'],
                     ['test', 'test'],
-                    ['', ''],
-                    ['', ''],
+                    [null, null],
+                    [null, null],
                 ], $array);
             }
         };

--- a/tests/Concerns/OnEachRowTest.php
+++ b/tests/Concerns/OnEachRowTest.php
@@ -21,14 +21,14 @@ class OnEachRowTest extends TestCase
             public function onRow(Row $row): void
             {
                 foreach ($row->getCellIterator() as $cell) {
-                    Assert::assertEquals('test', $cell->getValue());
+                    Assert::assertSame('test', $cell->getValue());
                 }
 
-                Assert::assertEquals([
+                Assert::assertSame([
                     'test', 'test',
                 ], $row->toArray());
 
-                Assert::assertEquals('test', $row[0]);
+                Assert::assertSame('test', $row[0]);
 
                 $this->called++;
             }
@@ -36,7 +36,7 @@ class OnEachRowTest extends TestCase
 
         $import->import('import.xlsx');
 
-        $this->assertEquals(2, $import->called);
+        $this->assertSame(2, $import->called);
     }
 
     public function test_it_respects_the_end_column(): void
@@ -52,7 +52,7 @@ class OnEachRowTest extends TestCase
                 // invalidate the cache once the end column changes
                 Assert::assertIsString($row[0]);
 
-                Assert::assertEquals([
+                Assert::assertSame([
                     'test',
                 ], $row->toArray(null, false, true, 'A'));
             }

--- a/tests/Concerns/RegistersEventListenersTest.php
+++ b/tests/Concerns/RegistersEventListenersTest.php
@@ -50,7 +50,7 @@ class RegistersEventListenersTest extends TestCase
         };
 
         $this->assertInstanceOf(BinaryFileResponse::class, $event->download('filename.xlsx'));
-        $this->assertEquals(4, $eventsTriggered);
+        $this->assertSame(4, $eventsTriggered);
     }
 
     public function test_events_get_called_when_importing(): void
@@ -78,7 +78,7 @@ class RegistersEventListenersTest extends TestCase
         };
 
         $event->import('import.xlsx');
-        $this->assertEquals(3, $eventsTriggered);
+        $this->assertSame(3, $eventsTriggered);
     }
 
     public function test_can_have_invokable_class_as_listener(): void

--- a/tests/Concerns/RemembersChunkOffsetTest.php
+++ b/tests/Concerns/RemembersChunkOffsetTest.php
@@ -20,7 +20,7 @@ class RemembersChunkOffsetTest extends TestCase
 
         $import->setChunkOffset(50);
 
-        $this->assertEquals(50, $import->getChunkOffset());
+        $this->assertSame(50, $import->getChunkOffset());
     }
 
     public function test_can_access_chunk_offset_on_import_to_array_in_chunks(): void
@@ -45,6 +45,6 @@ class RemembersChunkOffsetTest extends TestCase
 
         $import->import('import-batches.xlsx');
 
-        $this->assertEquals([1, 2001, 4001], $import->offsets);
+        $this->assertSame([1, 2001, 4001], $import->offsets);
     }
 }

--- a/tests/Concerns/RemembersRowNumberTest.php
+++ b/tests/Concerns/RemembersRowNumberTest.php
@@ -21,7 +21,7 @@ class RemembersRowNumberTest extends TestCase
 
         $import->rememberRowNumber(50);
 
-        $this->assertEquals(50, $import->getRowNumber());
+        $this->assertSame(50, $import->getRowNumber());
     }
 
     public function test_can_access_row_number_on_import_to_model(): void
@@ -43,7 +43,7 @@ class RemembersRowNumberTest extends TestCase
 
         $import->import('import-batches.xlsx');
 
-        $this->assertEquals([46, 47, 48, 49, 50, 51, 52, 53, 54, 55], array_slice($import->rowNumbers, 45, 10));
+        $this->assertSame([46, 47, 48, 49, 50, 51, 52, 53, 54, 55], array_slice($import->rowNumbers, 45, 10));
     }
 
     public function test_can_access_row_number_on_import_to_array_in_chunks(): void
@@ -70,7 +70,7 @@ class RemembersRowNumberTest extends TestCase
 
         $import->import('import-batches.xlsx');
 
-        $this->assertEquals([46, 47, 48, 49, 50, 51, 52, 53, 54, 55], array_slice($import->rowNumbers, 45, 10));
+        $this->assertSame([46, 47, 48, 49, 50, 51, 52, 53, 54, 55], array_slice($import->rowNumbers, 45, 10));
     }
 
     public function test_can_access_row_number_on_import_to_array_in_chunks_with_batch_inserts(): void
@@ -102,6 +102,6 @@ class RemembersRowNumberTest extends TestCase
 
         $import->import('import-batches.xlsx');
 
-        $this->assertEquals([46, 47, 48, 49, 50, 51, 52, 53, 54, 55], array_slice($import->rowNumbers, 45, 10));
+        $this->assertSame([46, 47, 48, 49, 50, 51, 52, 53, 54, 55], array_slice($import->rowNumbers, 45, 10));
     }
 }

--- a/tests/Concerns/SkipsEmptyRowsTest.php
+++ b/tests/Concerns/SkipsEmptyRowsTest.php
@@ -26,7 +26,7 @@ class SkipsEmptyRowsTest extends TestCase
             {
                 $this->called = true;
 
-                Assert::assertEquals([
+                Assert::assertSame([
                     ['Test1', 'Test2'],
                     ['Test3', 'Test4'],
                     ['Test5', 'Test6'],
@@ -57,7 +57,7 @@ class SkipsEmptyRowsTest extends TestCase
 
         $import->import('import-empty-rows.xlsx');
 
-        $this->assertEquals(3, $import->rows);
+        $this->assertSame(3, $import->rows);
     }
 
     public function test_skips_empty_rows_when_importing_to_model(): void
@@ -78,7 +78,7 @@ class SkipsEmptyRowsTest extends TestCase
 
         $import->import('import-empty-rows.xlsx');
 
-        $this->assertEquals(3, $import->rows);
+        $this->assertSame(3, $import->rows);
     }
 
     public function test_custom_skips_rows_when_importing_to_collection(): void
@@ -93,7 +93,7 @@ class SkipsEmptyRowsTest extends TestCase
             {
                 $this->called = true;
 
-                Assert::assertEquals([
+                Assert::assertSame([
                     ['Test1', 'Test2'],
                     ['Test3', 'Test4'],
                 ], $collection->toArray());
@@ -119,7 +119,7 @@ class SkipsEmptyRowsTest extends TestCase
 
             public function model(array $row): null
             {
-                Assert::assertEquals('Not empty', $row[0]);
+                Assert::assertSame('Not empty', $row[0]);
 
                 return null;
             }
@@ -146,7 +146,7 @@ class SkipsEmptyRowsTest extends TestCase
 
             public function onRow(Row $row): void
             {
-                Assert::assertEquals('Not empty', $row[0]);
+                Assert::assertSame('Not empty', $row[0]);
             }
 
             public function isEmptyWhen(array $row): bool

--- a/tests/Concerns/SkipsOnErrorTest.php
+++ b/tests/Concerns/SkipsOnErrorTest.php
@@ -147,8 +147,8 @@ class SkipsOnErrorTest extends TestCase
 
         $import->import('import-users.xlsx');
 
-        $this->assertEquals(1, $import->errors);
-        $this->assertEquals(1, $import->processedRows); // Only the valid row should be processed
+        $this->assertSame(1, $import->errors);
+        $this->assertSame(1, $import->processedRows); // Only the valid row should be processed
 
         // Should have inserted the valid row
         $this->assertDatabaseHas('users', [
@@ -194,7 +194,7 @@ class SkipsOnErrorTest extends TestCase
         $import->import('import-users.xlsx');
 
         $this->assertCount(1, $import->errors());
-        $this->assertEquals(1, $import->processedRows); // Only the valid row should be processed
+        $this->assertSame(1, $import->processedRows); // Only the valid row should be processed
 
         /** @var Throwable $e */
         $e = $import->errors()->first();
@@ -252,8 +252,8 @@ class SkipsOnErrorTest extends TestCase
 
         $import->import('import-users.xlsx');
 
-        $this->assertEquals(1, $import->errors);
-        $this->assertEquals(2, $import->processedRows); // Both rows should be processed, but one throws exception
+        $this->assertSame(1, $import->errors);
+        $this->assertSame(2, $import->processedRows); // Both rows should be processed, but one throws exception
 
         // Should have inserted the valid row
         $this->assertDatabaseHas('users', [
@@ -296,7 +296,7 @@ class SkipsOnErrorTest extends TestCase
         $import->import('import-users.xlsx');
 
         $this->assertCount(1, $import->errors());
-        $this->assertEquals(2, $import->processedRows); // Both rows should be processed, but one throws exception
+        $this->assertSame(2, $import->processedRows); // Both rows should be processed, but one throws exception
 
         /** @var Throwable $e */
         $e = $import->errors()->first();

--- a/tests/Concerns/SkipsOnErrorTest.php
+++ b/tests/Concerns/SkipsOnErrorTest.php
@@ -2,7 +2,7 @@
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
-use Illuminate\Database\QueryException;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Validation\Rule;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\OnEachRow;
@@ -48,8 +48,7 @@ class SkipsOnErrorTest extends TestCase
 
             public function onError(Throwable $e): void
             {
-                Assert::assertInstanceOf(QueryException::class, $e);
-                Assert::stringContains($e->getMessage(), 'Duplicate entry \'patrick@maatwebsite.nl\'');
+                Assert::assertInstanceOf(UniqueConstraintViolationException::class, $e);
 
                 $this->errors++;
             }
@@ -57,7 +56,7 @@ class SkipsOnErrorTest extends TestCase
 
         $import->import('import-users-with-duplicates.xlsx');
 
-        $this->assertEquals(1, $import->errors);
+        $this->assertSame(1, $import->errors);
 
         // Shouldn't have rollbacked other imported rows.
         $this->assertDatabaseHas('users', [
@@ -93,8 +92,7 @@ class SkipsOnErrorTest extends TestCase
         /** @var Throwable $e */
         $e = $import->errors()->first();
 
-        $this->assertInstanceOf(QueryException::class, $e);
-        $this->stringContains($e->getMessage(), 'Duplicate entry \'patrick@maatwebsite.nl\'');
+        $this->assertInstanceOf(UniqueConstraintViolationException::class, $e);
 
         // Shouldn't have rollbacked other imported rows.
         $this->assertDatabaseHas('users', [
@@ -141,7 +139,7 @@ class SkipsOnErrorTest extends TestCase
             public function onError(Throwable $e): void
             {
                 Assert::assertInstanceOf(ValidationException::class, $e);
-                Assert::stringContains($e->getMessage(), 'The selected 1 is invalid');
+                Assert::assertSame('The selected 2.1 is invalid.', $e->getMessage());
 
                 $this->errors++;
             }
@@ -202,7 +200,7 @@ class SkipsOnErrorTest extends TestCase
         $e = $import->errors()->first();
 
         $this->assertInstanceOf(ValidationException::class, $e);
-        $this->stringContains($e->getMessage(), 'The selected 1 is invalid');
+        $this->assertSame('The selected 2.1 is invalid.', $e->getMessage());
 
         // Should have inserted the valid row
         $this->assertDatabaseHas('users', [
@@ -246,7 +244,7 @@ class SkipsOnErrorTest extends TestCase
             public function onError(Throwable $e): void
             {
                 Assert::assertInstanceOf(\Exception::class, $e);
-                Assert::assertEquals('Custom error in onRow for Taylor', $e->getMessage());
+                Assert::assertSame('Custom error in onRow for Taylor', $e->getMessage());
 
                 $this->errors++;
             }
@@ -304,7 +302,7 @@ class SkipsOnErrorTest extends TestCase
         $e = $import->errors()->first();
 
         $this->assertInstanceOf(\RuntimeException::class, $e);
-        $this->assertEquals('Runtime error in onRow for Taylor', $e->getMessage());
+        $this->assertSame('Runtime error in onRow for Taylor', $e->getMessage());
 
         // Should have inserted the valid row
         $this->assertDatabaseHas('users', [

--- a/tests/Concerns/SkipsOnFailureTest.php
+++ b/tests/Concerns/SkipsOnFailureTest.php
@@ -58,14 +58,14 @@ class SkipsOnFailureTest extends TestCase
             {
                 $failure = $failures[0];
 
-                Assert::assertEquals(2, $failure->row());
-                Assert::assertEquals('1', $failure->attribute());
-                Assert::assertEquals(['The selected 1 is invalid.'], $failure->errors());
-                Assert::assertEquals(['Taylor Otwell', 'taylor@laravel.com'], $failure->values());
-                Assert::assertEquals(2, $failure->jsonSerialize()['row']);
-                Assert::assertEquals('1', $failure->jsonSerialize()['attribute']);
-                Assert::assertEquals(['The selected 1 is invalid.'], $failure->jsonSerialize()['errors']);
-                Assert::assertEquals(['Taylor Otwell', 'taylor@laravel.com'], $failure->jsonSerialize()['values']);
+                Assert::assertSame(2, $failure->row());
+                Assert::assertSame('1', $failure->attribute());
+                Assert::assertSame(['The selected 1 is invalid.'], $failure->errors());
+                Assert::assertSame(['Taylor Otwell', 'taylor@laravel.com'], $failure->values());
+                Assert::assertSame(2, $failure->jsonSerialize()['row']);
+                Assert::assertSame('1', $failure->jsonSerialize()['attribute']);
+                Assert::assertSame(['The selected 1 is invalid.'], $failure->jsonSerialize()['errors']);
+                Assert::assertSame(['Taylor Otwell', 'taylor@laravel.com'], $failure->jsonSerialize()['values']);
 
                 $this->failures += \count($failures);
             }
@@ -73,7 +73,7 @@ class SkipsOnFailureTest extends TestCase
 
         $import->import('import-users.xlsx');
 
-        $this->assertEquals(1, $import->failures);
+        $this->assertSame(1, $import->failures);
 
         // Shouldn't have rollbacked other imported rows.
         $this->assertDatabaseHas('users', [
@@ -114,9 +114,9 @@ class SkipsOnFailureTest extends TestCase
             {
                 $failure = $failures[0];
 
-                Assert::assertEquals(2, $failure->row());
-                Assert::assertEquals('1', $failure->attribute());
-                Assert::assertEquals(['The selected 1 is invalid.'], $failure->errors());
+                Assert::assertSame(2, $failure->row());
+                Assert::assertSame('1', $failure->attribute());
+                Assert::assertSame(['The selected 1 is invalid.'], $failure->errors());
 
                 $this->failures += \count($failures);
             }
@@ -129,7 +129,7 @@ class SkipsOnFailureTest extends TestCase
 
         $import->import('import-users.xlsx');
 
-        $this->assertEquals(1, $import->failures);
+        $this->assertSame(1, $import->failures);
 
         // Shouldn't have rollbacked/skipped the rest of the batch.
         $this->assertDatabaseHas('users', [
@@ -172,9 +172,9 @@ class SkipsOnFailureTest extends TestCase
         /** @var Failure $failure */
         $failure = $import->failures()->first();
 
-        $this->assertEquals(2, $failure->row());
-        $this->assertEquals('1', $failure->attribute());
-        $this->assertEquals(['The selected 1 is invalid.'], $failure->errors());
+        $this->assertSame(2, $failure->row());
+        $this->assertSame('1', $failure->attribute());
+        $this->assertSame(['The selected 1 is invalid.'], $failure->errors());
 
         // Shouldn't have rollbacked other imported rows.
         $this->assertDatabaseHas('users', [

--- a/tests/Concerns/ToArrayTest.php
+++ b/tests/Concerns/ToArrayTest.php
@@ -21,7 +21,7 @@ class ToArrayTest extends TestCase
             {
                 $this->called = true;
 
-                Assert::assertEquals([
+                Assert::assertSame([
                     ['test', 'test'],
                     ['test', 'test'],
                 ], $array);
@@ -47,7 +47,7 @@ class ToArrayTest extends TestCase
 
                 $sheetNumber = $this->called;
 
-                Assert::assertEquals([
+                Assert::assertSame([
                     [$sheetNumber . '.A1', $sheetNumber . '.B1'],
                     [$sheetNumber . '.A2', $sheetNumber . '.B2'],
                 ], $array);
@@ -56,6 +56,6 @@ class ToArrayTest extends TestCase
 
         $import->import('import-multiple-sheets.xlsx');
 
-        $this->assertEquals(2, $import->called);
+        $this->assertSame(2, $import->called);
     }
 }

--- a/tests/Concerns/ToCollectionTest.php
+++ b/tests/Concerns/ToCollectionTest.php
@@ -22,7 +22,7 @@ class ToCollectionTest extends TestCase
             {
                 $this->called = true;
 
-                Assert::assertEquals([
+                Assert::assertSame([
                     ['test', 'test'],
                     ['test', 'test'],
                 ], $collection->toArray());
@@ -48,7 +48,7 @@ class ToCollectionTest extends TestCase
 
                 $sheetNumber = $this->called;
 
-                Assert::assertEquals([
+                Assert::assertSame([
                     [$sheetNumber . '.A1', $sheetNumber . '.B1'],
                     [$sheetNumber . '.A2', $sheetNumber . '.B2'],
                 ], $collection->toArray());
@@ -57,6 +57,6 @@ class ToCollectionTest extends TestCase
 
         $import->import('import-multiple-sheets.xlsx');
 
-        $this->assertEquals(2, $import->called);
+        $this->assertSame(2, $import->called);
     }
 }

--- a/tests/Concerns/ToModelTest.php
+++ b/tests/Concerns/ToModelTest.php
@@ -151,8 +151,8 @@ class ToModelTest extends TestCase
         $import->import('import-users.xlsx');
 
         $this->assertCount(4, DB::getQueryLog());
-        $this->assertEquals(2, User::count());
-        $this->assertEquals(2, Group::count());
+        $this->assertSame(2, User::count());
+        $this->assertSame(2, Group::count());
         DB::connection()->disableQueryLog();
     }
 
@@ -195,7 +195,7 @@ class ToModelTest extends TestCase
         });
 
         $this->assertCount(2, $users);
-        $this->assertEquals(2, Group::count());
+        $this->assertSame(2, Group::count());
         DB::connection()->disableQueryLog();
     }
 
@@ -238,7 +238,7 @@ class ToModelTest extends TestCase
         });
 
         $this->assertCount(2, $users);
-        $this->assertEquals(2, Group::count());
+        $this->assertSame(2, Group::count());
         DB::connection()->disableQueryLog();
     }
 }

--- a/tests/Concerns/WithBackgroundColorTest.php
+++ b/tests/Concerns/WithBackgroundColorTest.php
@@ -27,8 +27,8 @@ class WithBackgroundColorTest extends TestCase
         $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/background-styles.xlsx', 'Xlsx');
         $sheet       = $spreadsheet->getDefaultStyle();
 
-        $this->assertEquals(Fill::FILL_SOLID, $sheet->getFill()->getFillType());
-        $this->assertEquals('000000', $sheet->getFill()->getStartColor()->getRGB());
+        $this->assertSame(Fill::FILL_SOLID, $sheet->getFill()->getFillType());
+        $this->assertSame('000000', $sheet->getFill()->getStartColor()->getRGB());
     }
 
     public function test_can_configure_background_color_as_array(): void
@@ -51,8 +51,8 @@ class WithBackgroundColorTest extends TestCase
         $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/background-styles.xlsx', 'Xlsx');
         $sheet       = $spreadsheet->getDefaultStyle();
 
-        $this->assertEquals(Fill::FILL_GRADIENT_LINEAR, $sheet->getFill()->getFillType());
-        $this->assertEquals(Color::COLOR_RED, $sheet->getFill()->getStartColor()->getARGB());
+        $this->assertSame(Fill::FILL_GRADIENT_LINEAR, $sheet->getFill()->getFillType());
+        $this->assertSame(Color::COLOR_RED, $sheet->getFill()->getStartColor()->getARGB());
     }
 
     public function test_can_configure_background_color_with_color_instance(): void
@@ -72,7 +72,7 @@ class WithBackgroundColorTest extends TestCase
         $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/background-styles.xlsx', 'Xlsx');
         $sheet       = $spreadsheet->getDefaultStyle();
 
-        $this->assertEquals(Fill::FILL_SOLID, $sheet->getFill()->getFillType());
-        $this->assertEquals(Color::COLOR_BLUE, $sheet->getFill()->getStartColor()->getARGB());
+        $this->assertSame(Fill::FILL_SOLID, $sheet->getFill()->getFillType());
+        $this->assertSame(Color::COLOR_BLUE, $sheet->getFill()->getStartColor()->getARGB());
     }
 }

--- a/tests/Concerns/WithBatchInsertsTest.php
+++ b/tests/Concerns/WithBatchInsertsTest.php
@@ -127,8 +127,8 @@ class WithBatchInsertsTest extends TestCase
         // Expected 2 batch queries, 1 for users, 1 for groups
         $this->assertCount(2, DB::getQueryLog());
 
-        $this->assertEquals(2, User::count());
-        $this->assertEquals(2, Group::count());
+        $this->assertSame(2, User::count());
+        $this->assertSame(2, Group::count());
 
         DB::connection()->disableQueryLog();
     }

--- a/tests/Concerns/WithCalculatedFormulasTest.php
+++ b/tests/Concerns/WithCalculatedFormulasTest.php
@@ -126,8 +126,8 @@ class WithCalculatedFormulasTest extends TestCase
 
                         public function array(array $array): void
                         {
-                            Assert::assertEquals([
-                                ['1', '1'],
+                            Assert::assertSame([
+                                [1, 1],
                             ], $array);
                         }
                     },
@@ -137,8 +137,8 @@ class WithCalculatedFormulasTest extends TestCase
 
                         public function array(array $array): void
                         {
-                            Assert::assertEquals([
-                                ['2'],
+                            Assert::assertSame([
+                                [2],
                             ], $array);
                         }
                     },

--- a/tests/Concerns/WithChunkReadingTest.php
+++ b/tests/Concerns/WithChunkReadingTest.php
@@ -85,8 +85,8 @@ class WithChunkReadingTest extends TestCase
         $this->assertCount(2, DB::getQueryLog());
         DB::connection()->disableQueryLog();
 
-        $this->assertEquals(1, $import->before, 'BeforeImport was not called or more than once.');
-        $this->assertEquals(1, $import->after, 'AfterImport was not called or more than once.');
+        $this->assertSame(1, $import->before, 'BeforeImport was not called or more than once.');
+        $this->assertSame(1, $import->after, 'AfterImport was not called or more than once.');
     }
 
     public function test_can_import_to_model_in_chunks_and_insert_in_batches(): void
@@ -240,7 +240,7 @@ class WithChunkReadingTest extends TestCase
 
         $import->import('import-batches.xlsx');
 
-        $this->assertEquals(50, $import->called);
+        $this->assertSame(50, $import->called);
     }
 
     public function test_can_import_to_model_in_chunks_and_insert_in_batches_with_multiple_sheets_objects_by_index(): void
@@ -376,7 +376,7 @@ class WithChunkReadingTest extends TestCase
                 return [
                     ImportFailed::class => function (ImportFailed $event): void {
                         Assert::assertInstanceOf(Throwable::class, $event->getException());
-                        Assert::assertEquals('Something went wrong in the chunk', $event->e->getMessage());
+                        Assert::assertSame('Something went wrong in the chunk', $event->e->getMessage());
 
                         $this->failed = true;
                     },
@@ -388,7 +388,7 @@ class WithChunkReadingTest extends TestCase
             $import->import('import-users.xlsx');
         } catch (Throwable $e) {
             $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Something went wrong in the chunk', $e->getMessage());
+            $this->assertSame('Something went wrong in the chunk', $e->getMessage());
         }
 
         $this->assertTrue($import->failed, 'ImportFailed event was not called.');
@@ -407,10 +407,8 @@ class WithChunkReadingTest extends TestCase
                 Assert::assertCount(2, $array);
                 Assert::assertCount(1, $array[0]);
                 Assert::assertCount(1, $array[1]);
-                Assert::assertIsString($array[0][0]);
-                Assert::assertIsString($array[1][0]);
-                Assert::assertEquals('01/12/22', $array[0][0]);
-                Assert::assertEquals('2023-02-20', $array[1][0]);
+                Assert::assertSame('01/12/22', $array[0][0]);
+                Assert::assertSame('2023-02-20', $array[1][0]);
             }
 
             public function chunkSize(): int
@@ -437,8 +435,8 @@ class WithChunkReadingTest extends TestCase
                 Assert::assertCount(1, $array[1]);
                 Assert::assertIsInt($array[0][0]);
                 Assert::assertIsInt($array[1][0]);
-                Assert::assertEquals((int) Date::dateTimeToExcel(DateTime::createFromFormat('Y-m-d', '2022-12-01')->setTime(0, 0, 0, 0)), $array[0][0]);
-                Assert::assertEquals((int) Date::dateTimeToExcel(DateTime::createFromFormat('Y-m-d', '2023-02-20')->setTime(0, 0, 0, 0)), $array[1][0]);
+                Assert::assertSame((int) Date::dateTimeToExcel(DateTime::createFromFormat('Y-m-d', '2022-12-01')->setTime(0, 0, 0, 0)), $array[0][0]);
+                Assert::assertSame((int) Date::dateTimeToExcel(DateTime::createFromFormat('Y-m-d', '2023-02-20')->setTime(0, 0, 0, 0)), $array[1][0]);
             }
 
             public function chunkSize(): int

--- a/tests/Concerns/WithColumnFormattingTest.php
+++ b/tests/Concerns/WithColumnFormattingTest.php
@@ -60,6 +60,6 @@ class WithColumnFormattingTest extends TestCase
             ['06/12/2021', '100.00 €'],
         ];
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 }

--- a/tests/Concerns/WithColumnLimitTest.php
+++ b/tests/Concerns/WithColumnLimitTest.php
@@ -29,7 +29,7 @@ class WithColumnLimitTest extends TestCase
 
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     [
                         'Patrick Brouwers',
                     ],
@@ -56,7 +56,7 @@ class WithColumnLimitTest extends TestCase
 
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     [
                         'Test1',
                         'Test2',

--- a/tests/Concerns/WithColumnWidthsTest.php
+++ b/tests/Concerns/WithColumnWidthsTest.php
@@ -35,6 +35,6 @@ class WithColumnWidthsTest extends TestCase
 
         $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/with-column-widths.xlsx', 'Xlsx');
 
-        $this->assertEquals(55, $spreadsheet->getActiveSheet()->getColumnDimension('A')->getWidth());
+        $this->assertSame(55.0, $spreadsheet->getActiveSheet()->getColumnDimension('A')->getWidth());
     }
 }

--- a/tests/Concerns/WithCustomCsvSettingsTest.php
+++ b/tests/Concerns/WithCustomCsvSettingsTest.php
@@ -88,7 +88,7 @@ class WithCustomCsvSettingsTest extends TestCase
 
         $contents = file_get_contents(__DIR__ . '/../Data/Disks/Local/custom-csv-iso.csv');
 
-        Assert::assertEquals('ISO-8859-15', mb_detect_encoding($contents, 'ISO-8859-15', true));
+        Assert::assertSame('ISO-8859-15', mb_detect_encoding($contents, 'ISO-8859-15', true));
         Assert::assertFalse(mb_detect_encoding($contents, 'UTF-8', true));
 
         $contents = mb_convert_encoding($contents, 'UTF-8', 'ISO-8859-15');
@@ -100,7 +100,7 @@ class WithCustomCsvSettingsTest extends TestCase
 
     public function test_can_read_csv_with_auto_detecting_delimiter_semicolon(): void
     {
-        $this->assertEquals([
+        $this->assertSame([
             [
                 ['a1', 'b1'],
             ],
@@ -109,7 +109,7 @@ class WithCustomCsvSettingsTest extends TestCase
 
     public function test_can_read_csv_with_auto_detecting_delimiter_comma(): void
     {
-        $this->assertEquals([
+        $this->assertSame([
             [
                 ['a1', 'b1'],
             ],
@@ -133,7 +133,7 @@ class WithCustomCsvSettingsTest extends TestCase
 
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     ['A1', 'B1'],
                     ['A2', 'B2'],
                 ], $array);
@@ -156,7 +156,7 @@ class WithCustomCsvSettingsTest extends TestCase
 
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     ['A1;B1'],
                     ['A2;B2'],
                 ], $array);

--- a/tests/Concerns/WithCustomStartCellTest.php
+++ b/tests/Concerns/WithCustomStartCellTest.php
@@ -41,7 +41,7 @@ class WithCustomStartCellTest extends TestCase
 
         $contents = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/custom-start-cell.csv', 'Csv');
 
-        $this->assertEquals([
+        $this->assertSame([
             [null, null, null],
             [null, 'A1', 'B1'],
             [null, 'A2', 'B2'],

--- a/tests/Concerns/WithCustomValueBinderTest.php
+++ b/tests/Concerns/WithCustomValueBinderTest.php
@@ -80,12 +80,12 @@ class WithCustomValueBinderTest extends TestCase
         $this->assertSame(Date::dateTimeToExcel(Carbon::now()), $sheet->getCell('A1')->getValue());
 
         // Check if formatted as datetime
-        $this->assertEquals(NumberFormat::FORMAT_DATE_DATETIME, $sheet->getCell('A1')->getStyle()->getNumberFormat()->getFormatCode());
+        $this->assertSame(NumberFormat::FORMAT_DATE_DATETIME, $sheet->getCell('A1')->getStyle()->getNumberFormat()->getFormatCode());
 
         // Check if the cell has the converted percentage
         $this->assertSame(0.1, $sheet->getCell('B1')->getValue());
 
         // Check if formatted as percentage
-        $this->assertEquals(NumberFormat::FORMAT_PERCENTAGE_00, $sheet->getCell('B1')->getStyle()->getNumberFormat()->getFormatCode());
+        $this->assertSame(NumberFormat::FORMAT_PERCENTAGE_00, $sheet->getCell('B1')->getStyle()->getNumberFormat()->getFormatCode());
     }
 }

--- a/tests/Concerns/WithDefaultStylesTest.php
+++ b/tests/Concerns/WithDefaultStylesTest.php
@@ -41,7 +41,7 @@ class WithDefaultStylesTest extends TestCase
         $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/with-default-styles.xlsx', 'Xlsx');
         $sheet       = $spreadsheet->getDefaultStyle();
 
-        $this->assertEquals(Fill::FILL_SOLID, $sheet->getFill()->getFillType());
-        $this->assertEquals('fff2f2f2', $sheet->getFill()->getStartColor()->getARGB());
+        $this->assertSame(Fill::FILL_SOLID, $sheet->getFill()->getFillType());
+        $this->assertSame('fff2f2f2', $sheet->getFill()->getStartColor()->getARGB());
     }
 }

--- a/tests/Concerns/WithEventsTest.php
+++ b/tests/Concerns/WithEventsTest.php
@@ -63,7 +63,7 @@ class WithEventsTest extends TestCase
         };
 
         $this->assertInstanceOf(BinaryFileResponse::class, $event->download('filename.xlsx'));
-        $this->assertEquals(4, $eventsTriggered);
+        $this->assertSame(4, $eventsTriggered);
     }
 
     public function test_import_events_get_called(): void
@@ -97,7 +97,7 @@ class WithEventsTest extends TestCase
         };
 
         $import->import('import.xlsx');
-        $this->assertEquals(4, $eventsTriggered);
+        $this->assertSame(4, $eventsTriggered);
     }
 
     public function test_import_chunked_events_get_called(): void
@@ -114,13 +114,13 @@ class WithEventsTest extends TestCase
         $import->beforeImport = function (BeforeImport $event) use (&$beforeImport): void {
             $this->assertInstanceOf(Reader::class, $event->getReader());
             // Ensure event is fired only once
-            $this->assertEquals(0, $beforeImport, 'Before import called twice');
+            $this->assertSame(0, $beforeImport, 'Before import called twice');
             $beforeImport++;
         };
 
         $import->afterImport = function (AfterImport $event) use (&$afterImport): void {
             $this->assertInstanceOf(Reader::class, $event->getReader());
-            $this->assertEquals(0, $afterImport, 'After import called twice');
+            $this->assertSame(0, $afterImport, 'After import called twice');
             $afterImport++;
         };
 
@@ -135,12 +135,12 @@ class WithEventsTest extends TestCase
         };
 
         $import->afterBatch = function (AfterBatch $event) use ($import, &$afterBatch): void {
-            $this->assertEquals(
+            $this->assertSame(
                 $import->batchSize(),
                 $event->getBatchSize(),
                 'Wrong Batch size'
             );
-            $this->assertEquals(
+            $this->assertSame(
                 $afterBatch * $import->batchSize() + 1,
                 $event->getStartRow(),
                 'Wrong batch start row'
@@ -149,7 +149,7 @@ class WithEventsTest extends TestCase
         };
 
         $import->afterChunk = function (AfterChunk $event) use ($import, &$afterChunk): void {
-            $this->assertEquals(
+            $this->assertSame(
                 $event->getStartRow(),
                 $afterChunk * $import->chunkSize() + 1,
                 'Wrong chunk start row'
@@ -158,10 +158,10 @@ class WithEventsTest extends TestCase
         };
 
         $import->import('import-batches.xlsx');
-        $this->assertEquals(10, $afterSheet);
-        $this->assertEquals(10, $beforeSheet);
-        $this->assertEquals(50, $afterBatch);
-        $this->assertEquals(10, $afterChunk);
+        $this->assertSame(10, $afterSheet);
+        $this->assertSame(10, $beforeSheet);
+        $this->assertSame(50, $afterBatch);
+        $this->assertSame(10, $afterChunk);
     }
 
     public function test_can_have_invokable_class_as_listener(): void
@@ -234,7 +234,7 @@ class WithEventsTest extends TestCase
 
         $exportWithConcern->store('with-custom-concern.xlsx');
         $actual = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/with-custom-concern.xlsx', 'Xlsx');
-        $this->assertEquals([
+        $this->assertSame([
             ['a', 'b'],
         ], $actual);
 
@@ -246,7 +246,7 @@ class WithEventsTest extends TestCase
         $exportWithoutConcern->store('without-custom-concern.xlsx');
         $actual = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/without-custom-concern.xlsx', 'Xlsx');
 
-        $this->assertEquals([[null]], $actual);
+        $this->assertSame([[null]], $actual);
     }
 
     public function test_can_have_custom_sheet_concern_handlers(): void
@@ -272,7 +272,7 @@ class WithEventsTest extends TestCase
 
         $exportWithConcern->store('with-custom-concern.xlsx');
         $actual = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/with-custom-concern.xlsx', 'Xlsx');
-        $this->assertEquals([
+        $this->assertSame([
             ['c', 'd'],
         ], $actual);
 
@@ -284,7 +284,7 @@ class WithEventsTest extends TestCase
         $exportWithoutConcern->store('without-custom-concern.xlsx');
         $actual = $this->readAsArray(__DIR__ . '/../Data/Disks/Local/without-custom-concern.xlsx', 'Xlsx');
 
-        $this->assertEquals([[null]], $actual);
+        $this->assertSame([[null]], $actual);
     }
 
     public function test_export_chunked_events_get_called(): void
@@ -311,6 +311,6 @@ class WithEventsTest extends TestCase
         $export->queue('filename.xlsx');
 
         // Chunk size is 1, so we expect 2 chunks to be executed with a total of 2 users
-        $this->assertEquals(2, ExportWithEventsChunks::$calledEvent);
+        $this->assertSame(2, ExportWithEventsChunks::$calledEvent);
     }
 }

--- a/tests/Concerns/WithGroupedHeadingRowTest.php
+++ b/tests/Concerns/WithGroupedHeadingRowTest.php
@@ -35,7 +35,7 @@ class WithGroupedHeadingRowTest extends TestCase
 
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     [
                         'name'    => 'Patrick Brouwers',
                         'email'   => 'patrick@maatwebsite.nl',
@@ -59,7 +59,7 @@ class WithGroupedHeadingRowTest extends TestCase
 
             public function onRow(Row $row): void
             {
-                Assert::assertEquals(
+                Assert::assertSame(
                     [
                         'name'    => 'Patrick Brouwers',
                         'email'   => 'patrick@maatwebsite.nl',
@@ -88,7 +88,7 @@ class WithGroupedHeadingRowTest extends TestCase
             {
                 $this->called = true;
 
-                Assert::assertEquals([
+                Assert::assertSame([
                     [
                         'name'    => 'Patrick Brouwers',
                         'email'   => 'patrick@maatwebsite.nl',

--- a/tests/Concerns/WithHeadingRowTest.php
+++ b/tests/Concerns/WithHeadingRowTest.php
@@ -95,7 +95,7 @@ class WithHeadingRowTest extends TestCase
 
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     [
                         'name'  => 'Patrick Brouwers',
                         'email' => 'patrick@maatwebsite.nl',
@@ -158,7 +158,7 @@ class WithHeadingRowTest extends TestCase
             {
                 $this->called = true;
 
-                Assert::assertEquals([
+                Assert::assertSame([
                     0 => 0,
                     1 => 'email',
                     2 => 'status',

--- a/tests/Concerns/WithHeadingsTest.php
+++ b/tests/Concerns/WithHeadingsTest.php
@@ -43,7 +43,7 @@ class WithHeadingsTest extends TestCase
             ['A2', 'B2', 'C2'],
         ];
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function test_can_export_from_collection_with_multiple_heading_rows(): void
@@ -82,7 +82,7 @@ class WithHeadingsTest extends TestCase
             ['A2', 'B2', 'C2'],
         ];
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function test_can_export_from_collection_with_heading_row_with_custom_start_cell(): void
@@ -123,6 +123,6 @@ class WithHeadingsTest extends TestCase
             [null, 'A2', 'B2', 'C2'],
         ];
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 }

--- a/tests/Concerns/WithLimitTest.php
+++ b/tests/Concerns/WithLimitTest.php
@@ -71,7 +71,7 @@ class WithLimitTest extends TestCase
 
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     [
                         'Patrick Brouwers',
                         'patrick@maatwebsite.nl',
@@ -96,7 +96,7 @@ class WithLimitTest extends TestCase
 
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     [
                         'name'  => 'Patrick Brouwers',
                         'email' => 'patrick@maatwebsite.nl',
@@ -121,7 +121,7 @@ class WithLimitTest extends TestCase
 
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     [
                         'name'  => 'Patrick Brouwers',
                         'email' => 'patrick@maatwebsite.nl',

--- a/tests/Concerns/WithMappedCellsTest.php
+++ b/tests/Concerns/WithMappedCellsTest.php
@@ -39,7 +39,7 @@ class WithMappedCellsTest extends TestCase
 
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     'name'  => 'Patrick Brouwers',
                     'email' => 'patrick@maatwebsite.nl',
                 ], $array);
@@ -71,7 +71,7 @@ class WithMappedCellsTest extends TestCase
 
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     [
                         'name'  => 'Patrick Brouwers',
                         'email' => 'patrick@maatwebsite.nl',
@@ -103,7 +103,7 @@ class WithMappedCellsTest extends TestCase
 
             public function model(array $array): User
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     'name'  => 'Patrick Brouwers',
                     'email' => 'patrick@maatwebsite.nl',
                 ], $array);

--- a/tests/Concerns/WithMappingTest.php
+++ b/tests/Concerns/WithMappingTest.php
@@ -33,7 +33,7 @@ class WithMappingTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function test_can_return_multiple_rows_in_map(): void

--- a/tests/Concerns/WithMultipleSheetsTest.php
+++ b/tests/Concerns/WithMultipleSheetsTest.php
@@ -150,7 +150,7 @@ class WithMultipleSheetsTest extends TestCase
 
         $import->import('import-multiple-sheets.xlsx');
 
-        $this->assertEquals('Some Random Sheet Name', $import->unknown);
+        $this->assertSame('Some Random Sheet Name', $import->unknown);
     }
 
     public function test_unknown_sheet_indices_can_be_ignored_per_name(): void
@@ -169,7 +169,7 @@ class WithMultipleSheetsTest extends TestCase
                          */
                         public function onUnknownSheet($sheetName): void
                         {
-                            Assert::assertEquals('Some Random Sheet Name', $sheetName);
+                            Assert::assertSame('Some Random Sheet Name', $sheetName);
                         }
                     },
                 ];
@@ -207,7 +207,7 @@ class WithMultipleSheetsTest extends TestCase
 
         $import->import('import-multiple-sheets.xlsx');
 
-        $this->assertEquals(99999, $import->unknown);
+        $this->assertSame(99999, $import->unknown);
     }
 
     public function test_unknown_sheet_indices_can_be_ignored_per_sheet(): void
@@ -226,7 +226,7 @@ class WithMultipleSheetsTest extends TestCase
                          */
                         public function onUnknownSheet($sheetName): void
                         {
-                            Assert::assertEquals(99999, $sheetName);
+                            Assert::assertSame(99999, $sheetName);
                         }
                     },
                 ];
@@ -249,7 +249,7 @@ class WithMultipleSheetsTest extends TestCase
                     {
                         public function array(array $array): void
                         {
-                            Assert::assertEquals([
+                            Assert::assertSame([
                                 ['1.A1', '1.B1'],
                                 ['1.A2', '1.B2'],
                             ], $array);
@@ -259,7 +259,7 @@ class WithMultipleSheetsTest extends TestCase
                     {
                         public function array(array $array): void
                         {
-                            Assert::assertEquals([
+                            Assert::assertSame([
                                 ['2.A1', '2.B1'],
                                 ['2.A2', '2.B2'],
                             ], $array);
@@ -285,7 +285,7 @@ class WithMultipleSheetsTest extends TestCase
                     {
                         public function array(array $array): void
                         {
-                            Assert::assertEquals([
+                            Assert::assertSame([
                                 ['2.A1', '2.B1'],
                                 ['2.A2', '2.B2'],
                             ], $array);
@@ -295,7 +295,7 @@ class WithMultipleSheetsTest extends TestCase
                     {
                         public function array(array $array): void
                         {
-                            Assert::assertEquals([
+                            Assert::assertSame([
                                 ['1.A1', '1.B1'],
                                 ['1.A2', '1.B2'],
                             ], $array);
@@ -326,7 +326,7 @@ class WithMultipleSheetsTest extends TestCase
                         public function array(array $array): void
                         {
                             $this->called = true;
-                            Assert::assertEquals([
+                            Assert::assertSame([
                                 ['1.A1', '1.B1'],
                                 ['1.A2', '1.B2'],
                             ], $array);
@@ -339,7 +339,7 @@ class WithMultipleSheetsTest extends TestCase
                         public function array(array $array): void
                         {
                             $this->called = true;
-                            Assert::assertEquals([
+                            Assert::assertSame([
                                 ['2.A1', '2.B1'],
                                 ['2.A2', '2.B2'],
                             ], $array);
@@ -379,7 +379,7 @@ class WithMultipleSheetsTest extends TestCase
                         public function array(array $array): void
                         {
                             $this->called = true;
-                            Assert::assertEquals([
+                            Assert::assertSame([
                                 ['1.A1', '1.B1'],
                                 ['1.A2', '1.B2'],
                             ], $array);
@@ -392,7 +392,7 @@ class WithMultipleSheetsTest extends TestCase
                         public function array(array $array): void
                         {
                             $this->called = true;
-                            Assert::assertEquals([
+                            Assert::assertSame([
                                 ['2.A1', '2.B1'],
                                 ['2.A2', '2.B2'],
                             ], $array);

--- a/tests/Concerns/WithPropertiesTest.php
+++ b/tests/Concerns/WithPropertiesTest.php
@@ -35,15 +35,15 @@ class WithPropertiesTest extends TestCase
         $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/with-properties.xlsx', 'Xlsx');
         $props       = $spreadsheet->getProperties();
 
-        $this->assertEquals('A', $props->getCreator());
-        $this->assertEquals('B', $props->getLastModifiedBy());
-        $this->assertEquals('C', $props->getTitle());
-        $this->assertEquals('D', $props->getDescription());
-        $this->assertEquals('E', $props->getSubject());
-        $this->assertEquals('F', $props->getKeywords());
-        $this->assertEquals('G', $props->getCategory());
-        $this->assertEquals('H', $props->getManager());
-        $this->assertEquals('I', $props->getCompany());
+        $this->assertSame('A', $props->getCreator());
+        $this->assertSame('B', $props->getLastModifiedBy());
+        $this->assertSame('C', $props->getTitle());
+        $this->assertSame('D', $props->getDescription());
+        $this->assertSame('E', $props->getSubject());
+        $this->assertSame('F', $props->getKeywords());
+        $this->assertSame('G', $props->getCategory());
+        $this->assertSame('H', $props->getManager());
+        $this->assertSame('I', $props->getCompany());
     }
 
     public function test_it_merges_with_default_properties(): void
@@ -68,8 +68,8 @@ class WithPropertiesTest extends TestCase
         $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/with-properties.xlsx', 'Xlsx');
         $props       = $spreadsheet->getProperties();
 
-        $this->assertEquals('Default Title', $props->getTitle());
-        $this->assertEquals('Custom Description', $props->getDescription());
+        $this->assertSame('Default Title', $props->getTitle());
+        $this->assertSame('Custom Description', $props->getDescription());
     }
 
     public function test_it_ignores_empty_properties(): void

--- a/tests/Concerns/WithSkipDuplicatesTest.php
+++ b/tests/Concerns/WithSkipDuplicatesTest.php
@@ -73,7 +73,7 @@ class WithSkipDuplicatesTest extends TestCase
             'password' => 'secret',
         ]);
 
-        $this->assertEquals(2, User::count());
+        $this->assertSame(2, User::count());
     }
 
     public function test_can_skip_duplicate_models_in_rows(): void
@@ -122,6 +122,6 @@ class WithSkipDuplicatesTest extends TestCase
             'password' => 'secret',
         ]);
 
-        $this->assertEquals(2, User::count());
+        $this->assertSame(2, User::count());
     }
 }

--- a/tests/Concerns/WithStartRowTest.php
+++ b/tests/Concerns/WithStartRowTest.php
@@ -64,7 +64,7 @@ class WithStartRowTest extends TestCase
 
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     [
                         'Patrick Brouwers',
                         'patrick@maatwebsite.nl',

--- a/tests/Concerns/WithStrictNullComparisonTest.php
+++ b/tests/Concerns/WithStrictNullComparisonTest.php
@@ -74,7 +74,7 @@ class WithStrictNullComparisonTest extends TestCase
             ['string', null, null, 'string'],
         ];
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     public function test_exports_trailing_empty_cells(): void
@@ -104,7 +104,7 @@ class WithStrictNullComparisonTest extends TestCase
             ['a2', null, null, 'd2'],
         ];
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
 
         $contents = file_get_contents($file);
         $this->assertStringContains('"a1","","","d1",""', $contents);

--- a/tests/Concerns/WithStylesTest.php
+++ b/tests/Concerns/WithStylesTest.php
@@ -43,6 +43,6 @@ class WithStylesTest extends TestCase
         $this->assertTrue($sheet->getStyle('B1')->getFont()->getItalic());
         $this->assertTrue($sheet->getStyle('B2')->getFont()->getBold());
         $this->assertFalse($sheet->getStyle('A2')->getFont()->getBold());
-        $this->assertEquals(16, $sheet->getStyle('C2')->getFont()->getSize());
+        $this->assertSame(16.0, $sheet->getStyle('C2')->getFont()->getSize());
     }
 }

--- a/tests/Concerns/WithTitleTest.php
+++ b/tests/Concerns/WithTitleTest.php
@@ -20,8 +20,8 @@ class WithTitleTest extends TestCase
 
         $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/with-title-store.xlsx', 'Xlsx');
 
-        $this->assertEquals('given-title', $spreadsheet->getProperties()->getTitle());
-        $this->assertEquals('given-title', $spreadsheet->getActiveSheet()->getTitle());
+        $this->assertSame('given-title', $spreadsheet->getProperties()->getTitle());
+        $this->assertSame('given-title', $spreadsheet->getActiveSheet()->getTitle());
     }
 
     public function test_can_export_sheet_title_when_longer_than_max_length(): void
@@ -46,7 +46,7 @@ class WithTitleTest extends TestCase
 
         $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/with-title-store.xlsx', 'Xlsx');
 
-        $this->assertEquals('12/3456789123/45678912345/678912345/6789', $spreadsheet->getProperties()->getTitle());
-        $this->assertEquals('1234567891234567891234567891234', $spreadsheet->getActiveSheet()->getTitle());
+        $this->assertSame('12/3456789123/45678912345/678912345/6789', $spreadsheet->getProperties()->getTitle());
+        $this->assertSame('1234567891234567891234567891234', $spreadsheet->getActiveSheet()->getTitle());
     }
 }

--- a/tests/Concerns/WithUpsertsTest.php
+++ b/tests/Concerns/WithUpsertsTest.php
@@ -74,7 +74,7 @@ class WithUpsertsTest extends TestCase
             'password' => 'secret',
         ]);
 
-        $this->assertEquals(2, User::count());
+        $this->assertSame(2, User::count());
     }
 
     public function test_can_upsert_models_in_rows(): void
@@ -123,7 +123,7 @@ class WithUpsertsTest extends TestCase
             'password' => 'secret',
         ]);
 
-        $this->assertEquals(2, User::count());
+        $this->assertSame(2, User::count());
     }
 
     public function test_can_upsert_models_in_batches_with_defined_upsert_columns(): void
@@ -182,7 +182,7 @@ class WithUpsertsTest extends TestCase
             'password' => 'secret',
         ]);
 
-        $this->assertEquals(2, User::count());
+        $this->assertSame(2, User::count());
     }
 
     public function test_can_upsert_models_in_rows_with_defined_upsert_columns(): void
@@ -236,6 +236,6 @@ class WithUpsertsTest extends TestCase
             'password' => 'secret',
         ]);
 
-        $this->assertEquals(2, User::count());
+        $this->assertSame(2, User::count());
     }
 }

--- a/tests/Concerns/WithValidationTest.php
+++ b/tests/Concerns/WithValidationTest.php
@@ -897,10 +897,10 @@ class WithValidationTest extends TestCase
         $failures = $e->failures();
         $failure  = head($failures);
 
-        $this->assertEquals($row, $failure->row());
-        $this->assertEquals($attribute, $failure->attribute());
-        $this->assertEquals($row, $failure->jsonSerialize()['row']);
-        $this->assertEquals($attribute, $failure->jsonSerialize()['attribute']);
+        $this->assertSame($row, $failure->row());
+        $this->assertSame($attribute, $failure->attribute());
+        $this->assertSame($row, $failure->jsonSerialize()['row']);
+        $this->assertSame($attribute, $failure->jsonSerialize()['attribute']);
 
         $this->assertRegex('/' . $messages[0] . '/', $failure->errors()[0]);
         $this->assertRegex('/' . $messages[0] . '/', $failure->jsonSerialize()['errors'][0]);

--- a/tests/Data/Stubs/AfterQueueImportJob.php
+++ b/tests/Data/Stubs/AfterQueueImportJob.php
@@ -18,6 +18,6 @@ class AfterQueueImportJob implements ShouldQueue
 
     public function handle(): void
     {
-        Assert::assertEquals($this->totalRows, DB::table('groups')->count('id'));
+        Assert::assertSame($this->totalRows, DB::table('groups')->count('id'));
     }
 }

--- a/tests/Data/Stubs/QueuedExportWithFailedEvents.php
+++ b/tests/Data/Stubs/QueuedExportWithFailedEvents.php
@@ -28,7 +28,7 @@ class QueuedExportWithFailedEvents implements WithEvents, WithMultipleSheets
 
     public function failed(Throwable $exception): void
     {
-        Assert::assertEquals('catch exception from QueueExport job', $exception->getMessage());
+        Assert::assertSame('catch exception from QueueExport job', $exception->getMessage());
 
         app()->bind('queue-has-failed-from-queue-export-job', fn () => true);
     }

--- a/tests/Data/Stubs/QueuedExportWithFailedHook.php
+++ b/tests/Data/Stubs/QueuedExportWithFailedHook.php
@@ -36,7 +36,7 @@ class QueuedExportWithFailedHook implements FromCollection, WithMapping
 
     public function failed(Exception $exception): void
     {
-        Assert::assertEquals('we expect this', $exception->getMessage());
+        Assert::assertSame('we expect this', $exception->getMessage());
 
         app()->bind('queue-has-failed', fn () => true);
     }

--- a/tests/Data/Stubs/QueuedExportWithLocalePreferences.php
+++ b/tests/Data/Stubs/QueuedExportWithLocalePreferences.php
@@ -41,7 +41,7 @@ class QueuedExportWithLocalePreferences implements FromCollection, HasLocalePref
      */
     public function prepareRows($rows): iterable
     {
-        Assert::assertEquals('ru', app()->getLocale());
+        Assert::assertSame('ru', app()->getLocale());
 
         app()->bind('queue-has-correct-locale', fn () => true);
 

--- a/tests/ExcelServiceProviderTest.php
+++ b/tests/ExcelServiceProviderTest.php
@@ -29,7 +29,7 @@ class ExcelServiceProviderTest extends TestCase
     public function test_has_aliased(): void
     {
         $this->assertTrue($this->app->isAlias(Excel::class));
-        $this->assertEquals('excel', $this->app->getAlias(Excel::class));
+        $this->assertSame('excel', $this->app->getAlias(Excel::class));
     }
 
     public function test_registers_console_commands(): void
@@ -46,7 +46,7 @@ class ExcelServiceProviderTest extends TestCase
     {
         $driver = config('excel.cache.driver');
 
-        $this->assertEquals('memory', $driver);
+        $this->assertSame('memory', $driver);
 
         if (InstalledVersions::satisfies(new VersionParser, 'psr/simple-cache', '^3.0')) {
             $this->assertInstanceOf(

--- a/tests/ExcelTest.php
+++ b/tests/ExcelTest.php
@@ -41,7 +41,7 @@ class ExcelTest extends TestCase
         $response = ExcelFacade::download($export, 'filename.xlsx');
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
-        $this->assertEquals('attachment; filename=filename.xlsx', str_replace('"', '', $response->headers->get('Content-Disposition')));
+        $this->assertSame('attachment; filename=filename.xlsx', str_replace('"', '', $response->headers->get('Content-Disposition')));
     }
 
     public function test_can_download_an_export_object(): void
@@ -51,7 +51,7 @@ class ExcelTest extends TestCase
         $response = $this->SUT->download($export, 'filename.xlsx');
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
-        $this->assertEquals('attachment; filename=filename.xlsx', str_replace('"', '', $response->headers->get('Content-Disposition')));
+        $this->assertSame('attachment; filename=filename.xlsx', str_replace('"', '', $response->headers->get('Content-Disposition')));
     }
 
     public function test_can_store_an_export_object_on_default_disk(): void
@@ -192,7 +192,7 @@ class ExcelTest extends TestCase
             use Importable;
         };
 
-        $this->assertEquals([
+        $this->assertSame([
             [
                 ['test', 'test'],
                 ['test', 'test'],
@@ -231,7 +231,7 @@ class ExcelTest extends TestCase
         {
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     ['test', 'test'],
                     ['test', 'test'],
                 ], $array);
@@ -249,7 +249,7 @@ class ExcelTest extends TestCase
         {
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     'tconst',
                     'titleType',
                     'primaryTitle',
@@ -281,7 +281,7 @@ class ExcelTest extends TestCase
         {
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     ['test', 'test'],
                     ['test', 'test'],
                 ], $array);
@@ -292,7 +292,7 @@ class ExcelTest extends TestCase
         {
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     ['test', 'test'],
                     ['test', 'test'],
                 ], $array);
@@ -312,7 +312,7 @@ class ExcelTest extends TestCase
         {
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     ['test', 'test'],
                     ['test', 'test'],
                 ], $array);
@@ -328,7 +328,7 @@ class ExcelTest extends TestCase
         {
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     ['test', 'test'],
                     ['test', 'test'],
                 ], $array);
@@ -346,7 +346,7 @@ class ExcelTest extends TestCase
         {
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     ['test', 'test'],
                     ['test', 'test'],
                 ], $array);
@@ -377,7 +377,7 @@ class ExcelTest extends TestCase
         {
             public function array(array $array): void
             {
-                Assert::assertEquals([
+                Assert::assertSame([
                     ['test', 'test'],
                     ['test', 'test'],
                 ], $array);

--- a/tests/HeadingRowImportTest.php
+++ b/tests/HeadingRowImportTest.php
@@ -19,7 +19,7 @@ class HeadingRowImportTest extends TestCase
 
         $headings = $import->toArray('import-users-with-headings.xlsx');
 
-        $this->assertEquals([
+        $this->assertSame([
             [
                 ['name', 'email'],
             ],
@@ -36,7 +36,7 @@ class HeadingRowImportTest extends TestCase
 
         $headings = $import->toArray('import-users-with-headings.xlsx');
 
-        $this->assertEquals([
+        $this->assertSame([
             [
                 ['custom-name', 'custom-email'],
             ],
@@ -53,7 +53,7 @@ class HeadingRowImportTest extends TestCase
 
         $headings = $import->toArray('import-users-with-headings.xlsx');
 
-        $this->assertEquals([
+        $this->assertSame([
             [
                 [0, 1],
             ],
@@ -66,7 +66,7 @@ class HeadingRowImportTest extends TestCase
 
         $headings = $import->toArray('import-users-with-headings.xlsx');
 
-        $this->assertEquals([
+        $this->assertSame([
             [
                 ['patrick_brouwers', 'patrick_at_maatwebsitenl'],
             ],
@@ -79,7 +79,7 @@ class HeadingRowImportTest extends TestCase
 
         $headings = $import->toArray('import-multiple-sheets.xlsx');
 
-        $this->assertEquals([
+        $this->assertSame([
             [
                 ['1a1', '1b1'], // slugged first row of sheet 1
             ],
@@ -98,7 +98,7 @@ class HeadingRowImportTest extends TestCase
 
         $headings = $import->toArray('import-multiple-sheets.xlsx');
 
-        $this->assertEquals([
+        $this->assertSame([
             [
                 [0, 1], // slugged first row of sheet 1
             ],
@@ -114,7 +114,7 @@ class HeadingRowImportTest extends TestCase
 
         $headings = $import->toArray('import-multiple-sheets.xlsx');
 
-        $this->assertEquals([
+        $this->assertSame([
             [
                 ['1a2', '1b2'], // slugged 2nd row of sheet 1
             ],
@@ -134,7 +134,7 @@ class HeadingRowImportTest extends TestCase
 
         $headings = $import->toArray('import-users-with-headings.xlsx');
 
-        $this->assertEquals([
+        $this->assertSame([
             [
                 ['custom2-name', 'custom2-email'],
             ],

--- a/tests/Mixins/DownloadCollectionTest.php
+++ b/tests/Mixins/DownloadCollectionTest.php
@@ -24,10 +24,10 @@ class DownloadCollectionTest extends TestCase
 
         // First row are not headings
         $firstRow = collect($array)->first();
-        $this->assertEquals(['test', 'test'], $firstRow);
+        $this->assertSame(['test', 'test'], $firstRow);
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
-        $this->assertEquals(
+        $this->assertSame(
             'attachment; filename=collection-download.xlsx',
             str_replace('"', '', $response->headers->get('Content-Disposition'))
         );
@@ -45,7 +45,7 @@ class DownloadCollectionTest extends TestCase
 
         $array = $this->readAsArray($response->getFile()->getPathName(), Excel::XLSX);
 
-        $this->assertEquals(['column_1', 'column_2'], collect($array)->first());
+        $this->assertSame(['column_1', 'column_2'], collect($array)->first());
     }
 
     public function test_can_download_collection_with_headers_with_hidden_eloquent_attributes(): void
@@ -59,7 +59,7 @@ class DownloadCollectionTest extends TestCase
 
         $array = $this->readAsArray($response->getFile()->getPathName(), Excel::XLSX);
 
-        $this->assertEquals(['name'], collect($array)->first());
+        $this->assertSame(['name'], collect($array)->first());
     }
 
     public function test_can_download_collection_with_headers_when_making_attributes_visible(): void
@@ -76,7 +76,7 @@ class DownloadCollectionTest extends TestCase
 
         $array = $this->readAsArray($response->getFile()->getPathName(), Excel::XLSX);
 
-        $this->assertEquals(['name', 'password'], collect($array)->first());
+        $this->assertSame(['name', 'password'], collect($array)->first());
     }
 
     public function test_can_set_custom_response_headers(): void

--- a/tests/Mixins/DownloadQueryMacroTest.php
+++ b/tests/Mixins/DownloadQueryMacroTest.php
@@ -30,7 +30,7 @@ class DownloadQueryMacroTest extends TestCase
         $this->assertCount(100, $array);
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
-        $this->assertEquals(
+        $this->assertSame(
             'attachment; filename=query-download.xlsx',
             str_replace('"', '', $response->headers->get('Content-Disposition'))
         );
@@ -45,6 +45,6 @@ class DownloadQueryMacroTest extends TestCase
 
         $this->assertCount(101, $array);
 
-        $this->assertEquals(['id', 'name', 'email', 'remember_token', 'created_at', 'updated_at'], collect($array)->first());
+        $this->assertSame(['id', 'name', 'email', 'remember_token', 'created_at', 'updated_at'], collect($array)->first());
     }
 }

--- a/tests/Mixins/ImportAsMacroTest.php
+++ b/tests/Mixins/ImportAsMacroTest.php
@@ -29,7 +29,7 @@ class ImportAsMacroTest extends TestCase
         ]);
 
         $this->assertCount(2, User::all());
-        $this->assertEquals([
+        $this->assertSame([
             'patrick@maatwebsite.nl',
             'taylor@laravel.com',
         ], User::query()->pluck('email')->all());

--- a/tests/Mixins/ImportMacroTest.php
+++ b/tests/Mixins/ImportMacroTest.php
@@ -28,7 +28,7 @@ class ImportMacroTest extends TestCase
         User::import('import-users-with-headings.xlsx');
 
         $this->assertCount(2, User::all());
-        $this->assertEquals([
+        $this->assertSame([
             'patrick@maatwebsite.nl',
             'taylor@laravel.com',
         ], User::query()->pluck('email')->all());

--- a/tests/Mixins/StoreCollectionTest.php
+++ b/tests/Mixins/StoreCollectionTest.php
@@ -42,9 +42,9 @@ class StoreCollectionTest extends TestCase
 
         // First row are not headings
         $firstRow = collect($array)->first();
-        $this->assertEquals(['test', 'test'], $firstRow);
+        $this->assertSame(['test', 'test'], $firstRow);
 
-        $this->assertEquals([
+        $this->assertSame([
             ['test', 'test'],
             ['test2', 'test2'],
         ], collect($array)->values()->all());
@@ -66,9 +66,9 @@ class StoreCollectionTest extends TestCase
         $this->assertFileExists($file);
 
         $array = $this->readAsArray($file, Excel::XLSX);
-        $this->assertEquals(['column_1', 'column_2'], collect($array)->first());
+        $this->assertSame(['column_1', 'column_2'], collect($array)->first());
 
-        $this->assertEquals([
+        $this->assertSame([
             ['test', 'test'],
             ['test', 'test'],
         ], collect($array)->except(0)->values()->all());
@@ -87,6 +87,6 @@ class StoreCollectionTest extends TestCase
         $this->assertFileExists($file);
 
         $array = $this->readAsArray($file, Excel::XLSX);
-        $this->assertEquals(['name', 'email', 'remember_token'], collect($array)->first());
+        $this->assertSame(['name', 'email', 'remember_token'], collect($array)->first());
     }
 }

--- a/tests/QueuedExportTest.php
+++ b/tests/QueuedExportTest.php
@@ -38,7 +38,7 @@ class QueuedExportTest extends TestCase
         $batch = $export->queue('batch-export.xlsx', 'test')->name('batch-export-name');
 
         $this->assertInstanceOf(PendingBatch::class, $batch);
-        $this->assertEquals('batch-export-name', $batch->name);
+        $this->assertSame('batch-export-name', $batch->name);
         $this->assertCount(1, $batch->jobs);
     }
 
@@ -89,7 +89,7 @@ class QueuedExportTest extends TestCase
         $array = $this->readAsArray(__DIR__ . '/Data/Disks/Local/queued-export.xlsx', Excel::XLSX);
 
         $this->assertCount(100, $array);
-        $this->assertEquals(3, $jobs);
+        $this->assertSame(3, $jobs);
     }
 
     public function test_can_queue_export_with_remote_temp_disk_and_prefix(): void
@@ -123,7 +123,7 @@ class QueuedExportTest extends TestCase
 
         $actual = $this->readAsArray(__DIR__ . '/Data/Disks/Local/queued-export.xlsx', 'Xlsx');
 
-        $this->assertEquals([
+        $this->assertSame([
             ['Patrick', 'Brouwers'],
         ], $actual);
     }
@@ -161,7 +161,7 @@ class QueuedExportTest extends TestCase
 
         $this->assertTrue(app('queue-has-correct-locale'));
 
-        $this->assertEquals($currentLocale, app()->getLocale());
+        $this->assertSame($currentLocale, app()->getLocale());
     }
 
     public function test_can_queue_export_not_flushing_the_cache(): void
@@ -179,6 +179,6 @@ class QueuedExportTest extends TestCase
         $array = $this->readAsArray(__DIR__ . '/Data/Disks/Local/queued-export.xlsx', Excel::XLSX);
         $this->assertCount(100, $array);
 
-        $this->assertEquals('test', Cache::get('test'));
+        $this->assertSame('test', Cache::get('test'));
     }
 }

--- a/tests/QueuedImportTest.php
+++ b/tests/QueuedImportTest.php
@@ -67,7 +67,7 @@ class QueuedImportTest extends TestCase
         $batch = $import->queue('import-batches.xlsx')->name('batch-import-name');
 
         $this->assertInstanceOf(PendingBatch::class, $batch);
-        $this->assertEquals('batch-import-name', $batch->name);
+        $this->assertSame('batch-import-name', $batch->name);
         $this->assertCount(1, $batch->jobs);
     }
 
@@ -165,7 +165,7 @@ class QueuedImportTest extends TestCase
         try {
             (new QueuedImportWithFailure)->queue('import-batches.xlsx');
         } catch (Throwable $e) {
-            $this->assertEquals('Something went wrong in the chunk', $e->getMessage());
+            $this->assertSame('Something went wrong in the chunk', $e->getMessage());
         }
 
         $this->assertFalse($tempFile?->existsLocally());
@@ -185,7 +185,7 @@ class QueuedImportTest extends TestCase
         try {
             (new QueuedImportWithFailure)->queue('import-batches.xlsx');
         } catch (Throwable $e) {
-            $this->assertEquals('Something went wrong in the chunk', $e->getMessage());
+            $this->assertSame('Something went wrong in the chunk', $e->getMessage());
         }
 
         $this->assertTrue($tempFile?->exists());
@@ -216,7 +216,7 @@ class QueuedImportTest extends TestCase
         try {
             (new QueuedImportWithMiddleware)->queue('import-batches.xlsx');
         } catch (Throwable $e) {
-            $this->assertEquals('Job reached middleware method', $e->getMessage());
+            $this->assertSame('Job reached middleware method', $e->getMessage());
         }
     }
 
@@ -225,7 +225,7 @@ class QueuedImportTest extends TestCase
         try {
             (new QueuedImportWithRetryUntil)->queue('import-batches.xlsx');
         } catch (Throwable $e) {
-            $this->assertEquals('Job reached retryUntil method', $e->getMessage());
+            $this->assertSame('Job reached retryUntil method', $e->getMessage());
         }
     }
 
@@ -244,9 +244,9 @@ class QueuedImportTest extends TestCase
             $import->maxExceptions = 3;
             $import->queue('import-batches.xlsx');
         } catch (Throwable $e) {
-            $this->assertEquals('Something went wrong in the chunk', $e->getMessage());
+            $this->assertSame('Something went wrong in the chunk', $e->getMessage());
         }
 
-        $this->assertEquals(3, $maxExceptionsCount);
+        $this->assertSame(3, $maxExceptionsCount);
     }
 }

--- a/tests/QueuedQueryExportTest.php
+++ b/tests/QueuedQueryExportTest.php
@@ -75,7 +75,7 @@ class QueuedQueryExportTest extends TestCase
 
         // Only 1 column when using map()
         $this->assertCount(1, $actual[0]);
-        $this->assertEquals(User::value('name'), $actual[0][0]);
+        $this->assertSame(User::value('name'), $actual[0][0]);
     }
 
     public function test_can_queue_scout_export(): void

--- a/tests/QueuedViewExportTest.php
+++ b/tests/QueuedViewExportTest.php
@@ -52,8 +52,8 @@ class QueuedViewExportTest extends TestCase
             $user->email,
         ])->prepend(['Name', 'Email'])->toArray();
 
-        $this->assertEquals(101, count($contents));
-        $this->assertEquals($expected, $contents);
+        $this->assertSame(101, count($contents));
+        $this->assertSame($expected, $contents);
 
         $contents = $this->readAsArray(__DIR__ . '/Data/Disks/Local/queued-multiple-view-export.xlsx', 'Xlsx', 2);
 
@@ -62,7 +62,7 @@ class QueuedViewExportTest extends TestCase
             $user->email,
         ])->prepend(['Name', 'Email'])->toArray();
 
-        $this->assertEquals(101, count($contents));
-        $this->assertEquals($expected, $contents);
+        $this->assertSame(101, count($contents));
+        $this->assertSame($expected, $contents);
     }
 }

--- a/tests/TemporaryFileTest.php
+++ b/tests/TemporaryFileTest.php
@@ -43,8 +43,8 @@ class TemporaryFileTest extends TestCase
         $temporaryFile->put('data-set');
 
         $this->assertFileExists($temporaryFile->getLocalPath());
-        $this->assertEquals($this->defaultDirectoryPermissions, substr(sprintf('%o', fileperms(dirname($temporaryFile->getLocalPath()))), -4));
-        $this->assertEquals($this->defaultFilePermissions, substr(sprintf('%o', fileperms($temporaryFile->getLocalPath())), -4));
+        $this->assertSame($this->defaultDirectoryPermissions, substr(sprintf('%o', fileperms(dirname($temporaryFile->getLocalPath()))), -4));
+        $this->assertSame($this->defaultFilePermissions, substr(sprintf('%o', fileperms($temporaryFile->getLocalPath())), -4));
     }
 
     public function test_can_use_dir_rights(): void
@@ -61,8 +61,8 @@ class TemporaryFileTest extends TestCase
         $temporaryFile->put('data-set');
 
         $this->assertFileExists($temporaryFile->getLocalPath());
-        $this->assertEquals('0700', substr(sprintf('%o', fileperms(dirname($temporaryFile->getLocalPath()))), -4));
-        $this->assertEquals($this->defaultFilePermissions, substr(sprintf('%o', fileperms($temporaryFile->getLocalPath())), -4));
+        $this->assertSame('0700', substr(sprintf('%o', fileperms(dirname($temporaryFile->getLocalPath()))), -4));
+        $this->assertSame($this->defaultFilePermissions, substr(sprintf('%o', fileperms($temporaryFile->getLocalPath())), -4));
     }
 
     public function test_can_use_file_rights(): void
@@ -79,7 +79,7 @@ class TemporaryFileTest extends TestCase
         $temporaryFile->put('data-set');
 
         $this->assertFileExists($temporaryFile->getLocalPath());
-        $this->assertEquals($this->defaultDirectoryPermissions, substr(sprintf('%o', fileperms(dirname($temporaryFile->getLocalPath()))), -4));
-        $this->assertEquals('0600', substr(sprintf('%o', fileperms($temporaryFile->getLocalPath())), -4));
+        $this->assertSame($this->defaultDirectoryPermissions, substr(sprintf('%o', fileperms(dirname($temporaryFile->getLocalPath()))), -4));
+        $this->assertSame('0600', substr(sprintf('%o', fileperms($temporaryFile->getLocalPath())), -4));
     }
 }

--- a/tests/Validators/RowValidatorTest.php
+++ b/tests/Validators/RowValidatorTest.php
@@ -29,7 +29,7 @@ class RowValidatorTest extends TestCase
 
         $result = $this->callPrivateMethod('formatRule', [$rules]);
 
-        $this->assertEquals($rules, $result);
+        $this->assertSame($rules, $result);
     }
 
     public function test_format_rule_with_object_input(): void
@@ -38,7 +38,7 @@ class RowValidatorTest extends TestCase
 
         $result = $this->callPrivateMethod('formatRule', [$rule]);
 
-        $this->assertEquals($rule, $result);
+        $this->assertSame($rule, $result);
     }
 
     public function test_format_rule_with_callable_input(): void
@@ -47,7 +47,7 @@ class RowValidatorTest extends TestCase
 
         $result = $this->callPrivateMethod('formatRule', [$rule]);
 
-        $this->assertEquals($rule, $result);
+        $this->assertSame($rule, $result);
     }
 
     public function test_format_rule_with_required_without_all(): void
@@ -56,7 +56,7 @@ class RowValidatorTest extends TestCase
 
         $result = $this->callPrivateMethod('formatRule', [$rule]);
 
-        $this->assertEquals('required_without_all:*.first_name,*.last_name', $result);
+        $this->assertSame('required_without_all:*.first_name,*.last_name', $result);
     }
 
     public function test_format_rule_with_required_without(): void
@@ -65,7 +65,7 @@ class RowValidatorTest extends TestCase
 
         $result = $this->callPrivateMethod('formatRule', [$rule]);
 
-        $this->assertEquals('required_without:*.first_name', $result);
+        $this->assertSame('required_without:*.first_name', $result);
     }
 
     public function test_format_rule_with_string_input_not_matching_pattern(): void
@@ -74,7 +74,7 @@ class RowValidatorTest extends TestCase
 
         $result = $this->callPrivateMethod('formatRule', [$rule]);
 
-        $this->assertEquals($rule, $result);
+        $this->assertSame($rule, $result);
     }
 
     /**


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?

`$this->stringContains()` expects second argument to be `bool $case` rather than comparison string. Instead, `assertStringContainsString()` should be used. 
However, most Unique Constraint error assertions were failing after changing as we are using SQLite in tests - this is because SQLite doesn't report the row details, including email, that caused the constraint violation. Since we require Laravel 12+, we can rely on `UniqueConstraintViolationException` instead. These issues are reported by PHPStan level 5.

Remaining validation assertions were updated as well to avoid false negatives and keep regressions from occuring.

Second commit replaces most occurrences of `assertEquals` with `assertSame` to ensure strict comparisons.

It might be a good idea to partially backport these changes to v3.1 as well.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

3️⃣  Does it include tests, if possible?

4️⃣  Any drawbacks? Possible breaking changes?

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
