### PR TITLE
Minimal phpoffice/phpspreadsheet to v5.9.0, PHP 8.5 support (#4345)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
   ],
   "require": {
     "ext-json": "*",
-    "php": "^7.0||^8.0",
-    "phpoffice/phpspreadsheet": "^1.30.5",
+    "php": "^8.2",
+    "phpoffice/phpspreadsheet": "^5.9.0",
     "illuminate/support": "5.8.*||^6.0||^7.0||^8.0||^9.0||^10.0||^11.0||^12.0||^13.0",
     "psr/simple-cache": "^1.0||^2.0||^3.0",
     "composer/semver": "^3.3"

--- a/src/DefaultValueBinder.php
+++ b/src/DefaultValueBinder.php
@@ -12,7 +12,7 @@ class DefaultValueBinder extends PhpSpreadsheetDefaultValueBinder
      * @param  mixed  $value  Value to bind in cell
      * @return bool
      */
-    public function bindValue(Cell $cell, $value)
+    public function bindValue(Cell $cell, mixed $value): bool
     {
         if (is_array($value)) {
             $value = \json_encode($value);

--- a/src/Filters/ChunkReadFilter.php
+++ b/src/Filters/ChunkReadFilter.php
@@ -46,7 +46,7 @@ class ChunkReadFilter implements IReadFilter
      * @param  string  $worksheetName
      * @return bool
      */
-    public function readCell($column, $row, $worksheetName = '')
+    public function readCell(string $column, int $row, string $worksheetName = ''): bool
     {
         //  Only read the heading row, and the rows that are configured in $this->_startRow and $this->_endRow
         return ($worksheetName === $this->worksheetName || $worksheetName === '')

--- a/src/Filters/LimitFilter.php
+++ b/src/Filters/LimitFilter.php
@@ -32,7 +32,7 @@ class LimitFilter implements IReadFilter
      * @param  string  $worksheetName
      * @return bool
      */
-    public function readCell($column, $row, $worksheetName = '')
+    public function readCell(string $column, int $row, string $worksheetName = ''): bool
     {
         return $row >= $this->startRow && $row <= $this->endRow;
     }

--- a/tests/Concerns/ExportableTest.php
+++ b/tests/Concerns/ExportableTest.php
@@ -16,7 +16,7 @@ class ExportableTest extends TestCase
     public function test_needs_to_have_a_file_name_when_downloading()
     {
         $this->expectException(\Maatwebsite\Excel\Exceptions\NoFilenameGivenException::class);
-        $this->expectExceptionMessage('A filename needs to be passed in order to download the export');
+        $this->expectExceptionMessageIsOrContains('A filename needs to be passed in order to download the export');
 
         $export = new class
         {
@@ -29,7 +29,7 @@ class ExportableTest extends TestCase
     public function test_needs_to_have_a_file_name_when_storing()
     {
         $this->expectException(\Maatwebsite\Excel\Exceptions\NoFilePathGivenException::class);
-        $this->expectExceptionMessage('A filepath needs to be passed in order to store the export');
+        $this->expectExceptionMessageIsOrContains('A filepath needs to be passed in order to store the export');
 
         $export = new class
         {
@@ -42,7 +42,7 @@ class ExportableTest extends TestCase
     public function test_needs_to_have_a_file_name_when_queuing()
     {
         $this->expectException(\Maatwebsite\Excel\Exceptions\NoFilePathGivenException::class);
-        $this->expectExceptionMessage('A filepath needs to be passed in order to store the export');
+        $this->expectExceptionMessageIsOrContains('A filepath needs to be passed in order to store the export');
 
         $export = new class
         {
@@ -55,7 +55,7 @@ class ExportableTest extends TestCase
     public function test_responsable_needs_to_have_file_name_configured_inside_the_export()
     {
         $this->expectException(\Maatwebsite\Excel\Exceptions\NoFilenameGivenException::class);
-        $this->expectExceptionMessage('A filename needs to be passed in order to download the export');
+        $this->expectExceptionMessageIsOrContains('A filename needs to be passed in order to download the export');
 
         $export = new class implements Responsable
         {

--- a/tests/Concerns/WithCustomValueBinderTest.php
+++ b/tests/Concerns/WithCustomValueBinderTest.php
@@ -40,7 +40,7 @@ class WithCustomValueBinderTest extends TestCase
             /**
              * {@inheritdoc}
              */
-            public function bindValue(Cell $cell, $value)
+            public function bindValue(Cell $cell, mixed $value): bool
             {
                 // Handle percentage
                 if (preg_match('/^\-?\d*\.?\d*\s?\%$/', $value)) {
@@ -102,7 +102,7 @@ class WithCustomValueBinderTest extends TestCase
             /**
              * {@inheritdoc}
              */
-            public function bindValue(Cell $cell, $value)
+            public function bindValue(Cell $cell, mixed $value): bool
             {
                 if ($cell->getCoordinate() === 'B2') {
                     $cell->setValueExplicit($value, DataType::TYPE_STRING);

--- a/tests/Concerns/WithReadFilterTest.php
+++ b/tests/Concerns/WithReadFilterTest.php
@@ -20,7 +20,7 @@ class WithReadFilterTest extends TestCase
             {
                 return new class implements IReadFilter
                 {
-                    public function readCell($column, $row, $worksheetName = '')
+                    public function readCell(string $column, int $row, string $worksheetName = ''): bool
                     {
                         // Assert read filter is being called.
                         // If assertion is not called, test will fail due to


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?
Updating to currently latest phpoffice/phpspreadsheet 5.9.0 which supports PHP 8.5 (1.x branch is restricted to <8.5). This is a minimal change to support latest PHP, which was released Nov 2025 (a while ago). Currently projects using this package are blocked from using PHP 8.5.
Separate PR made since many have resorted to using unreleased 4.x branch while the actual change to this package is minimal. Hopefully it can be released while 4.x is still being worked on. 

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No. Only related package change, extended class method arguments and return types added to match parent and required minimal PHP version bump to 8.2 (note: latest Laravel 13 requires minimally 8.3 and Laravel 12 already required 8.2).

3️⃣  Does it include tests, if possible?
All existing tests pass

4️⃣  Any drawbacks? Possible breaking changes?
Requires at least PHP 8.2. Any extending classes might need updating to match parent signature

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression. - nothing to add

6️⃣  Thanks for contributing! 🙌
