### PR TITLE
[4.x] Make `OnEachRow` extend `Import`

### DIFF
--- a/UPGRADE-4.x.md
+++ b/UPGRADE-4.x.md
@@ -69,7 +69,7 @@ republish or migrate your configuration.
 
 Two new marker interfaces have been introduced: `Maatwebsite\Excel\Concerns\Export` and `Maatwebsite\Excel\Concerns\Import`.
 All export-related concerns (e.g. `FromArray`, `FromCollection`, `FromQuery`) now extend `Export`, and all import-related
-concerns (e.g. `ToModel`, `ToArray`, `ToCollection`) now extend `Import`. Because your export and import classes already
+concerns (e.g. `ToModel`, `ToArray`, `ToCollection`, `OnEachRow`) now extend `Import`. Because your export and import classes already
 implement those concerns, they automatically satisfy the new interfaces — no changes are required in most cases.
 
 You can now use `Export` and `Import` as type hints wherever you previously used `object` to represent an export or import:

--- a/src/Concerns/OnEachRow.php
+++ b/src/Concerns/OnEachRow.php
@@ -6,7 +6,7 @@ namespace Maatwebsite\Excel\Concerns;
 
 use Maatwebsite\Excel\Row;
 
-interface OnEachRow
+interface OnEachRow extends Import
 {
     public function onRow(Row $row): void;
 }

--- a/tests/Concerns/OnEachRowTest.php
+++ b/tests/Concerns/OnEachRowTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
-use Maatwebsite\Excel\Concerns\Import;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\OnEachRow;
 use Maatwebsite\Excel\Row;
@@ -15,7 +14,7 @@ final class OnEachRowTest extends TestCase
 {
     public function test_can_import_each_row_individually(): void
     {
-        $import = new class implements Import, OnEachRow
+        $import = new class implements OnEachRow
         {
             use Importable;
 
@@ -44,7 +43,7 @@ final class OnEachRowTest extends TestCase
 
     public function test_it_respects_the_end_column(): void
     {
-        $import = new class implements Import, OnEachRow
+        $import = new class implements OnEachRow
         {
             use Importable;
 

--- a/tests/Concerns/SkipsEmptyRowsTest.php
+++ b/tests/Concerns/SkipsEmptyRowsTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Maatwebsite\Excel\Tests\Concerns;
 
 use Illuminate\Support\Collection;
-use Maatwebsite\Excel\Concerns\Import;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\OnEachRow;
 use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
@@ -44,7 +43,7 @@ final class SkipsEmptyRowsTest extends TestCase
 
     public function test_skips_empty_rows_when_importing_on_each_row(): void
     {
-        $import = new class implements Import, OnEachRow, SkipsEmptyRows
+        $import = new class implements OnEachRow, SkipsEmptyRows
         {
             use Importable;
 
@@ -147,7 +146,7 @@ final class SkipsEmptyRowsTest extends TestCase
 
     public function test_custom_skips_rows_when_using_oneachrow(): void
     {
-        $import = new class implements Import, OnEachRow, SkipsEmptyRows
+        $import = new class implements OnEachRow, SkipsEmptyRows
         {
             use Importable;
 

--- a/tests/Concerns/SkipsOnErrorTest.php
+++ b/tests/Concerns/SkipsOnErrorTest.php
@@ -8,7 +8,6 @@ use Exception;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\In;
-use Maatwebsite\Excel\Concerns\Import;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\OnEachRow;
 use Maatwebsite\Excel\Concerns\SkipsErrors;
@@ -113,7 +112,7 @@ final class SkipsOnErrorTest extends TestCase
 
     public function test_can_skip_on_error_when_using_oneachrow_with_validation(): void
     {
-        $import = new class implements Import, OnEachRow, SkipsOnError, WithValidation
+        $import = new class implements OnEachRow, SkipsOnError, WithValidation
         {
             use Importable;
 
@@ -172,7 +171,7 @@ final class SkipsOnErrorTest extends TestCase
 
     public function test_can_skip_errors_and_collect_all_errors_when_using_oneachrow_with_validation(): void
     {
-        $import = new class implements Import, OnEachRow, SkipsOnError, WithValidation
+        $import = new class implements OnEachRow, SkipsOnError, WithValidation
         {
             use Importable, SkipsErrors;
 
@@ -227,7 +226,7 @@ final class SkipsOnErrorTest extends TestCase
 
     public function test_can_skip_on_error_when_exception_thrown_in_onrow(): void
     {
-        $import = new class implements Import, OnEachRow, SkipsOnError
+        $import = new class implements OnEachRow, SkipsOnError
         {
             use Importable;
 
@@ -280,7 +279,7 @@ final class SkipsOnErrorTest extends TestCase
 
     public function test_can_skip_errors_and_collect_all_errors_when_exception_thrown_in_onrow(): void
     {
-        $import = new class implements Import, OnEachRow, SkipsOnError
+        $import = new class implements OnEachRow, SkipsOnError
         {
             use Importable, SkipsErrors;
 

--- a/tests/Concerns/SkipsOnFailureTest.php
+++ b/tests/Concerns/SkipsOnFailureTest.php
@@ -7,7 +7,6 @@ namespace Maatwebsite\Excel\Tests\Concerns;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\In;
-use Maatwebsite\Excel\Concerns\Import;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\OnEachRow;
 use Maatwebsite\Excel\Concerns\SkipsFailures;
@@ -202,7 +201,7 @@ final class SkipsOnFailureTest extends TestCase
 
     public function test_can_validate_using_oneachrow_and_skipsonfailure(): void
     {
-        $import = new class implements Import, OnEachRow, SkipsOnFailure, WithValidation
+        $import = new class implements OnEachRow, SkipsOnFailure, WithValidation
         {
             use Importable, SkipsFailures;
 

--- a/tests/Concerns/WithGroupedHeadingRowTest.php
+++ b/tests/Concerns/WithGroupedHeadingRowTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Maatwebsite\Excel\Tests\Concerns;
 
 use Illuminate\Support\Collection;
-use Maatwebsite\Excel\Concerns\Import;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\OnEachRow;
 use Maatwebsite\Excel\Concerns\ToArray;
@@ -56,7 +55,7 @@ final class WithGroupedHeadingRowTest extends TestCase
 
     public function test_can_import_oneachrow_with_grouped_headers(): void
     {
-        $import = new class implements Import, OnEachRow, WithGroupedHeadingRow
+        $import = new class implements OnEachRow, WithGroupedHeadingRow
         {
             use Importable;
 

--- a/tests/Concerns/WithValidationTest.php
+++ b/tests/Concerns/WithValidationTest.php
@@ -10,7 +10,6 @@ use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\In;
-use Maatwebsite\Excel\Concerns\Import;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\OnEachRow;
 use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
@@ -538,7 +537,7 @@ final class WithValidationTest extends TestCase
 
     public function test_can_validate_using_oneachrow(): void
     {
-        $import = new class implements Import, OnEachRow, WithHeadingRow, WithValidation
+        $import = new class implements OnEachRow, WithHeadingRow, WithValidation
         {
             use Importable;
 
@@ -832,7 +831,7 @@ final class WithValidationTest extends TestCase
 
     public function test_can_prepare_using_oneachrow(): void
     {
-        $import = new class implements Import, OnEachRow, WithValidation
+        $import = new class implements OnEachRow, WithValidation
         {
             use Importable;
 
@@ -885,7 +884,7 @@ final class WithValidationTest extends TestCase
 
     public function test_can_prepare_using_skipsemptyrows(): void
     {
-        $import = new class implements Import, OnEachRow, SkipsEmptyRows, WithValidation
+        $import = new class implements OnEachRow, SkipsEmptyRows, WithValidation
         {
             use Importable;
 


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?

Follows up #4403 by making `OnEachRow` extend the `Import` interface which was previously missed. This is to cover scenarios where import doesn't create any models but instead is handled in a custom way.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No
3️⃣  Does it include tests, if possible?
Tests updated
4️⃣  Any drawbacks? Possible breaking changes?
No
5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
