### PR TITLE
Fix Excel::fake() not working with ShouldBatch

### DIFF
--- a/src/Fakes/ExcelFake.php
+++ b/src/Fakes/ExcelFake.php
@@ -3,6 +3,7 @@
 namespace Maatwebsite\Excel\Fakes;
 
 use Exception;
+use Illuminate\Bus\Batchable;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -91,7 +92,7 @@ class ExcelFake implements Exporter, Importer
 
         $this->job = new class
         {
-            use Queueable;
+            use Batchable, Queueable;
 
             public function handle(): void
             {
@@ -164,7 +165,7 @@ class ExcelFake implements Exporter, Importer
 
         $this->job = new class
         {
-            use Queueable;
+            use Batchable, Queueable;
 
             public function handle(): void
             {

--- a/tests/ExcelFakeTest.php
+++ b/tests/ExcelFakeTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Maatwebsite\Excel\Tests;
 
+use Illuminate\Bus\PendingBatch;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\ShouldBatch;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Excel;
 use Maatwebsite\Excel\Facades\Excel as ExcelFacade;
@@ -226,6 +228,31 @@ final class ExcelFakeTest extends TestCase
         ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/');
     }
 
+    public function test_can_assert_against_a_fake_batched_export(): void
+    {
+        ExcelFacade::fake();
+
+        $response = ExcelFacade::queue($this->givenBatchedExport(), 'batched-filename.csv', 's3');
+
+        $this->assertInstanceOf(PendingBatch::class, $response);
+
+        ExcelFacade::assertQueued('batched-filename.csv', 's3');
+        ExcelFacade::assertQueued('batched-filename.csv', 's3', fn (FromCollection $export) => $export->collection()->contains('foo'));
+    }
+
+    public function test_can_assert_against_a_fake_batched_import(): void
+    {
+        ExcelFacade::fake();
+
+        $response = ExcelFacade::queueImport($this->givenBatchedImport(), 'batched-filename.csv', 's3');
+
+        $this->assertInstanceOf(PendingBatch::class, $response);
+
+        ExcelFacade::assertImported('batched-filename.csv', 's3');
+        ExcelFacade::assertQueued('batched-filename.csv', 's3');
+        ExcelFacade::assertQueued('batched-filename.csv', 's3', fn (ToModel $import): bool => $import->model([]) instanceof User);
+    }
+
     /**
      * @return FromCollection<int, string>
      */
@@ -274,6 +301,34 @@ final class ExcelFakeTest extends TestCase
     private function givenQueuedImport(): object
     {
         return new class implements ShouldQueue, ToModel
+        {
+            public function model(array $row): User
+            {
+                return new User([]);
+            }
+        };
+    }
+
+    /**
+     * @return FromCollection<int, string>
+     */
+    private function givenBatchedExport(): FromCollection
+    {
+        return new class implements FromCollection, ShouldBatch, ShouldQueue
+        {
+            /**
+             * @return Collection<int, string>
+             */
+            public function collection(): Collection
+            {
+                return collect(['foo', 'bar']);
+            }
+        };
+    }
+
+    private function givenBatchedImport(): object
+    {
+        return new class implements ShouldBatch, ShouldQueue, ToModel
         {
             public function model(array $row): User
             {

--- a/tests/ExcelFakeTest.php
+++ b/tests/ExcelFakeTest.php
@@ -228,6 +228,68 @@ final class ExcelFakeTest extends TestCase
         ExcelFacade::assertQueued('/\w{6}-\w{8}\.csv/');
     }
 
+    public function test_can_assert_against_a_fake_implicitly_batched_export(): void
+    {
+        ExcelFacade::fake();
+
+        $response = ExcelFacade::store($this->givenBatchedExport(), 'batched-filename.csv', 's3');
+
+        $this->assertInstanceOf(PendingBatch::class, $response);
+
+        ExcelFacade::assertStored('batched-filename.csv', 's3');
+        ExcelFacade::assertQueued('batched-filename.csv', 's3');
+    }
+
+    public function test_can_assert_against_a_fake_implicitly_batched_import(): void
+    {
+        ExcelFacade::fake();
+
+        $response = ExcelFacade::import($this->givenBatchedImport(), 'batched-filename.csv', 's3');
+
+        $this->assertInstanceOf(PendingBatch::class, $response);
+
+        ExcelFacade::assertImported('batched-filename.csv', 's3');
+        ExcelFacade::assertQueued('batched-filename.csv', 's3');
+    }
+
+    public function test_can_assert_to_array_fake(): void
+    {
+        ExcelFacade::fake();
+
+        $result = ExcelFacade::toArray($this->givenImport(), 'stored-filename.csv', 's3');
+
+        $this->assertSame([], $result);
+
+        ExcelFacade::assertImported('stored-filename.csv', 's3');
+        ExcelFacade::assertImported('stored-filename.csv', 's3', fn (ToModel $import): bool => $import->model([]) instanceof User);
+    }
+
+    public function test_can_assert_to_collection_fake(): void
+    {
+        ExcelFacade::fake();
+
+        $result = ExcelFacade::toCollection($this->givenImport(), 'stored-filename.csv', 's3');
+
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertTrue($result->isEmpty());
+
+        ExcelFacade::assertImported('stored-filename.csv', 's3');
+        ExcelFacade::assertImported('stored-filename.csv', 's3', fn (ToModel $import): bool => $import->model([]) instanceof User);
+    }
+
+    public function test_do_not_match_by_regex_reverts_to_exact_matching(): void
+    {
+        ExcelFacade::fake();
+
+        ExcelFacade::store($this->givenExport(), 'stored-filename.csv', 's3');
+
+        ExcelFacade::matchByRegex();
+        ExcelFacade::assertStored('/\w{6}-\w{8}\.csv/', 's3');
+
+        ExcelFacade::doNotMatchByRegex();
+        ExcelFacade::assertStored('stored-filename.csv', 's3');
+    }
+
     public function test_can_assert_against_a_fake_batched_export(): void
     {
         ExcelFacade::fake();


### PR DESCRIPTION
1️⃣  **Why?** `Excel::fake()` throws a `RuntimeException` when used with exports/imports implementing `ShouldBatch`, because the anonymous stub jobs in `ExcelFake::queue()` and `ExcelFake::queueImport()` only used the `Queueable` trait — `Bus::batch()` requires `Batchable` too. Fixes #4424.

2️⃣  Single, focused change.

3️⃣  Adding more tests to cover entire `ExcelFake` class

4️⃣  No drawbacks or breaking changes.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌