### PR TITLE
[4.x] Fix: FromScout does not close the sheet

### DIFF
--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -189,8 +189,6 @@ class Sheet
 
             if ($sheetExport instanceof FromScout) {
                 $this->fromScout($sheetExport, $this->worksheet);
-
-                return;
             }
 
             if ($sheetExport instanceof FromCollection) {


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?
When using a non-queued FromScout interface, the sheet was not properly closed (no charts were generated, etc) because of premature return.
2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No
3️⃣  Does it include tests, if possible?

4️⃣  Any drawbacks? Possible breaking changes?

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
