### PR TITLE
[3.1] Clean up legacy compatibility layers

### DIFF
--- a/src/Factories/ReaderFactory.php
+++ b/src/Factories/ReaderFactory.php
@@ -33,13 +33,8 @@ class ReaderFactory
             $readerType ?: static::identify($file)
         );
 
-        if (method_exists($reader, 'setReadDataOnly')) {
-            $reader->setReadDataOnly(config('excel.imports.read_only', true));
-        }
-
-        if (method_exists($reader, 'setReadEmptyCells')) {
-            $reader->setReadEmptyCells(!config('excel.imports.ignore_empty', false));
-        }
+        $reader->setReadDataOnly(config('excel.imports.read_only', true));
+        $reader->setReadEmptyCells(!config('excel.imports.ignore_empty', false));
 
         if ($reader instanceof Csv) {
             static::applyCsvSettings(config('excel.imports.csv', []));
@@ -53,9 +48,7 @@ class ReaderFactory
             $reader->setEscapeCharacter(static::$escapeCharacter);
             $reader->setContiguous(static::$contiguous);
             $reader->setInputEncoding(static::$inputEncoding);
-            if (method_exists($reader, 'setTestAutoDetect')) {
-                $reader->setTestAutoDetect(static::$testAutoDetect);
-            }
+            $reader->setTestAutoDetect(static::$testAutoDetect);
         }
 
         if ($import instanceof WithReadFilter) {

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -324,11 +324,9 @@ class Reader
             }
 
             // Load specific sheets.
-            if (method_exists($this->reader, 'setLoadSheetsOnly')) {
-                $this->reader->setLoadSheetsOnly(
-                    collect($worksheetNames)->intersect(array_keys($worksheets))->values()->all()
-                );
-            }
+            $this->reader->setLoadSheetsOnly(
+                collect($worksheetNames)->intersect(array_keys($worksheets))->values()->all()
+            );
         } else {
             // Each worksheet the same import class.
             foreach ($worksheetNames as $name) {
@@ -396,10 +394,7 @@ class Reader
 
             // When only sheet names are given and the reader has
             // an option to load only the selected sheets.
-            if (
-                method_exists($this->reader, 'setLoadSheetsOnly')
-                && count(array_filter(array_keys($sheetImports), 'is_numeric')) === 0
-            ) {
+            if (count(array_filter(array_keys($sheetImports), 'is_numeric')) === 0) {
                 $this->reader->setLoadSheetsOnly(array_keys($sheetImports));
             }
         }


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?

Removes unnecessary `method_exists` checks. All checked methods are already available since phpspreadsheet v1.20+ and since we already require v1.30.5, they are no longer necessary.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

3️⃣  Does it include tests, if possible?

4️⃣  Any drawbacks? Possible breaking changes?

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
