### PR TITLE
[4.x] Fix closing already closed resource regression

### DIFF
--- a/src/Files/Disk.php
+++ b/src/Files/Disk.php
@@ -54,10 +54,13 @@ class Disk
                 fclose($tempStream);
             }
         } else {
+            /** @var resource|closed-resource $readStream */
             $success = $this->put($destination, $readStream);
         }
 
-        fclose($readStream);
+        if (is_resource($readStream)) {
+            fclose($readStream);
+        }
 
         return $success;
     }

--- a/tests/Files/DiskTest.php
+++ b/tests/Files/DiskTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Files;
+
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Maatwebsite\Excel\Files\Disk;
+use Maatwebsite\Excel\Files\LocalTemporaryFile;
+use Maatwebsite\Excel\Tests\TestCase;
+use Mockery;
+use Mockery\MockInterface;
+
+final class DiskTest extends TestCase
+{
+    private Disk $disk;
+
+    private Filesystem&MockInterface $filesystem;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = Mockery::mock(Filesystem::class);
+        $this->disk       = new Disk($this->filesystem);
+    }
+
+    public function test_it_handles_closed_resource(): void
+    {
+        $this->filesystem->shouldReceive('put')
+            ->with('test', Mockery::type('resource'), [])
+            ->andReturnUsing(fn (string $destination, $contents): bool => fclose($contents))
+            ->once();
+
+        $this->disk->copy(new LocalTemporaryFile(tempnam(sys_get_temp_dir(), 'laravel-excel')), 'test');
+    }
+
+    public function test_it_closes_an_open_resource(): void
+    {
+        $this->filesystem->shouldReceive('put')
+            ->with('test', Mockery::type('resource'), [])
+            ->andReturnTrue()
+            ->once();
+
+        $this->disk->copy(new LocalTemporaryFile(tempnam(sys_get_temp_dir(), 'laravel-excel')), 'test');
+    }
+}


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?

Fixes a regression reported in #4401.
Filesystem adapters might already close the resource within `put()` method, causing subsequent `fclose` to fail.

Fixes #4401

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣  Does it include tests, if possible?

Yes, added tests for coverage.

4️⃣  Any drawbacks? Possible breaking changes?

Restored behaviour consistent with v3.1

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
