### PR TITLE
[4.x] Fix WithLimit discarding rows when the heading row is not the first row

### DIFF
--- a/src/Factories/ReaderFactory.php
+++ b/src/Factories/ReaderFactory.php
@@ -6,12 +6,13 @@ use Maatwebsite\Excel\Columns\ColumnCollection;
 use Maatwebsite\Excel\Concerns\Import;
 use Maatwebsite\Excel\Concerns\MapsCsvSettings;
 use Maatwebsite\Excel\Concerns\WithCustomCsvSettings;
+use Maatwebsite\Excel\Concerns\WithHeadingRow;
 use Maatwebsite\Excel\Concerns\WithLimit;
 use Maatwebsite\Excel\Concerns\WithReadFilter;
-use Maatwebsite\Excel\Concerns\WithStartRow;
 use Maatwebsite\Excel\Exceptions\NoTypeDetectedException;
 use Maatwebsite\Excel\Files\TemporaryFile;
 use Maatwebsite\Excel\Filters\LimitFilter;
+use Maatwebsite\Excel\Imports\HeadingRowExtractor;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Reader\Csv;
 use PhpOffice\PhpSpreadsheet\Reader\Exception;
@@ -60,8 +61,9 @@ class ReaderFactory
             $reader->setReadFilter($import->readFilter());
         } elseif ($import instanceof WithLimit) {
             $reader->setReadFilter(new LimitFilter(
-                $import instanceof WithStartRow ? $import->startRow() : 1,
-                $import->limit()
+                HeadingRowExtractor::determineStartRow($import),
+                $import->limit(),
+                $import instanceof WithHeadingRow ? HeadingRowExtractor::headingRow($import) : null
             ));
         }
 

--- a/src/Filters/LimitFilter.php
+++ b/src/Filters/LimitFilter.php
@@ -13,12 +13,17 @@ class LimitFilter implements IReadFilter
     public function __construct(
         private readonly int $startRow,
         int $limit,
+        private readonly ?int $headingRow = null,
     ) {
-        $this->endRow = $this->startRow + $limit;
+        // Subtract 1 row from the start row, so a limit of 1 row
+        // will have the same start and end row.
+        $this->endRow = ($this->startRow - 1) + $limit;
     }
 
     public function readCell(string $columnAddress, int $row, string $worksheetName = ''): bool
     {
-        return $row >= $this->startRow && $row <= $this->endRow;
+        //  Only read the heading row, and the rows within the limited range.
+        return $row === $this->headingRow
+            || ($row >= $this->startRow && $row <= $this->endRow);
     }
 }

--- a/tests/Concerns/WithLimitTest.php
+++ b/tests/Concerns/WithLimitTest.php
@@ -144,6 +144,71 @@ final class WithLimitTest extends TestCase
         $import->import('import-users-with-headings.xlsx');
     }
 
+    public function test_can_import_with_limit_and_a_heading_row_below_the_first_row(): void
+    {
+        $import = new class implements ToArray, WithHeadingRow, WithLimit
+        {
+            use Importable;
+
+            public function array(array $array): void
+            {
+                Assert::assertSame([
+                    [
+                        'name'  => 'Patrick Brouwers',
+                        'email' => 'patrick@maatwebsite.nl',
+                    ],
+                ], $array);
+            }
+
+            public function headingRow(): int
+            {
+                return 4;
+            }
+
+            public function limit(): int
+            {
+                return 1;
+            }
+        };
+
+        $import->import('import-users-with-different-heading-row.xlsx');
+    }
+
+    public function test_can_import_with_limit_and_a_start_row_below_the_heading_row(): void
+    {
+        $import = new class implements ToArray, WithHeadingRow, WithLimit, WithStartRow
+        {
+            use Importable;
+
+            public function array(array $array): void
+            {
+                Assert::assertSame([
+                    [
+                        'name'  => 'Taylor Otwell',
+                        'email' => 'taylor@laravel.com',
+                    ],
+                ], $array);
+            }
+
+            public function headingRow(): int
+            {
+                return 4;
+            }
+
+            public function startRow(): int
+            {
+                return 6;
+            }
+
+            public function limit(): int
+            {
+                return 1;
+            }
+        };
+
+        $import->import('import-users-with-different-heading-row.xlsx');
+    }
+
     public function test_can_set_limit_bigger_than_row_size(): void
     {
         $import = new class implements ToArray, WithLimit


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?
The read filter is built from `startRow ?: 1` and never told about the heading row, while the reader iterates from heading row + 1. The windows disagree, and unfiltered cells are never loaded at all. With headings on row 4 and a limit of 1, the import returns nothing; combined with a start row, the headings are dropped and rows come back numerically keyed — so a `ToModel` import silently writes nulls for every row. Chunk reading already handles this correctly; only non-chunked limits are affected.
2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No — one bug, two files: the filter learns about the heading row, and the call site derives its window the same way the reader does. Neither half fixes it alone. A one-line off-by-one on the same expression is included, since the filter was reading one row more than the limit
3️⃣  Does it include tests, if possible?
Yes, two regression tests covering both cases, using the existing fixture. Both fail before the fix. Full suite green, PHPStan and Pint clean.
4️⃣  Any drawbacks? Possible breaking changes?
No API break — the new heading-row argument is optional and defaults to null. Behavior does change where it was wrong: affected imports now return the correct rows, so anyone who inflated their limit to compensate will get more rows than before. No performance cost, and slightly less data parsed.
5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
