### PR TITLE
[4.x] Fix remaining missing types, use readonly

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,6 +15,8 @@ parameters:
         uncheckedExceptionClasses:
             - Psr\SimpleCache\InvalidArgumentException
             - Throwable
+    additionalConstructors:
+        - PHPUnit\Framework\TestCase::setUp
     configDirectories:
         - ./tests
         - ./config

--- a/rector.php
+++ b/rector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector;
 use Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEqualsToSameRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
@@ -42,6 +43,7 @@ return RectorConfig::configure()
         PHPUnitSetList::PHPUNIT_CODE_QUALITY,
     ])
     ->withSkip([
+        RemoveDuplicatedReturnSelfDocblockRector::class,
         // BatchCache::set/setMultiple use func_num_args() to distinguish
         // "no TTL passed" from "explicit null". Removing the explicit null
         // silently changes behavior. Scoped to the one test that depends on

--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -13,17 +13,17 @@ class CacheManager extends Manager
     /**
      * @const string
      */
-    public const DRIVER_BATCH = 'batch';
+    public const string DRIVER_BATCH = 'batch';
 
     /**
      * @const string
      */
-    public const DRIVER_MEMORY = 'memory';
+    public const string DRIVER_MEMORY = 'memory';
 
     /**
      * @const string
      */
-    public const DRIVER_ILLUMINATE = 'illuminate';
+    public const string DRIVER_ILLUMINATE = 'illuminate';
 
     /**
      * Get the default driver name.

--- a/src/Cell.php
+++ b/src/Cell.php
@@ -15,7 +15,7 @@ class Cell
     use DelegatedMacroable;
 
     final public function __construct(
-        private SpreadsheetCell $cell,
+        private readonly SpreadsheetCell $cell,
     ) {
     }
 

--- a/src/Concerns/Exportable.php
+++ b/src/Concerns/Exportable.php
@@ -96,11 +96,10 @@ trait Exportable
      * Create an HTTP response that represents the object.
      *
      * @param  Request  $request
-     * @return BinaryFileResponse
      *
      * @throws NoFilenameGivenException
      */
-    public function toResponse($request)
+    public function toResponse($request): BinaryFileResponse
     {
         return $this->download();
     }

--- a/src/Concerns/Importable.php
+++ b/src/Concerns/Importable.php
@@ -93,10 +93,7 @@ trait Importable
         );
     }
 
-    /**
-     * @return $this
-     */
-    public function withOutput(OutputStyle $output)
+    public function withOutput(OutputStyle $output): static
     {
         $this->output = $output;
 

--- a/src/Concerns/Importable.php
+++ b/src/Concerns/Importable.php
@@ -93,6 +93,9 @@ trait Importable
         );
     }
 
+    /**
+     * @return $this
+     */
     public function withOutput(OutputStyle $output): static
     {
         $this->output = $output;

--- a/src/Concerns/OnEachRow.php
+++ b/src/Concerns/OnEachRow.php
@@ -8,8 +8,5 @@ use Maatwebsite\Excel\Row;
 
 interface OnEachRow
 {
-    /**
-     * @return mixed
-     */
-    public function onRow(Row $row);
+    public function onRow(Row $row): void;
 }

--- a/src/Concerns/RegistersEventListeners.php
+++ b/src/Concerns/RegistersEventListeners.php
@@ -35,7 +35,7 @@ trait RegistersEventListeners
         $listeners = [];
 
         foreach ($listenersClasses as $class => $name) {
-            // Method names are case insensitive in php
+            // Method names are case-insensitive in php
             if (method_exists($this, $name)) {
                 // Allow methods to not be static
                 $listeners[$class] = [$this, $name];

--- a/src/Concerns/WithConditionalSheets.php
+++ b/src/Concerns/WithConditionalSheets.php
@@ -11,9 +11,8 @@ trait WithConditionalSheets
 
     /**
      * @param  string|array<int, int|string>  $sheets
-     * @return $this
      */
-    public function onlySheets(string|array $sheets)
+    public function onlySheets(string|array $sheets): static
     {
         $this->conditionallySelectedSheets = is_array($sheets) ? $sheets : func_get_args();
 

--- a/src/Concerns/WithConditionalSheets.php
+++ b/src/Concerns/WithConditionalSheets.php
@@ -11,6 +11,7 @@ trait WithConditionalSheets
 
     /**
      * @param  string|array<int, int|string>  $sheets
+     * @return $this
      */
     public function onlySheets(string|array $sheets): static
     {

--- a/src/Concerns/WithCustomQuerySize.php
+++ b/src/Concerns/WithCustomQuerySize.php
@@ -9,7 +9,7 @@ interface WithCustomQuerySize
     /**
      * Queued exportables are processed in chunks; each chunk being a job pushed to the queue by the QueuedWriter.
      * In case of exportables that implement the FromQuery concern, the number of jobs is calculated by dividing the $query->count() by the chunk size.
-     * Depending on the implementation of the query() method (eg. When using a groupBy clause), this calculation might not be correct.
+     * Depending on the implementation of the query() method (e.g. When using a groupBy clause), this calculation might not be correct.
      *
      * When this is the case, you should use this method to provide a custom calculation of the query size.
      */

--- a/src/Concerns/WithStyles.php
+++ b/src/Concerns/WithStyles.php
@@ -11,5 +11,5 @@ interface WithStyles
     /**
      * @return array<int|string, array<string, mixed>>|null
      */
-    public function styles(Worksheet $sheet);
+    public function styles(Worksheet $sheet): ?array;
 }

--- a/src/Events/AfterBatch.php
+++ b/src/Events/AfterBatch.php
@@ -23,7 +23,7 @@ class AfterBatch extends Event
         return $this->manager;
     }
 
-    public function getDelegate(): mixed
+    public function getDelegate(): ModelManager
     {
         return $this->manager;
     }

--- a/src/Events/AfterChunk.php
+++ b/src/Events/AfterChunk.php
@@ -23,7 +23,7 @@ class AfterChunk extends Event
         return $this->sheet;
     }
 
-    public function getDelegate(): mixed
+    public function getDelegate(): Sheet
     {
         return $this->sheet;
     }

--- a/src/Events/AfterImport.php
+++ b/src/Events/AfterImport.php
@@ -21,7 +21,7 @@ class AfterImport extends Event
         return $this->reader;
     }
 
-    public function getDelegate(): mixed
+    public function getDelegate(): Reader
     {
         return $this->reader;
     }

--- a/src/Events/AfterSheet.php
+++ b/src/Events/AfterSheet.php
@@ -22,7 +22,7 @@ class AfterSheet extends Event
         return $this->sheet;
     }
 
-    public function getDelegate(): mixed
+    public function getDelegate(): Sheet
     {
         return $this->sheet;
     }

--- a/src/Events/BeforeExport.php
+++ b/src/Events/BeforeExport.php
@@ -21,7 +21,7 @@ class BeforeExport extends Event
         return $this->writer;
     }
 
-    public function getDelegate(): mixed
+    public function getDelegate(): Writer
     {
         return $this->writer;
     }

--- a/src/Events/BeforeImport.php
+++ b/src/Events/BeforeImport.php
@@ -21,7 +21,7 @@ class BeforeImport extends Event
         return $this->reader;
     }
 
-    public function getDelegate(): mixed
+    public function getDelegate(): Reader
     {
         return $this->reader;
     }

--- a/src/Events/BeforeSheet.php
+++ b/src/Events/BeforeSheet.php
@@ -22,7 +22,7 @@ class BeforeSheet extends Event
         return $this->sheet;
     }
 
-    public function getDelegate(): mixed
+    public function getDelegate(): Sheet
     {
         return $this->sheet;
     }

--- a/src/Events/BeforeWriting.php
+++ b/src/Events/BeforeWriting.php
@@ -21,7 +21,7 @@ class BeforeWriting extends Event
         return $this->writer;
     }
 
-    public function getDelegate(): mixed
+    public function getDelegate(): Writer
     {
         return $this->writer;
     }

--- a/src/Excel.php
+++ b/src/Excel.php
@@ -48,7 +48,7 @@ class Excel implements Exporter, Importer
     public function __construct(
         protected Writer $writer,
         protected QueuedWriter $queuedWriter,
-        private Reader $reader,
+        private readonly Reader $reader,
         protected Filesystem $filesystem,
     ) {
     }

--- a/src/Excel.php
+++ b/src/Excel.php
@@ -21,29 +21,29 @@ class Excel implements Exporter, Importer
 {
     use Macroable, RegistersCustomConcerns;
 
-    public const XLSX = 'Xlsx';
+    public const string XLSX = 'Xlsx';
 
-    public const CSV = 'Csv';
+    public const string CSV = 'Csv';
 
-    public const TSV = 'Csv';
+    public const string TSV = 'Csv';
 
-    public const ODS = 'Ods';
+    public const string ODS = 'Ods';
 
-    public const XLS = 'Xls';
+    public const string XLS = 'Xls';
 
-    public const SLK = 'Slk';
+    public const string SLK = 'Slk';
 
-    public const XML = 'Xml';
+    public const string XML = 'Xml';
 
-    public const GNUMERIC = 'Gnumeric';
+    public const string GNUMERIC = 'Gnumeric';
 
-    public const HTML = 'Html';
+    public const string HTML = 'Html';
 
-    public const MPDF = 'Mpdf';
+    public const string MPDF = 'Mpdf';
 
-    public const DOMPDF = 'Dompdf';
+    public const string DOMPDF = 'Dompdf';
 
-    public const TCPDF = 'Tcpdf';
+    public const string TCPDF = 'Tcpdf';
 
     public function __construct(
         protected Writer $writer,

--- a/src/HeadingRowImport.php
+++ b/src/HeadingRowImport.php
@@ -17,7 +17,7 @@ class HeadingRowImport implements Import, WithLimit, WithMapping, WithStartRow
     use Importable;
 
     public function __construct(
-        private int $headingRow = 1,
+        private readonly int $headingRow = 1,
     ) {
     }
 

--- a/src/Imports/HeadingRowExtractor.php
+++ b/src/Imports/HeadingRowExtractor.php
@@ -14,7 +14,7 @@ class HeadingRowExtractor
     /**
      * @const int
      */
-    public const DEFAULT_HEADING_ROW = 1;
+    public const int DEFAULT_HEADING_ROW = 1;
 
     public static function headingRow(mixed $importable): int
     {

--- a/src/Imports/ModelImporter.php
+++ b/src/Imports/ModelImporter.php
@@ -43,7 +43,7 @@ class ModelImporter
         $headerIsGrouped  = HeadingRowExtractor::extractGrouping($headingRow, $import);
         $batchSize        = $import instanceof WithBatchInserts ? $import->batchSize() : 1;
         $endRow           = EndRowFinder::find($import, $startRow, $worksheet->getHighestRow());
-        $progessBar       = $import instanceof WithProgressBar;
+        $progressBar      = $import instanceof WithProgressBar;
         $withMapping      = $import instanceof WithMapping;
         $withCalcFormulas = $import instanceof WithCalculatedFormulas;
         $formatData       = $import instanceof WithFormatData;
@@ -84,7 +84,7 @@ class ModelImporter
                     $batchStartRow += $i;
                     $i = 0;
 
-                    if ($progessBar) {
+                    if ($progressBar) {
                         $import->getConsoleOutput()->progressAdvance($batchSize);
                     }
                 }

--- a/src/Imports/ModelImporter.php
+++ b/src/Imports/ModelImporter.php
@@ -23,7 +23,7 @@ class ModelImporter
     use HasEventBus;
 
     public function __construct(
-        private ModelManager $manager,
+        private readonly ModelManager $manager,
     ) {
     }
 

--- a/src/Jobs/AppendDataToSheet.php
+++ b/src/Jobs/AppendDataToSheet.php
@@ -24,7 +24,7 @@ class AppendDataToSheet implements ShouldQueue
         public int $sheetIndex,
         /** @var array<array-key, mixed> */
         public array $data,
-        public ?object $export = null,
+        public ?Export $export = null,
     ) {
     }
 

--- a/src/Jobs/AppendPaginatedToSheet.php
+++ b/src/Jobs/AppendPaginatedToSheet.php
@@ -7,6 +7,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Maatwebsite\Excel\Concerns\Export;
 use Maatwebsite\Excel\Concerns\FromQuery;
 use Maatwebsite\Excel\Concerns\FromScout;
 use Maatwebsite\Excel\Files\TemporaryFile;
@@ -25,7 +26,7 @@ class AppendPaginatedToSheet implements ShouldQueue
         public int $sheetIndex,
         public int $page,
         public int $perPage,
-        public ?object $export = null,
+        public ?Export $export = null,
     ) {
     }
 

--- a/src/Jobs/AppendQueryToSheet.php
+++ b/src/Jobs/AppendQueryToSheet.php
@@ -7,6 +7,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Maatwebsite\Excel\Concerns\Export;
 use Maatwebsite\Excel\Concerns\FromQuery;
 use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Events\AfterChunk;
@@ -27,7 +28,7 @@ class AppendQueryToSheet implements ShouldQueue
         public int $sheetIndex,
         public int $page,
         public int $chunkSize,
-        public ?object $export = null,
+        public ?Export $export = null,
     ) {
     }
 

--- a/src/Jobs/AppendViewToSheet.php
+++ b/src/Jobs/AppendViewToSheet.php
@@ -7,6 +7,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Maatwebsite\Excel\Concerns\Export;
 use Maatwebsite\Excel\Concerns\FromView;
 use Maatwebsite\Excel\Files\TemporaryFile;
 use Maatwebsite\Excel\Jobs\Middleware\LocalizeJob;
@@ -22,7 +23,7 @@ class AppendViewToSheet implements ShouldQueue
         public TemporaryFile $temporaryFile,
         public string $writerType,
         public int $sheetIndex,
-        public ?object $export = null,
+        public ?Export $export = null,
     ) {
     }
 

--- a/src/Jobs/CloseSheet.php
+++ b/src/Jobs/CloseSheet.php
@@ -22,7 +22,7 @@ class CloseSheet implements ShouldQueue
         private TemporaryFile $temporaryFile,
         private string $writerType,
         private int $sheetIndex,
-        private ?object $export = null,
+        private ?Export $export = null,
     ) {
     }
 

--- a/src/Jobs/CloseSheet.php
+++ b/src/Jobs/CloseSheet.php
@@ -18,11 +18,11 @@ class CloseSheet implements ShouldQueue
     use Batchable, Dispatchable, InteractsWithQueue, ProxyFailures, Queueable;
 
     public function __construct(
-        private Export $sheetExport,
-        private TemporaryFile $temporaryFile,
-        private string $writerType,
-        private int $sheetIndex,
-        private ?Export $export = null,
+        private readonly Export $sheetExport,
+        private readonly TemporaryFile $temporaryFile,
+        private readonly string $writerType,
+        private readonly int $sheetIndex,
+        private readonly ?Export $export = null,
     ) {
     }
 

--- a/src/Jobs/ExtendedQueueable.php
+++ b/src/Jobs/ExtendedQueueable.php
@@ -12,9 +12,8 @@ trait ExtendedQueueable
 
     /**
      * @param  array<int, object>  $chain
-     * @return $this
      */
-    public function chain($chain)
+    public function chain($chain): static
     {
         collect($chain)->each(function ($job): void {
             $serialized      = $this->serializeJob($job);

--- a/src/Jobs/Middleware/LocalizeJob.php
+++ b/src/Jobs/Middleware/LocalizeJob.php
@@ -12,11 +12,9 @@ class LocalizeJob
 
     /**
      * LocalizeJob constructor.
-     *
-     * @param  object  $localizable
      */
     public function __construct(
-        private $localizable,
+        private readonly object $localizable,
     ) {
     }
 

--- a/src/Jobs/QueueExport.php
+++ b/src/Jobs/QueueExport.php
@@ -21,8 +21,8 @@ class QueueExport implements ShouldQueue
 
     public function __construct(
         public Export $export,
-        private TemporaryFile $temporaryFile,
-        private string $writerType,
+        private readonly TemporaryFile $temporaryFile,
+        private readonly string $writerType,
     ) {
     }
 

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -53,13 +53,13 @@ class ReadChunk implements ShouldQueue
     private string $uniqueId;
 
     public function __construct(
-        private WithChunkReading&Import $import,
-        private IReader $reader,
-        private TemporaryFile $temporaryFile,
-        private string $sheetName,
-        private Import $sheetImport,
+        private readonly WithChunkReading&Import $import,
+        private readonly IReader $reader,
+        private readonly TemporaryFile $temporaryFile,
+        private readonly string $sheetName,
+        private readonly Import $sheetImport,
         private int $startRow,
-        private int $chunkSize,
+        private readonly int $chunkSize,
     ) {
         $this->timeout       = $this->import->timeout ?? null;
         $this->tries         = $this->import->tries ?? null;

--- a/src/Jobs/ReadChunk.php
+++ b/src/Jobs/ReadChunk.php
@@ -95,7 +95,7 @@ class ReadChunk implements ShouldQueue
     }
 
     /**
-     * Determine the time at which the job should timeout.
+     * Determine the time at which the job should time out.
      */
     public function retryUntil(): ?DateTime
     {

--- a/src/Jobs/StoreQueuedExport.php
+++ b/src/Jobs/StoreQueuedExport.php
@@ -18,10 +18,10 @@ class StoreQueuedExport implements ShouldQueue
      * @param  array<string, mixed>|string  $diskOptions
      */
     public function __construct(
-        private TemporaryFile $temporaryFile,
-        private string $filePath,
-        private ?string $disk = null,
-        private array|string $diskOptions = [],
+        private readonly TemporaryFile $temporaryFile,
+        private readonly string $filePath,
+        private readonly ?string $disk = null,
+        private readonly array|string $diskOptions = [],
     ) {
     }
 

--- a/src/Mixins/DownloadCollectionMixin.php
+++ b/src/Mixins/DownloadCollectionMixin.php
@@ -27,7 +27,7 @@ class DownloadCollectionMixin
                 /**
                  * @param  Collection<array-key, mixed>  $collection
                  */
-                public function __construct(Collection $collection, private bool $withHeadings = false)
+                public function __construct(Collection $collection, private readonly bool $withHeadings = false)
                 {
                     $this->collection = $collection->toBase();
                 }

--- a/src/Mixins/DownloadQueryMacro.php
+++ b/src/Mixins/DownloadQueryMacro.php
@@ -23,8 +23,8 @@ class DownloadQueryMacro
                  * @param  Builder<Model>  $query
                  */
                 public function __construct(
-                    private Builder $query,
-                    private bool $withHeadings = false,
+                    private readonly Builder $query,
+                    private readonly bool $withHeadings = false,
                 ) {
                 }
 

--- a/src/Mixins/ImportAsMacro.php
+++ b/src/Mixins/ImportAsMacro.php
@@ -25,7 +25,7 @@ class ImportAsMacro
                 private $mapping;
 
                 public function __construct(
-                    private string $model,
+                    private readonly string $model,
                     callable $mapping,
                 ) {
                     $this->mapping = $mapping;

--- a/src/Mixins/ImportMacro.php
+++ b/src/Mixins/ImportMacro.php
@@ -21,7 +21,7 @@ class ImportMacro
                 use Importable;
 
                 public function __construct(
-                    private string $model,
+                    private readonly string $model,
                 ) {
                 }
 

--- a/src/Mixins/StoreCollectionMixin.php
+++ b/src/Mixins/StoreCollectionMixin.php
@@ -25,7 +25,7 @@ class StoreCollectionMixin
                 /**
                  * @param  Collection<array-key, mixed>  $collection
                  */
-                public function __construct(Collection $collection, private bool $withHeadings = false)
+                public function __construct(Collection $collection, private readonly bool $withHeadings = false)
                 {
                     $this->collection = $collection->toBase();
                 }

--- a/src/Mixins/StoreQueryMacro.php
+++ b/src/Mixins/StoreQueryMacro.php
@@ -23,8 +23,8 @@ class StoreQueryMacro
                  * @param  Builder<Model>  $query
                  */
                 public function __construct(
-                    private Builder $query,
-                    private bool $withHeadings = false,
+                    private readonly Builder $query,
+                    private readonly bool $withHeadings = false,
                 ) {
                 }
 

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -106,7 +106,7 @@ class QueuedWriter
         TemporaryFile $temporaryFile,
         string $writerType,
         int $sheetIndex,
-        object $export
+        Export $export
     ): Enumerable {
         return $sheetExport
             ->collection()
@@ -133,7 +133,7 @@ class QueuedWriter
         TemporaryFile $temporaryFile,
         string $writerType,
         int $sheetIndex,
-        object $export
+        Export $export
     ): Collection {
         $query = $sheetExport->query();
         $count = $sheetExport instanceof WithCustomQuerySize ? $sheetExport->querySize() : $query->count();
@@ -164,7 +164,7 @@ class QueuedWriter
         TemporaryFile $temporaryFile,
         string $writerType,
         int $sheetIndex,
-        object $export
+        Export $export
     ): Collection {
         $jobs = new Collection;
 
@@ -203,7 +203,7 @@ class QueuedWriter
         TemporaryFile $temporaryFile,
         string $writerType,
         int $sheetIndex,
-        object $export
+        Export $export
     ): Collection {
         $jobs = new Collection;
         $jobs->push(new AppendViewToSheet(

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -524,7 +524,7 @@ class Sheet
         foreach ($this->buildColumnRange('A', $this->worksheet->getHighestDataColumn()) as $col) {
             $dimension = $this->worksheet->getColumnDimension($col);
 
-            // Only auto-size columns that have not have an explicit width.
+            // Only auto-size columns that have not had an explicit width.
             if ($dimension->getWidth() == -1) {
                 $dimension->setAutoSize(true);
             }

--- a/tests/Concerns/FromViewTest.php
+++ b/tests/Concerns/FromViewTest.php
@@ -36,7 +36,7 @@ final class FromViewTest extends TestCase
              * @param  Collection<int, User>  $users
              */
             public function __construct(
-                protected Collection $users,
+                protected readonly Collection $users,
             ) {
             }
 
@@ -75,7 +75,7 @@ final class FromViewTest extends TestCase
              * @param  Collection<int, User>  $users
              */
             public function __construct(
-                protected Collection $users,
+                protected readonly Collection $users,
             ) {
             }
 

--- a/tests/Concerns/SkipsOnFailureTest.php
+++ b/tests/Concerns/SkipsOnFailureTest.php
@@ -206,11 +206,11 @@ final class SkipsOnFailureTest extends TestCase
         {
             use Importable, SkipsFailures;
 
-            public function onRow(Row $row): User
+            public function onRow(Row $row): void
             {
                 $row = $row->toArray();
 
-                return User::create([
+                User::create([
                     'name'     => $row[0],
                     'email'    => $row[1],
                     'password' => 'secret',

--- a/tests/Concerns/WithConditionalSheetsTest.php
+++ b/tests/Concerns/WithConditionalSheetsTest.php
@@ -20,7 +20,7 @@ final class WithConditionalSheetsTest extends TestCase
             use Importable, WithConditionalSheets;
 
             /** @var array<string, object> */
-            public $sheets = [];
+            public array $sheets = [];
 
             public function __construct()
             {

--- a/tests/Concerns/WithCustomCsvSettingsTest.php
+++ b/tests/Concerns/WithCustomCsvSettingsTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Assert;
 
 final class WithCustomCsvSettingsTest extends TestCase
 {
-    protected Excel $SUT;
+    protected readonly Excel $SUT;
 
     protected function setUp(): void
     {

--- a/tests/Concerns/WithCustomStartCellTest.php
+++ b/tests/Concerns/WithCustomStartCellTest.php
@@ -12,7 +12,7 @@ use Maatwebsite\Excel\Tests\TestCase;
 
 final class WithCustomStartCellTest extends TestCase
 {
-    protected Excel $SUT;
+    protected readonly Excel $SUT;
 
     protected function setUp(): void
     {

--- a/tests/Concerns/WithExportTemplateTest.php
+++ b/tests/Concerns/WithExportTemplateTest.php
@@ -141,6 +141,9 @@ final class WithExportTemplateTest extends TestCase
             ) {
             }
 
+            /**
+             * @return Export[]
+             */
             public function sheets(): array
             {
                 return [
@@ -155,7 +158,7 @@ final class WithExportTemplateTest extends TestCase
                 return $this->templatePath;
             }
 
-            private function sheetExport(string $value): object
+            private function sheetExport(string $value): Export
             {
                 return new readonly class($value) implements FromArray, WithCustomStartCell
                 {

--- a/tests/Concerns/WithExportTemplateTest.php
+++ b/tests/Concerns/WithExportTemplateTest.php
@@ -38,7 +38,7 @@ final class WithExportTemplateTest extends TestCase
             use Exportable;
 
             public function __construct(
-                private string $templatePath,
+                private readonly string $templatePath,
             ) {
             }
 
@@ -86,7 +86,7 @@ final class WithExportTemplateTest extends TestCase
             use Exportable;
 
             public function __construct(
-                private string $templatePath,
+                private readonly string $templatePath,
             ) {
             }
 
@@ -137,7 +137,7 @@ final class WithExportTemplateTest extends TestCase
             use Exportable;
 
             public function __construct(
-                private string $templatePath,
+                private readonly string $templatePath,
             ) {
             }
 

--- a/tests/Concerns/WithMultipleSheetsTest.php
+++ b/tests/Concerns/WithMultipleSheetsTest.php
@@ -61,7 +61,7 @@ final class WithMultipleSheetsTest extends TestCase
              * @param  Collection<int, User>  $users
              */
             public function __construct(
-                protected Collection $users,
+                protected readonly Collection $users,
             ) {
             }
 

--- a/tests/Concerns/WithValidationTest.php
+++ b/tests/Concerns/WithValidationTest.php
@@ -542,11 +542,11 @@ final class WithValidationTest extends TestCase
         {
             use Importable;
 
-            public function onRow(Row $row): User
+            public function onRow(Row $row): void
             {
                 $values = $row->toArray();
 
-                return new User([
+                new User([
                     'name'     => $values['name'],
                     'email'    => $values['email'],
                     'password' => 'secret',

--- a/tests/Data/Stubs/AfterQueueExportJob.php
+++ b/tests/Data/Stubs/AfterQueueExportJob.php
@@ -13,7 +13,7 @@ class AfterQueueExportJob implements ShouldQueue
     use Queueable;
 
     public function __construct(
-        private string $filePath,
+        private readonly string $filePath,
     ) {
     }
 

--- a/tests/Data/Stubs/AfterQueueImportJob.php
+++ b/tests/Data/Stubs/AfterQueueImportJob.php
@@ -14,7 +14,7 @@ class AfterQueueImportJob implements ShouldQueue
     use Queueable;
 
     public function __construct(
-        private int $totalRows,
+        private readonly int $totalRows,
     ) {
     }
 

--- a/tests/Data/Stubs/FromViewExportWithMultipleSheets.php
+++ b/tests/Data/Stubs/FromViewExportWithMultipleSheets.php
@@ -16,7 +16,7 @@ class FromViewExportWithMultipleSheets implements Export, WithMultipleSheets
      * @param  Collection<int, User>  $users
      */
     public function __construct(
-        protected Collection $users,
+        protected readonly Collection $users,
     ) {
     }
 

--- a/tests/Data/Stubs/QueuedExportWithLocalePreferences.php
+++ b/tests/Data/Stubs/QueuedExportWithLocalePreferences.php
@@ -20,7 +20,7 @@ class QueuedExportWithLocalePreferences implements FromCollection, HasLocalePref
      * QueuedExportWithLocalePreferences constructor.
      */
     public function __construct(
-        protected string $locale,
+        protected readonly string $locale,
     ) {
     }
 

--- a/tests/Data/Stubs/SheetForUsersFromView.php
+++ b/tests/Data/Stubs/SheetForUsersFromView.php
@@ -16,7 +16,7 @@ class SheetForUsersFromView implements FromView
      * @param  Collection<int, User>  $users
      */
     public function __construct(
-        protected Collection $users,
+        protected readonly Collection $users,
     ) {
     }
 

--- a/tests/Data/Stubs/SheetWith100Rows.php
+++ b/tests/Data/Stubs/SheetWith100Rows.php
@@ -21,7 +21,7 @@ class SheetWith100Rows implements FromCollection, ShouldAutoSize, WithEvents, Wi
     use Exportable, RegistersEventListeners;
 
     public function __construct(
-        private string $title,
+        private readonly string $title,
     ) {
     }
 

--- a/tests/ExcelTest.php
+++ b/tests/ExcelTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 final class ExcelTest extends TestCase
 {
-    protected Excel $SUT;
+    protected readonly Excel $SUT;
 
     protected function setUp(): void
     {

--- a/tests/Files/DiskTest.php
+++ b/tests/Files/DiskTest.php
@@ -13,9 +13,9 @@ use Mockery\MockInterface;
 
 final class DiskTest extends TestCase
 {
-    private Disk $disk;
+    private readonly Disk $disk;
 
-    private Filesystem&MockInterface $filesystem;
+    private readonly Filesystem&MockInterface $filesystem;
 
     protected function setUp(): void
     {

--- a/tests/PhpSpreadsheetV5CompatibilityTest.php
+++ b/tests/PhpSpreadsheetV5CompatibilityTest.php
@@ -282,7 +282,7 @@ final class PhpSpreadsheetV5CompatibilityTest extends TestCase
             public $skippedSheets = [];
 
             /**
-             * @return array<string, object>
+             * @return array<string, Import>
              */
             public function sheets(): array
             {
@@ -334,10 +334,10 @@ final class PhpSpreadsheetV5CompatibilityTest extends TestCase
             use Importable;
 
             /** @var array<int, string|int> */
-            public $skippedSheets = [];
+            public array $skippedSheets = [];
 
             /**
-             * @return array<string, object>
+             * @return array<string, Import>
              */
             public function sheets(): array
             {

--- a/tests/TemporaryFileTest.php
+++ b/tests/TemporaryFileTest.php
@@ -10,9 +10,9 @@ use RuntimeException;
 
 final class TemporaryFileTest extends TestCase
 {
-    private string $defaultDirectoryPermissions;
+    private readonly string $defaultDirectoryPermissions;
 
-    private string $defaultFilePermissions;
+    private readonly string $defaultFilePermissions;
 
     /**
      * Setup the test environment.

--- a/tests/Validators/RowValidatorTest.php
+++ b/tests/Validators/RowValidatorTest.php
@@ -12,7 +12,7 @@ use stdClass;
 
 final class RowValidatorTest extends TestCase
 {
-    protected RowValidator $validator;
+    protected readonly RowValidator $validator;
 
     /**
      * Set up the test.


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?

Fixes remaining missing types after merging #4403 and #4329 and cleans up

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

It contains adding missing PHP types and also adds `readonly` to `private` properties where applicable.
There are still a few classes that we could make completely readonly but that should only be done for final classes which we don't currently have.
Narrows down some `mixed` types in events and fixes spelling.

3️⃣  Does it include tests, if possible?
yes
4️⃣  Any drawbacks? Possible breaking changes?
no
5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
