### PR TITLE
[4.x] Add Time/Enum column types and sheet-level export concerns

### DIFF
--- a/src/Columns/Enum.php
+++ b/src/Columns/Enum.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Columns;
+
+use BackedEnum;
+use UnitEnum;
+
+/**
+ * @template TEnum of UnitEnum
+ */
+class Enum extends Column
+{
+    /** @var class-string<TEnum>|null */
+    protected ?string $enumClass = null;
+
+    protected bool $byName = false;
+
+    /**
+     * @template T of UnitEnum
+     *
+     * @param  class-string<T>  $enumClass
+     *
+     * @phpstan-this-out self<T>
+     */
+    public function of(string $enumClass): static
+    {
+        $this->enumClass = $enumClass;
+
+        return $this;
+    }
+
+    public function byName(): static
+    {
+        $this->byName = true;
+
+        return $this;
+    }
+
+    protected function toExcelValue(mixed $value): int|string|null
+    {
+        if ($value instanceof BackedEnum) {
+            return $this->byName ? $value->name : $value->value;
+        }
+
+        if ($value instanceof UnitEnum) {
+            return $value->name;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return TEnum|null
+     */
+    protected function cast(mixed $value): mixed
+    {
+        if ($this->enumClass === null) {
+            return $value;
+        }
+
+        if (!$this->byName && is_subclass_of($this->enumClass, BackedEnum::class)) {
+            return $this->enumClass::tryFrom($value);
+        }
+
+        foreach ($this->enumClass::cases() as $case) {
+            if ($case->name === (string) $value) {
+                return $case;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Columns/Time.php
+++ b/src/Columns/Time.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Columns;
+
+use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
+
+class Time extends Date
+{
+    protected ?string $format = NumberFormat::FORMAT_DATE_TIME4;
+
+    protected bool $time = true;
+}

--- a/src/Concerns/WithFreezePane.php
+++ b/src/Concerns/WithFreezePane.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Concerns;
+
+interface WithFreezePane extends Export
+{
+    /**
+     * The cell coordinate that becomes the top-left of the scrolling region.
+     * 'A2' freezes the first row; 'B1' freezes column A; 'B2' freezes both.
+     */
+    public function freezePane(): string;
+}

--- a/src/Concerns/WithPageBreaks.php
+++ b/src/Concerns/WithPageBreaks.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Concerns;
+
+interface WithPageBreaks extends Export
+{
+    /**
+     * Row numbers before which a horizontal page break is inserted.
+     *
+     * @return array<int>
+     */
+    public function pageBreaks(): array;
+}

--- a/src/Concerns/WithPrintArea.php
+++ b/src/Concerns/WithPrintArea.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Concerns;
+
+interface WithPrintArea extends Export
+{
+    /**
+     * The cell range to set as the print area, e.g. 'A1:G100'.
+     */
+    public function printArea(): string;
+}

--- a/src/Concerns/WithSheetProtection.php
+++ b/src/Concerns/WithSheetProtection.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Concerns;
+
+interface WithSheetProtection extends Export
+{
+    /**
+     * Return a password to protect the sheet with a password,
+     * or null to lock the sheet without requiring a password.
+     */
+    public function sheetProtection(): ?string;
+}

--- a/src/Concerns/WithTabColor.php
+++ b/src/Concerns/WithTabColor.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Concerns;
+
+interface WithTabColor extends Export
+{
+    /**
+     * RGB hex color for the sheet tab, without a leading #.
+     * Example: 'FF0000' for red.
+     */
+    public function tabColor(): string;
+}

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -38,13 +38,18 @@ use Maatwebsite\Excel\Concerns\WithCustomValueBinder;
 use Maatwebsite\Excel\Concerns\WithDrawings;
 use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Concerns\WithFormatData;
+use Maatwebsite\Excel\Concerns\WithFreezePane;
 use Maatwebsite\Excel\Concerns\WithGroupedHeadingRow;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithMappedCells;
 use Maatwebsite\Excel\Concerns\WithMapping;
+use Maatwebsite\Excel\Concerns\WithPageBreaks;
+use Maatwebsite\Excel\Concerns\WithPrintArea;
 use Maatwebsite\Excel\Concerns\WithProgressBar;
+use Maatwebsite\Excel\Concerns\WithSheetProtection;
 use Maatwebsite\Excel\Concerns\WithStrictNullComparison;
 use Maatwebsite\Excel\Concerns\WithStyles;
+use Maatwebsite\Excel\Concerns\WithTabColor;
 use Maatwebsite\Excel\Concerns\WithTitle;
 use Maatwebsite\Excel\Concerns\WithValidation;
 use Maatwebsite\Excel\Events\AfterSheet;
@@ -421,6 +426,33 @@ class Sheet
 
         if ($sheetExport instanceof ShouldAutoSize) {
             $this->autoSize();
+        }
+
+        if ($sheetExport instanceof WithFreezePane) {
+            $this->worksheet->freezePane($sheetExport->freezePane());
+        }
+
+        if ($sheetExport instanceof WithTabColor) {
+            $this->worksheet->getTabColor()->setRGB($sheetExport->tabColor());
+        }
+
+        if ($sheetExport instanceof WithSheetProtection) {
+            $protection = $this->worksheet->getProtection();
+            $protection->setSheet(true);
+            $password = $sheetExport->sheetProtection();
+            if ($password !== null) {
+                $protection->setPassword($password);
+            }
+        }
+
+        if ($sheetExport instanceof WithPageBreaks) {
+            foreach ($sheetExport->pageBreaks() as $row) {
+                $this->worksheet->setBreak('A' . $row, Worksheet::BREAK_ROW);
+            }
+        }
+
+        if ($sheetExport instanceof WithPrintArea) {
+            $this->worksheet->getPageSetup()->setPrintArea($sheetExport->printArea());
         }
 
         if ($sheetExport instanceof WithColumnWidths) {

--- a/tests/Columns/EnumColumnTest.php
+++ b/tests/Columns/EnumColumnTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Columns;
+
+use Maatwebsite\Excel\Columns\Enum;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
+
+enum UserStatus: string
+{
+    case Active   = 'active';
+    case Inactive = 'inactive';
+}
+
+enum Priority: int
+{
+    case Low    = 1;
+    case Medium = 2;
+    case High   = 3;
+}
+
+enum Color
+{
+    case Red;
+    case Green;
+    case Blue;
+}
+
+final class EnumColumnTest extends BaseColumnTestCase
+{
+    public function test_writes_string_backed_enum_by_value(): void
+    {
+        $this->write(Enum::make('Status')->of(UserStatus::class), [
+            'status' => UserStatus::Active,
+        ]);
+
+        $this->assertSame('active', $this->sheet->getCell('A1')->getValue());
+    }
+
+    public function test_writes_int_backed_enum_by_value(): void
+    {
+        $this->write(Enum::make('Priority')->of(Priority::class), [
+            'priority' => Priority::High,
+        ]);
+
+        $this->assertSame(3, $this->sheet->getCell('A1')->getValue());
+    }
+
+    public function test_writes_unit_enum_by_name(): void
+    {
+        $this->write(Enum::make('Color')->of(Color::class), [
+            'color' => Color::Red,
+        ]);
+
+        $this->assertSame('Red', $this->sheet->getCell('A1')->getValue());
+    }
+
+    public function test_writes_backed_enum_by_name_when_requested(): void
+    {
+        $this->write(Enum::make('Status')->of(UserStatus::class)->byName(), [
+            'status' => UserStatus::Active,
+        ]);
+
+        $this->assertSame('Active', $this->sheet->getCell('A1')->getValue());
+    }
+
+    public function test_reads_string_backed_enum_by_value(): void
+    {
+        $this->givenCellValue('active', DataType::TYPE_STRING, NumberFormat::FORMAT_GENERAL);
+
+        $result = $this->readCellValue(Enum::make('Status')->of(UserStatus::class));
+
+        $this->assertSame(UserStatus::Active, $result);
+    }
+
+    public function test_reads_int_backed_enum_by_value(): void
+    {
+        $this->givenCellValue(2, DataType::TYPE_NUMERIC, NumberFormat::FORMAT_GENERAL);
+
+        $result = $this->readCellValue(Enum::make('Priority')->of(Priority::class));
+
+        $this->assertSame(Priority::Medium, $result);
+    }
+
+    public function test_reads_unit_enum_by_name(): void
+    {
+        $this->givenCellValue('Green', DataType::TYPE_STRING, NumberFormat::FORMAT_GENERAL);
+
+        $result = $this->readCellValue(Enum::make('Color')->of(Color::class));
+
+        $this->assertSame(Color::Green, $result);
+    }
+
+    public function test_reads_backed_enum_by_name_when_requested(): void
+    {
+        $this->givenCellValue('Active', DataType::TYPE_STRING, NumberFormat::FORMAT_GENERAL);
+
+        $result = $this->readCellValue(Enum::make('Status')->of(UserStatus::class)->byName());
+
+        $this->assertSame(UserStatus::Active, $result);
+    }
+
+    public function test_returns_null_for_unknown_backed_enum_value(): void
+    {
+        $this->givenCellValue('unknown', DataType::TYPE_STRING, NumberFormat::FORMAT_GENERAL);
+
+        $result = $this->readCellValue(Enum::make('Status')->of(UserStatus::class));
+
+        $this->assertNull($result);
+    }
+
+    public function test_returns_null_for_unknown_unit_enum_name(): void
+    {
+        $this->givenCellValue('Purple', DataType::TYPE_STRING, NumberFormat::FORMAT_GENERAL);
+
+        $result = $this->readCellValue(Enum::make('Color')->of(Color::class));
+
+        $this->assertNull($result);
+    }
+
+    public function test_returns_raw_value_when_no_enum_class_set(): void
+    {
+        $this->givenCellValue('active', DataType::TYPE_STRING, NumberFormat::FORMAT_GENERAL);
+
+        $result = $this->readCellValue(Enum::make('Status'));
+
+        $this->assertSame('active', $result);
+    }
+}

--- a/tests/Columns/TimeColumnTest.php
+++ b/tests/Columns/TimeColumnTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Columns;
+
+use Carbon\Carbon;
+use Iterator;
+use Maatwebsite\Excel\Columns\Time;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Shared\Date as ExcelDate;
+use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class TimeColumnTest extends BaseColumnTestCase
+{
+    #[DataProvider('exportValues')]
+    public function test_can_write_time_values(mixed $given, float $expected): void
+    {
+        $this->write(Time::make('Shift Start'), [
+            'shift_start' => $given,
+        ]);
+
+        $this->assertCellValue($expected);
+        $this->assertCellDataType(DataType::TYPE_NUMERIC);
+        $this->assertNumberFormat(NumberFormat::FORMAT_DATE_TIME4);
+    }
+
+    /**
+     * @return Iterator<int<0, max>, array{mixed, float}>
+     */
+    public static function exportValues(): Iterator
+    {
+        yield [Carbon::createFromTime(9, 30, 0), ExcelDate::dateTimeToExcel(Carbon::createFromTime(9, 30, 0))];
+        yield [Carbon::createFromTime(17, 0, 0), ExcelDate::dateTimeToExcel(Carbon::createFromTime(17, 0, 0))];
+    }
+
+    #[DataProvider('importValues')]
+    public function test_can_read_time_values(float $given, int $expectedHour, int $expectedMinute, int $expectedSecond): void
+    {
+        $this->givenCellValue($given, DataType::TYPE_NUMERIC, NumberFormat::FORMAT_DATE_TIME4);
+
+        $result = $this->readCellValue(Time::make('Shift Start'));
+
+        $this->assertInstanceOf(Carbon::class, $result);
+        $this->assertSame($expectedHour, $result->hour);
+        $this->assertSame($expectedMinute, $result->minute);
+        $this->assertSame($expectedSecond, $result->second);
+    }
+
+    /**
+     * @return Iterator<int<0, max>, array{float, int, int, int}>
+     */
+    public static function importValues(): Iterator
+    {
+        yield [ExcelDate::dateTimeToExcel(Carbon::createFromTime(9, 30, 0)), 9, 30, 0];
+        yield [ExcelDate::dateTimeToExcel(Carbon::createFromTime(17, 0, 0)), 17, 0, 0];
+        yield [ExcelDate::dateTimeToExcel(Carbon::createFromTime(0, 0, 0)), 0, 0, 0];
+    }
+}

--- a/tests/Concerns/WithFreezePaneTest.php
+++ b/tests/Concerns/WithFreezePaneTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Concerns;
+
+use Maatwebsite\Excel\Concerns\Export;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\WithFreezePane;
+use Maatwebsite\Excel\Tests\TestCase;
+
+final class WithFreezePaneTest extends TestCase
+{
+    public function test_can_freeze_the_first_row(): void
+    {
+        $export = new class implements Export, FromArray, WithFreezePane
+        {
+            use Exportable;
+
+            public function array(): array
+            {
+                return [['Patrick', 'Brouwers']];
+            }
+
+            public function freezePane(): string
+            {
+                return 'A2';
+            }
+        };
+
+        $export->store('with-freeze-pane.xlsx');
+
+        $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/with-freeze-pane.xlsx', 'Xlsx');
+        $sheet       = $spreadsheet->getActiveSheet();
+
+        $this->assertSame('A2', $sheet->getFreezePane());
+    }
+
+    public function test_can_freeze_both_row_and_column(): void
+    {
+        $export = new class implements Export, FromArray, WithFreezePane
+        {
+            use Exportable;
+
+            public function array(): array
+            {
+                return [['Patrick', 'Brouwers']];
+            }
+
+            public function freezePane(): string
+            {
+                return 'B2';
+            }
+        };
+
+        $export->store('with-freeze-pane.xlsx');
+
+        $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/with-freeze-pane.xlsx', 'Xlsx');
+        $sheet       = $spreadsheet->getActiveSheet();
+
+        $this->assertSame('B2', $sheet->getFreezePane());
+    }
+}

--- a/tests/Concerns/WithPageBreaksTest.php
+++ b/tests/Concerns/WithPageBreaksTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Concerns;
+
+use Maatwebsite\Excel\Concerns\Export;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\WithPageBreaks;
+use Maatwebsite\Excel\Tests\TestCase;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+final class WithPageBreaksTest extends TestCase
+{
+    public function test_can_add_page_breaks(): void
+    {
+        $export = new class implements Export, FromArray, WithPageBreaks
+        {
+            use Exportable;
+
+            public function array(): array
+            {
+                return array_fill(0, 10, ['value']);
+            }
+
+            public function pageBreaks(): array
+            {
+                return [5, 8];
+            }
+        };
+
+        $export->store('with-page-breaks.xlsx');
+
+        $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/with-page-breaks.xlsx', 'Xlsx');
+        $breaks      = $spreadsheet->getActiveSheet()->getRowBreaks();
+
+        $this->assertArrayHasKey('A5', $breaks);
+        $this->assertSame(Worksheet::BREAK_ROW, $breaks['A5']->getBreakType());
+        $this->assertArrayHasKey('A8', $breaks);
+        $this->assertSame(Worksheet::BREAK_ROW, $breaks['A8']->getBreakType());
+    }
+}

--- a/tests/Concerns/WithPrintAreaTest.php
+++ b/tests/Concerns/WithPrintAreaTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Concerns;
+
+use Maatwebsite\Excel\Concerns\Export;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\WithPrintArea;
+use Maatwebsite\Excel\Tests\TestCase;
+
+final class WithPrintAreaTest extends TestCase
+{
+    public function test_can_set_print_area(): void
+    {
+        $export = new class implements Export, FromArray, WithPrintArea
+        {
+            use Exportable;
+
+            public function array(): array
+            {
+                return [['Patrick', 'Brouwers']];
+            }
+
+            public function printArea(): string
+            {
+                return 'A1:B10';
+            }
+        };
+
+        $export->store('with-print-area.xlsx');
+
+        $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/with-print-area.xlsx', 'Xlsx');
+        $sheet       = $spreadsheet->getActiveSheet();
+
+        $this->assertSame('A1:B10', $sheet->getPageSetup()->getPrintArea());
+    }
+}

--- a/tests/Concerns/WithSheetProtectionTest.php
+++ b/tests/Concerns/WithSheetProtectionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Concerns;
+
+use Maatwebsite\Excel\Concerns\Export;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\WithSheetProtection;
+use Maatwebsite\Excel\Tests\TestCase;
+
+final class WithSheetProtectionTest extends TestCase
+{
+    public function test_can_protect_sheet_without_password(): void
+    {
+        $export = new class implements Export, FromArray, WithSheetProtection
+        {
+            use Exportable;
+
+            public function array(): array
+            {
+                return [['Patrick', 'Brouwers']];
+            }
+
+            public function sheetProtection(): ?string
+            {
+                return null;
+            }
+        };
+
+        $export->store('with-sheet-protection.xlsx');
+
+        $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/with-sheet-protection.xlsx', 'Xlsx');
+        $protection  = $spreadsheet->getActiveSheet()->getProtection();
+
+        $this->assertTrue($protection->getSheet());
+        $this->assertEmpty($protection->getPassword());
+    }
+
+    public function test_can_protect_sheet_with_password(): void
+    {
+        $export = new class implements Export, FromArray, WithSheetProtection
+        {
+            use Exportable;
+
+            public function array(): array
+            {
+                return [['Patrick', 'Brouwers']];
+            }
+
+            public function sheetProtection(): string
+            {
+                return 'secret';
+            }
+        };
+
+        $export->store('with-sheet-protection.xlsx');
+
+        $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/with-sheet-protection.xlsx', 'Xlsx');
+        $protection  = $spreadsheet->getActiveSheet()->getProtection();
+
+        $this->assertTrue($protection->getSheet());
+        $this->assertNotEmpty($protection->getPassword());
+    }
+}

--- a/tests/Concerns/WithTabColorTest.php
+++ b/tests/Concerns/WithTabColorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Concerns;
+
+use Maatwebsite\Excel\Concerns\Export;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\WithTabColor;
+use Maatwebsite\Excel\Tests\TestCase;
+
+final class WithTabColorTest extends TestCase
+{
+    public function test_can_set_tab_color(): void
+    {
+        $export = new class implements Export, FromArray, WithTabColor
+        {
+            use Exportable;
+
+            public function array(): array
+            {
+                return [['Patrick', 'Brouwers']];
+            }
+
+            public function tabColor(): string
+            {
+                return 'FF0000';
+            }
+        };
+
+        $export->store('with-tab-color.xlsx');
+
+        $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/with-tab-color.xlsx', 'Xlsx');
+        $sheet       = $spreadsheet->getActiveSheet();
+
+        $this->assertSame('FFFF0000', $sheet->getTabColor()->getARGB());
+    }
+}


### PR DESCRIPTION
Adds several commonly-needed features that today require an `AfterSheet` event workaround.

## New column types

- **`Time`** – time-of-day column (`hh:mm:ss`), sibling of the existing `Date`/`DateTime` columns. Reads back as a `Carbon` instance.
- **`Enum`** – PHP backed/unit enum column. Serialises to value (backed) or name (unit/byName). Deserialises via `tryFrom` or case lookup, returning `null` on unknown values. Fully typed with PHPStan generics (`@template TEnum of UnitEnum`).

## New sheet-level concerns

| Concern | Method | Description |
|---|---|---|
| `WithFreezePane` | `freezePane(): string` | Freeze rows/columns (e.g. `'A2'` to freeze the header row) |
| `WithTabColor` | `tabColor(): string` | RGB hex colour for the sheet tab |
| `WithSheetProtection` | `sheetProtection(): ?string` | Lock the sheet, optionally with a password |
| `WithPageBreaks` | `pageBreaks(): array` | Row numbers where a horizontal page break is inserted |
| `WithPrintArea` | `printArea(): string` | Cell range to set as print area (e.g. `'A1:G100'`) |

All sheet-level concerns extend `Export` and are applied in `Sheet::close()`, consistent with how `ShouldAutoSize`, `WithColumnFormatting`, etc. work.

## Tests

One test class per feature (15 files total, 633 insertions). Concern tests write a file, read it back via PhpSpreadsheet directly, and assert the expected worksheet state.