### PR TITLE
[4.x] Add WithExportTemplate concern

### DIFF
--- a/src/Concerns/WithExportTemplate.php
+++ b/src/Concerns/WithExportTemplate.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Concerns;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+
+interface WithExportTemplate
+{
+    public function exportTemplate(): Spreadsheet;
+}

--- a/src/Concerns/WithExportTemplate.php
+++ b/src/Concerns/WithExportTemplate.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Maatwebsite\Excel\Concerns;
 
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
-
 interface WithExportTemplate
 {
-    public function exportTemplate(): Spreadsheet;
+    public function exportTemplate(): string;
 }

--- a/src/Jobs/QueueExport.php
+++ b/src/Jobs/QueueExport.php
@@ -59,7 +59,7 @@ class QueueExport implements ShouldQueue
 
             // Pre-create the worksheets
             foreach ($sheetExports as $sheetIndex => $sheetExport) {
-                $sheet = $writer->addNewSheet($sheetIndex);
+                $sheet = $writer->getSheetForExport($sheetIndex);
                 $sheet->open($sheetExport);
             }
 

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -510,7 +510,7 @@ class Sheet
             $startCell = 'A1';
         }
 
-        if ($this->hasRows()) {
+        if ($this->hasRows($startCell)) {
             $startCell = CellHelper::getColumnFromCoordinate($startCell) . ($this->worksheet->getHighestRow() + 1);
         }
 
@@ -690,13 +690,8 @@ class Sheet
         }
     }
 
-    private function hasRows(): bool
+    private function hasRows(string $startCell): bool
     {
-        $startCell = 'A1';
-        if ($this->exportable instanceof WithCustomStartCell) {
-            $startCell = $this->exportable->startCell();
-        }
-
         return $this->worksheet->cellExists($startCell);
     }
 

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -6,6 +6,7 @@ use Maatwebsite\Excel\Concerns\WithBackgroundColor;
 use Maatwebsite\Excel\Concerns\WithCustomValueBinder;
 use Maatwebsite\Excel\Concerns\WithDefaultStyles;
 use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Concerns\WithExportTemplate;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 use Maatwebsite\Excel\Concerns\WithProperties;
 use Maatwebsite\Excel\Concerns\WithTitle;
@@ -49,8 +50,8 @@ class Writer
             $sheetExports = $export->sheets();
         }
 
-        foreach ($sheetExports as $sheetExport) {
-            $this->addNewSheet()->export($sheetExport);
+        foreach (array_values($sheetExports) as $sheetIndex => $sheetExport) {
+            $this->getSheetForExport($sheetIndex)->export($sheetExport);
         }
 
         return $this->write($export, $this->temporaryFileFactory->makeLocal(null, strtolower($writerType)), $writerType);
@@ -64,9 +65,14 @@ class Writer
             $this->registerListeners($export->registerEvents());
         }
 
-        $this->exportable  = $export;
-        $this->spreadsheet = new Spreadsheet;
-        $this->spreadsheet->disconnectWorksheets();
+        $this->exportable = $export;
+
+        if ($export instanceof WithExportTemplate) {
+            $this->spreadsheet = $export->exportTemplate();
+        } else {
+            $this->spreadsheet = new Spreadsheet;
+            $this->spreadsheet->disconnectWorksheets();
+        }
 
         if ($export instanceof WithCustomValueBinder) {
             Cell::setValueBinder($export);
@@ -171,6 +177,18 @@ class Writer
     public function addNewSheet(?int $sheetIndex = null): Sheet
     {
         return new Sheet($this->spreadsheet->createSheet($sheetIndex));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function getSheetForExport(int $sheetIndex): Sheet
+    {
+        if ($this->exportable instanceof WithExportTemplate && $sheetIndex < $this->spreadsheet->getSheetCount()) {
+            return $this->getSheetByIndex($sheetIndex);
+        }
+
+        return $this->addNewSheet($sheetIndex);
     }
 
     public function getDelegate(): Spreadsheet

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -72,7 +72,7 @@ class Writer
         $this->exportable = $export;
 
         if ($export instanceof WithExportTemplate) {
-            $this->spreadsheet = $export->exportTemplate();
+            $this->spreadsheet = IOFactory::load($export->exportTemplate());
         } else {
             $this->spreadsheet = new Spreadsheet;
             $this->spreadsheet->disconnectWorksheets();

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -51,7 +51,11 @@ class Writer
         }
 
         foreach (array_values($sheetExports) as $sheetIndex => $sheetExport) {
-            $this->getSheetForExport($sheetIndex)->export($sheetExport);
+            $sheet = $export instanceof WithExportTemplate
+                ? $this->getSheetForExport($sheetIndex)
+                : $this->addNewSheet();
+
+            $sheet->export($sheetExport);
         }
 
         return $this->write($export, $this->temporaryFileFactory->makeLocal(null, strtolower($writerType)), $writerType);

--- a/tests/Concerns/WithCustomStartCellTest.php
+++ b/tests/Concerns/WithCustomStartCellTest.php
@@ -52,4 +52,38 @@ final class WithCustomStartCellTest extends TestCase
             [null, 'A2', 'B2'],
         ], $contents);
     }
+
+    public function test_can_append_multiple_chunks_with_custom_start_cell_without_export_template(): void
+    {
+        $export = new class implements FromCollection, WithCustomStartCell
+        {
+            /**
+             * @return Collection<int, array{int}>
+             */
+            public function collection(): Collection
+            {
+                return new Collection(array_map(
+                    fn (int $row): array => [$row],
+                    range(1, 1001)
+                ));
+            }
+
+            public function startCell(): string
+            {
+                return 'B2';
+            }
+        };
+
+        $this->SUT->store($export, 'custom-start-cell-without-export-template.xlsx');
+
+        $spreadsheet = $this->read(
+            __DIR__ . '/../Data/Disks/Local/custom-start-cell-without-export-template.xlsx',
+            'Xlsx'
+        );
+        $sheet = $spreadsheet->getActiveSheet();
+
+        $this->assertSame(1, $sheet->getCell('B2')->getValue());
+        $this->assertSame(1000, $sheet->getCell('B1001')->getValue());
+        $this->assertSame(1001, $sheet->getCell('B1002')->getValue());
+    }
 }

--- a/tests/Concerns/WithEventsTest.php
+++ b/tests/Concerns/WithEventsTest.php
@@ -68,6 +68,22 @@ final class WithEventsTest extends TestCase
         $this->assertSame(4, $eventsTriggered);
     }
 
+    public function test_export_appends_worksheets_after_sheets_created_by_before_export(): void
+    {
+        $export = new ExportWithEvents;
+
+        $export->beforeExport = function (BeforeExport $event): void {
+            $event->writer->getDelegate()->createSheet()->setTitle('Created by event');
+        };
+
+        $export->store('before-export-sheet-order.xlsx');
+
+        $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/before-export-sheet-order.xlsx', 'Xlsx');
+
+        $this->assertSame('Created by event', $spreadsheet->getSheet(0)->getTitle());
+        $this->assertSame('Worksheet', $spreadsheet->getSheet(1)->getTitle());
+    }
+
     public function test_import_events_get_called(): void
     {
         $import = new ImportWithEvents;

--- a/tests/Concerns/WithExportTemplateTest.php
+++ b/tests/Concerns/WithExportTemplateTest.php
@@ -92,7 +92,7 @@ final class WithExportTemplateTest extends TestCase
 
             private function sheetExport(string $value): object
             {
-                return new class($value) implements FromArray, WithCustomStartCell
+                return new readonly class($value) implements FromArray, WithCustomStartCell
                 {
                     public function __construct(
                         private string $value,

--- a/tests/Concerns/WithExportTemplateTest.php
+++ b/tests/Concerns/WithExportTemplateTest.php
@@ -11,16 +11,33 @@ use Maatwebsite\Excel\Concerns\WithExportTemplate;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportWithTemplate;
 use Maatwebsite\Excel\Tests\TestCase;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\PageSetup;
+use RuntimeException;
 
 final class WithExportTemplateTest extends TestCase
 {
     public function test_can_export_into_a_template(): void
     {
-        $export = new class implements FromArray, WithCustomStartCell, WithExportTemplate
+        $template = new Spreadsheet;
+        $sheet    = $template->getActiveSheet();
+        $sheet->setTitle('Report');
+        $sheet->setCellValue('A1', 'Users');
+        $sheet->setCellValue('C3', '=COUNTA(A3:B3)');
+        $sheet->getStyle('A1')->getFont()->setBold(true);
+        $sheet->getPageSetup()->setOrientation(PageSetup::ORIENTATION_LANDSCAPE);
+
+        $template->createSheet()->setTitle('Notes')->setCellValue('A1', 'Keep me');
+
+        $export = new class($this->saveTemplate($template)) implements FromArray, WithCustomStartCell, WithExportTemplate
         {
             use Exportable;
+
+            public function __construct(
+                private string $templatePath,
+            ) {
+            }
 
             public function array(): array
             {
@@ -34,19 +51,9 @@ final class WithExportTemplateTest extends TestCase
                 return 'A3';
             }
 
-            public function exportTemplate(): Spreadsheet
+            public function exportTemplate(): string
             {
-                $spreadsheet = new Spreadsheet;
-                $sheet       = $spreadsheet->getActiveSheet();
-                $sheet->setTitle('Report');
-                $sheet->setCellValue('A1', 'Users');
-                $sheet->setCellValue('C3', '=COUNTA(A3:B3)');
-                $sheet->getStyle('A1')->getFont()->setBold(true);
-                $sheet->getPageSetup()->setOrientation(PageSetup::ORIENTATION_LANDSCAPE);
-
-                $spreadsheet->createSheet()->setTitle('Notes')->setCellValue('A1', 'Keep me');
-
-                return $spreadsheet;
+                return $this->templatePath;
             }
         };
 
@@ -68,9 +75,18 @@ final class WithExportTemplateTest extends TestCase
 
     public function test_can_export_multiple_sheets_into_a_template(): void
     {
-        $export = new class implements WithExportTemplate, WithMultipleSheets
+        $template = new Spreadsheet;
+        $template->getActiveSheet()->setTitle('First template')->setCellValue('A1', 'First heading');
+        $template->createSheet()->setTitle('Second template')->setCellValue('A1', 'Second heading');
+
+        $export = new class($this->saveTemplate($template)) implements WithExportTemplate, WithMultipleSheets
         {
             use Exportable;
+
+            public function __construct(
+                private string $templatePath,
+            ) {
+            }
 
             public function sheets(): array
             {
@@ -81,13 +97,9 @@ final class WithExportTemplateTest extends TestCase
                 ];
             }
 
-            public function exportTemplate(): Spreadsheet
+            public function exportTemplate(): string
             {
-                $spreadsheet = new Spreadsheet;
-                $spreadsheet->getActiveSheet()->setTitle('First template')->setCellValue('A1', 'First heading');
-                $spreadsheet->createSheet()->setTitle('Second template')->setCellValue('A1', 'Second heading');
-
-                return $spreadsheet;
+                return $this->templatePath;
             }
 
             private function sheetExport(string $value): object
@@ -126,7 +138,10 @@ final class WithExportTemplateTest extends TestCase
 
     public function test_can_queue_an_export_into_a_template_across_multiple_chunks(): void
     {
-        $export = new QueuedExportWithTemplate;
+        $template = new Spreadsheet;
+        $template->getActiveSheet()->setCellValue('A1', 'Queued users');
+
+        $export = new QueuedExportWithTemplate($this->saveTemplate($template));
 
         $export->queue('queued-with-export-template.xlsx');
 
@@ -138,5 +153,17 @@ final class WithExportTemplateTest extends TestCase
         $this->assertSame('Brouwers', $sheet->getCell('B3')->getValue());
         $this->assertSame('Taylor', $sheet->getCell('A4')->getValue());
         $this->assertSame('Otwell', $sheet->getCell('B4')->getValue());
+    }
+
+    private function saveTemplate(Spreadsheet $spreadsheet): string
+    {
+        $templatePath = tempnam(sys_get_temp_dir(), 'laravel-excel-template-');
+        if ($templatePath === false) {
+            throw new RuntimeException('Unable to create the template file.');
+        }
+
+        IOFactory::createWriter($spreadsheet, 'Xlsx')->save($templatePath);
+
+        return $templatePath;
     }
 }

--- a/tests/Concerns/WithExportTemplateTest.php
+++ b/tests/Concerns/WithExportTemplateTest.php
@@ -124,7 +124,7 @@ final class WithExportTemplateTest extends TestCase
         $this->assertSame('Third export', $spreadsheet->getSheet(2)->getCell('A3')->getValue());
     }
 
-    public function test_can_queue_an_export_into_a_template(): void
+    public function test_can_queue_an_export_into_a_template_across_multiple_chunks(): void
     {
         $export = new QueuedExportWithTemplate;
 
@@ -136,5 +136,7 @@ final class WithExportTemplateTest extends TestCase
         $this->assertSame('Queued users', $sheet->getCell('A1')->getValue());
         $this->assertSame('Patrick', $sheet->getCell('A3')->getValue());
         $this->assertSame('Brouwers', $sheet->getCell('B3')->getValue());
+        $this->assertSame('Taylor', $sheet->getCell('A4')->getValue());
+        $this->assertSame('Otwell', $sheet->getCell('B4')->getValue());
     }
 }

--- a/tests/Concerns/WithExportTemplateTest.php
+++ b/tests/Concerns/WithExportTemplateTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
+use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\WithCustomStartCell;
 use Maatwebsite\Excel\Concerns\WithExportTemplate;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
@@ -71,6 +73,56 @@ final class WithExportTemplateTest extends TestCase
         $this->assertTrue($report->getStyle('A1')->getFont()->getBold());
         $this->assertSame(PageSetup::ORIENTATION_LANDSCAPE, $report->getPageSetup()->getOrientation());
         $this->assertSame('Keep me', $spreadsheet->getSheet(1)->getCell('A1')->getValue());
+    }
+
+    public function test_can_append_multiple_chunks_with_custom_start_cell_and_export_template(): void
+    {
+        $template = new Spreadsheet;
+        $template->getActiveSheet()->setCellValue('A1', 'Users');
+
+        $export = new class($this->saveTemplate($template)) implements FromCollection, WithCustomStartCell, WithExportTemplate
+        {
+            use Exportable;
+
+            public function __construct(
+                private string $templatePath,
+            ) {
+            }
+
+            /**
+             * @return Collection<int, array{int}>
+             */
+            public function collection(): Collection
+            {
+                return new Collection(array_map(
+                    fn (int $row): array => [$row],
+                    range(1, 1001)
+                ));
+            }
+
+            public function startCell(): string
+            {
+                return 'B2';
+            }
+
+            public function exportTemplate(): string
+            {
+                return $this->templatePath;
+            }
+        };
+
+        $export->store('custom-start-cell-with-export-template.xlsx');
+
+        $spreadsheet = $this->read(
+            __DIR__ . '/../Data/Disks/Local/custom-start-cell-with-export-template.xlsx',
+            'Xlsx'
+        );
+        $sheet = $spreadsheet->getActiveSheet();
+
+        $this->assertSame('Users', $sheet->getCell('A1')->getValue());
+        $this->assertSame(1, $sheet->getCell('B2')->getValue());
+        $this->assertSame(1000, $sheet->getCell('B1001')->getValue());
+        $this->assertSame(1001, $sheet->getCell('B1002')->getValue());
     }
 
     public function test_can_export_multiple_sheets_into_a_template(): void

--- a/tests/Concerns/WithExportTemplateTest.php
+++ b/tests/Concerns/WithExportTemplateTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Concerns;
+
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\WithCustomStartCell;
+use Maatwebsite\Excel\Concerns\WithExportTemplate;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+use Maatwebsite\Excel\Tests\Data\Stubs\QueuedExportWithTemplate;
+use Maatwebsite\Excel\Tests\TestCase;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\PageSetup;
+
+final class WithExportTemplateTest extends TestCase
+{
+    public function test_can_export_into_a_template(): void
+    {
+        $export = new class implements FromArray, WithCustomStartCell, WithExportTemplate
+        {
+            use Exportable;
+
+            public function array(): array
+            {
+                return [
+                    ['Patrick', 'Brouwers'],
+                ];
+            }
+
+            public function startCell(): string
+            {
+                return 'A3';
+            }
+
+            public function exportTemplate(): Spreadsheet
+            {
+                $spreadsheet = new Spreadsheet;
+                $sheet       = $spreadsheet->getActiveSheet();
+                $sheet->setTitle('Report');
+                $sheet->setCellValue('A1', 'Users');
+                $sheet->setCellValue('C3', '=COUNTA(A3:B3)');
+                $sheet->getStyle('A1')->getFont()->setBold(true);
+                $sheet->getPageSetup()->setOrientation(PageSetup::ORIENTATION_LANDSCAPE);
+
+                $spreadsheet->createSheet()->setTitle('Notes')->setCellValue('A1', 'Keep me');
+
+                return $spreadsheet;
+            }
+        };
+
+        $export->store('with-export-template.xlsx');
+
+        $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/with-export-template.xlsx', 'Xlsx');
+        $report      = $spreadsheet->getSheet(0);
+
+        $this->assertSame(2, $spreadsheet->getSheetCount());
+        $this->assertSame('Report', $report->getTitle());
+        $this->assertSame('Users', $report->getCell('A1')->getValue());
+        $this->assertSame('Patrick', $report->getCell('A3')->getValue());
+        $this->assertSame('Brouwers', $report->getCell('B3')->getValue());
+        $this->assertSame('=COUNTA(A3:B3)', $report->getCell('C3')->getValue());
+        $this->assertTrue($report->getStyle('A1')->getFont()->getBold());
+        $this->assertSame(PageSetup::ORIENTATION_LANDSCAPE, $report->getPageSetup()->getOrientation());
+        $this->assertSame('Keep me', $spreadsheet->getSheet(1)->getCell('A1')->getValue());
+    }
+
+    public function test_can_export_multiple_sheets_into_a_template(): void
+    {
+        $export = new class implements WithExportTemplate, WithMultipleSheets
+        {
+            use Exportable;
+
+            public function sheets(): array
+            {
+                return [
+                    $this->sheetExport('First export'),
+                    $this->sheetExport('Second export'),
+                    $this->sheetExport('Third export'),
+                ];
+            }
+
+            public function exportTemplate(): Spreadsheet
+            {
+                $spreadsheet = new Spreadsheet;
+                $spreadsheet->getActiveSheet()->setTitle('First template')->setCellValue('A1', 'First heading');
+                $spreadsheet->createSheet()->setTitle('Second template')->setCellValue('A1', 'Second heading');
+
+                return $spreadsheet;
+            }
+
+            private function sheetExport(string $value): object
+            {
+                return new class($value) implements FromArray, WithCustomStartCell
+                {
+                    public function __construct(
+                        private string $value,
+                    ) {
+                    }
+
+                    public function array(): array
+                    {
+                        return [[$this->value]];
+                    }
+
+                    public function startCell(): string
+                    {
+                        return 'A3';
+                    }
+                };
+            }
+        };
+
+        $export->store('multiple-sheets-with-export-template.xlsx');
+
+        $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/multiple-sheets-with-export-template.xlsx', 'Xlsx');
+
+        $this->assertSame(3, $spreadsheet->getSheetCount());
+        $this->assertSame('First heading', $spreadsheet->getSheet(0)->getCell('A1')->getValue());
+        $this->assertSame('First export', $spreadsheet->getSheet(0)->getCell('A3')->getValue());
+        $this->assertSame('Second heading', $spreadsheet->getSheet(1)->getCell('A1')->getValue());
+        $this->assertSame('Second export', $spreadsheet->getSheet(1)->getCell('A3')->getValue());
+        $this->assertSame('Third export', $spreadsheet->getSheet(2)->getCell('A3')->getValue());
+    }
+
+    public function test_can_queue_an_export_into_a_template(): void
+    {
+        $export = new QueuedExportWithTemplate;
+
+        $export->queue('queued-with-export-template.xlsx');
+
+        $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/queued-with-export-template.xlsx', 'Xlsx');
+        $sheet       = $spreadsheet->getActiveSheet();
+
+        $this->assertSame('Queued users', $sheet->getCell('A1')->getValue());
+        $this->assertSame('Patrick', $sheet->getCell('A3')->getValue());
+        $this->assertSame('Brouwers', $sheet->getCell('B3')->getValue());
+    }
+}

--- a/tests/Concerns/WithMultipleSheetsTest.php
+++ b/tests/Concerns/WithMultipleSheetsTest.php
@@ -314,7 +314,7 @@ final class WithMultipleSheetsTest extends TestCase
             use Importable;
 
             /** @var array<int|string, object> */
-            public array $sheets = [];
+            public array $sheets;
 
             public function __construct()
             {
@@ -368,7 +368,7 @@ final class WithMultipleSheetsTest extends TestCase
             use Importable;
 
             /** @var array<int|string, object> */
-            public array $sheets = [];
+            public array $sheets;
 
             public function __construct()
             {

--- a/tests/Data/Stubs/QueuedExportWithTemplate.php
+++ b/tests/Data/Stubs/QueuedExportWithTemplate.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Data\Stubs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithCustomStartCell;
+use Maatwebsite\Excel\Concerns\WithExportTemplate;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+
+/** @implements FromCollection<int, array{string, string}> */
+class QueuedExportWithTemplate implements FromCollection, ShouldQueue, WithCustomStartCell, WithExportTemplate
+{
+    use Exportable;
+
+    /**
+     * @return Collection<int, array{string, string}>
+     */
+    public function collection(): Collection
+    {
+        return new Collection([
+            ['Patrick', 'Brouwers'],
+        ]);
+    }
+
+    public function startCell(): string
+    {
+        return 'A3';
+    }
+
+    public function exportTemplate(): Spreadsheet
+    {
+        $spreadsheet = new Spreadsheet;
+        $spreadsheet->getActiveSheet()->setCellValue('A1', 'Queued users');
+
+        return $spreadsheet;
+    }
+}

--- a/tests/Data/Stubs/QueuedExportWithTemplate.php
+++ b/tests/Data/Stubs/QueuedExportWithTemplate.php
@@ -8,12 +8,13 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithCustomChunkSize;
 use Maatwebsite\Excel\Concerns\WithCustomStartCell;
 use Maatwebsite\Excel\Concerns\WithExportTemplate;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 /** @implements FromCollection<int, array{string, string}> */
-class QueuedExportWithTemplate implements FromCollection, ShouldQueue, WithCustomStartCell, WithExportTemplate
+class QueuedExportWithTemplate implements FromCollection, ShouldQueue, WithCustomChunkSize, WithCustomStartCell, WithExportTemplate
 {
     use Exportable;
 
@@ -24,7 +25,13 @@ class QueuedExportWithTemplate implements FromCollection, ShouldQueue, WithCusto
     {
         return new Collection([
             ['Patrick', 'Brouwers'],
+            ['Taylor', 'Otwell'],
         ]);
+    }
+
+    public function chunkSize(): int
+    {
+        return 1;
     }
 
     public function startCell(): string

--- a/tests/Data/Stubs/QueuedExportWithTemplate.php
+++ b/tests/Data/Stubs/QueuedExportWithTemplate.php
@@ -11,12 +11,16 @@ use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\WithCustomChunkSize;
 use Maatwebsite\Excel\Concerns\WithCustomStartCell;
 use Maatwebsite\Excel\Concerns\WithExportTemplate;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 /** @implements FromCollection<int, array{string, string}> */
 class QueuedExportWithTemplate implements FromCollection, ShouldQueue, WithCustomChunkSize, WithCustomStartCell, WithExportTemplate
 {
     use Exportable;
+
+    public function __construct(
+        private readonly string $templatePath,
+    ) {
+    }
 
     /**
      * @return Collection<int, array{string, string}>
@@ -39,11 +43,8 @@ class QueuedExportWithTemplate implements FromCollection, ShouldQueue, WithCusto
         return 'A3';
     }
 
-    public function exportTemplate(): Spreadsheet
+    public function exportTemplate(): string
     {
-        $spreadsheet = new Spreadsheet;
-        $spreadsheet->getActiveSheet()->setCellValue('A1', 'Queued users');
-
-        return $spreadsheet;
+        return $this->templatePath;
     }
 }

--- a/tests/InteractsWithQueueTest.php
+++ b/tests/InteractsWithQueueTest.php
@@ -13,14 +13,6 @@ use Maatwebsite\Excel\Jobs\ReadChunk;
 
 final class InteractsWithQueueTest extends TestCase
 {
-    /**
-     * Setup the test environment.
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     public function test_read_chunk_job_can_interact_with_queue(): void
     {
         $this->assertContains(InteractsWithQueue::class, class_uses(ReadChunk::class));


### PR DESCRIPTION
## Summary

This PR introduces the `WithExportTemplate` concern, allowing exports to start from an existing PhpSpreadsheet `Spreadsheet` instance instead of always creating an empty workbook.

```php
use Maatwebsite\Excel\Concerns\WithExportTemplate;
use PhpOffice\PhpSpreadsheet\IOFactory;
use PhpOffice\PhpSpreadsheet\Spreadsheet;

class UsersExport implements WithExportTemplate
{
    public function exportTemplate(): Spreadsheet
    {
        return IOFactory::load(
            storage_path('app/templates/users.xlsx')
        );
    }
}
```

The export data is written into the template worksheets while retaining the workbook structure already defined by the caller.

Related to #2068.

## Motivation

Some exports require more than tabular data and a collection of styles. They may depend on an existing workbook containing:

- formulas;
- number formats and styles;
- conditional formatting;
- data validation;
- merged cells;
- frozen panes;
- column widths and row heights;
- print and page settings;
- hidden or supporting worksheets;
- named ranges.

Recreating all of this through export concerns and events can become cumbersome. Until now, using an existing workbook also required workarounds around the internal `BeforeWriting` and `reopen()` flow, particularly for queued and multi-sheet exports.

Providing the template as a `Spreadsheet` keeps loading and configuring the workbook under the caller's control while giving the export pipeline a native way to use it.

## Behavior

When `WithExportTemplate` is implemented:

- existing template worksheets are reused in export order;
- worksheets not used by an export remain in the workbook;
- additional worksheets are created when exports outnumber the template worksheets;
- existing values, formulas, styles and page settings are preserved;
- synchronous and queued exports are supported;
- queued exports continue writing correctly across multiple chunks;
- `WithCustomStartCell` determines where exported data starts.

Exports that do not implement the concern retain the existing behavior: Laravel Excel creates an empty spreadsheet, disconnects its default worksheet and appends the exported worksheets normally.

This includes preserving the position of worksheets created by `BeforeExport` listeners.

## Styling considerations

This feature is not intended to replace `WithStyles` or to claim a universal performance improvement.

Style arrays returned by `WithStyles` are already applied internally through:

```php
$worksheet->getStyle($coordinate)->applyFromArray($styles);
```

PhpSpreadsheet also optimizes exact whole-column ranges such as `A:G`, so a template is not necessarily faster for simple column-level formatting.

The main benefit is structural reuse: a workbook can be prepared once and used without rebuilding its layout and configuration for every export.

## Compatibility and trade-offs

The feature is opt-in, and no breaking changes are expected for existing exports.

The caller remains responsible for creating or loading a compatible `Spreadsheet` instance. Loading a workbook introduces its own I/O and baseline memory cost, and preservation of advanced Excel features remains subject to PhpSpreadsheet and the selected writer.

The returned `Spreadsheet` is consumed by the writer and disconnected after the export is saved. Therefore, `exportTemplate()` should return a fresh instance for each export.

Writing follows the existing append semantics. If the configured start cell already exists in the template, exported rows are appended after the worksheet's current highest row. Whole-column styles such as `A:G` do not materialize the start cell and can be used without changing its append position.

Chart output continues to require the existing `WithCharts` concern.

## Verification

The implementation includes coverage for:

- exporting into an existing template;
- preserving values, formulas, styles and page setup;
- preserving unused template worksheets;
- reusing multiple template worksheets;
- creating worksheets when exports outnumber template worksheets;
- queued exports across multiple chunks;
- custom start cells in queued exports;
- worksheet ordering when `BeforeExport` creates additional sheets;
- existing exports without templates.

The following checks pass:

- `XDEBUG_MODE=off vendor/bin/paratest --configuration phpunit.xml.dist --no-progress`
  - 360 tests
  - 1470 assertions
- `vendor/bin/phpstan --no-progress --memory-limit=512M`
- `vendor/bin/pint --test --parallel`

The codebase and currently open pull requests were reviewed to confirm that equivalent template support is not already available. This PR is limited to the export-template feature and its required regression coverage.

Documentation for the new concern can be submitted separately.