### PR TITLE
feat: `AfterChunk` event raised after sheet disconnect in queued export chunks

### DIFF
--- a/src/Jobs/AppendQueryToSheet.php
+++ b/src/Jobs/AppendQueryToSheet.php
@@ -64,9 +64,10 @@ class AppendQueryToSheet implements ShouldQueue
 
             $sheet->appendRows($query->get(), $this->sheetExport);
 
+            $this->raise(new AfterChunk($sheet, $this->sheetExport, ($this->page - 1) * $this->chunkSize));
+
             $writer->write($this->sheetExport, $this->temporaryFile, $this->writerType);
 
-            $this->raise(new AfterChunk($sheet, $this->sheetExport, ($this->page - 1) * $this->chunkSize));
             $this->clearListeners();
         });
     }


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?

- `AfterChunk` was fired **after** `Writer::write()` in `AppendQueryToSheet::handle()`.                                                                                
- `write()` ends by calling `$this->spreadsheet->disconnectWorksheets()`, which calls `Worksheet::disconnectCells()` on every worksheet — unsetting the typed `$cellCollection` property and nulling `$parent`.                                                                                                                    
- Any event handler that accesses `$event->getSheet()->getDelegate()->getCell(...)` (or any other cell-collection-dependent method) inside an `AfterChunk` handler hits an uninitialized typed property and throws `Error: Typed property ...Worksheet::$cellCollection must not be accessed before initialization.
- Moving `raise(AfterChunk)` before `write()` ensures the worksheet is still fully connected inside event handlers, which is the naturally expected behavior — and mirrors the same fix already applied to the import side (`ReadChunk::handle()`) in #4385.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No.
This PR contains a single focused fix: reordering `raise(AfterChunk)` and `write()` in  `AppendQueryToSheet::handle()`.

3️⃣  Does it include tests, if possible?

No test is included in this PR, but the fix was verified manually against a temporary regression test (not committed) added to the `AfterChunk` listener in `ExportWithEventsChunks`, which calls `$event->getSheet()->getDelegate()->getCell('A1')`:

```bash

.vendor/bin/phpunit --filter test_export_chunked_events_get_called tests/Concerns/WithEventsTest.php

**Before the fix:**                                                                                                                                                  
  Error: Typed property PhpOffice\PhpSpreadsheet\Worksheet\Worksheet::$cellCollection                                                                                  
  must not be accessed before initialization

**After the fix:**                                                                                                                                                   
  OK (1 test, 5 assertions)

```

4️⃣  Any drawbacks? Possible breaking changes?

Nothing.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
