### PR TITLE
[chore] Improve test coverage

### DIFF
--- a/tests/Cache/BatchCacheTest.php
+++ b/tests/Cache/BatchCacheTest.php
@@ -217,6 +217,86 @@ final class BatchCacheTest extends TestCase
         $this->assertCount(2, $dispatchedCollection);
     }
 
+    public function test_delete_removes_value_held_in_memory(): void
+    {
+        $cache = $this->givenCache(['A1' => 'A1-value']);
+
+        $this->assertTrue($cache->delete('A1'));
+        $this->assertNull($cache->get('A1'));
+    }
+
+    public function test_delete_removes_value_from_persisted_cache_when_not_in_memory(): void
+    {
+        $cache = $this->givenCache([], ['A1' => 'A1-value']);
+
+        $this->assertTrue($cache->delete('A1'));
+        $this->assertNull($cache->get('A1'));
+    }
+
+    public function test_clear_empties_both_memory_and_persisted_cache(): void
+    {
+        $cache = $this->givenCache(['A1' => 'A1-value'], ['A2' => 'A2-value']);
+
+        $this->assertTrue($cache->clear());
+        $this->assertNull($cache->get('A1'));
+        $this->assertNull($cache->get('A2'));
+    }
+
+    public function test_has_returns_true_when_value_is_in_memory(): void
+    {
+        $cache = $this->givenCache(['A1' => 'A1-value']);
+
+        $this->assertTrue($cache->has('A1'));
+    }
+
+    public function test_has_returns_true_when_value_is_in_persisted_cache(): void
+    {
+        $cache = $this->givenCache([], ['A1' => 'A1-value']);
+
+        $this->assertTrue($cache->has('A1'));
+    }
+
+    public function test_has_returns_false_when_value_is_absent(): void
+    {
+        $cache = $this->givenCache();
+
+        $this->assertFalse($cache->has('A1'));
+    }
+
+    public function test_set_multiple_returns_true_without_persisting_when_memory_limit_not_reached(): void
+    {
+        $cache = $this->givenCache([], [], 10);
+
+        $this->assertTrue($cache->setMultiple(['A1' => 'A1-value'], 10000));
+        $this->assertNull($this->cache->get('A1'));
+        $this->assertSame('A1-value', $cache->get('A1'));
+    }
+
+    public function test_set_multiple_uses_default_ttl_when_ttl_argument_is_omitted(): void
+    {
+        config()->set('excel.cache.default_ttl', 1);
+
+        $cache = $this->givenCache([], [], 1);
+        $this->cache->setEventDispatcher(Event::fake());
+        $cache->setMultiple(['A2' => 'A2-value']);
+
+        $dispatchedCollection = Event::dispatched(
+            KeyWritten::class,
+            fn (KeyWritten $event): bool => $event->seconds === 1
+        );
+
+        $this->assertCount(1, $dispatchedCollection);
+    }
+
+    public function test_batch_cache_survives_serialization_roundtrip(): void
+    {
+        $cache = $this->givenCache(['A1' => 'A1-value']);
+
+        $unserialized = unserialize(serialize($cache));
+
+        $this->assertSame('A1-value', $unserialized->get('A1'));
+    }
+
     /**
      * @return array<string, array{int|Closure|null, int|Closure|null}>
      *

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Cache;
+
+use Maatwebsite\Excel\Cache\CacheManager;
+use Maatwebsite\Excel\Tests\TestCase;
+
+final class CacheManagerTest extends TestCase
+{
+    public function test_is_in_memory_returns_true_for_default_memory_driver(): void
+    {
+        config()->set('excel.cache.driver', 'memory');
+
+        $this->assertTrue(app(CacheManager::class)->isInMemory());
+    }
+
+    public function test_is_in_memory_returns_false_for_other_drivers(): void
+    {
+        config()->set('excel.cache.driver', 'illuminate');
+
+        $this->assertFalse(app(CacheManager::class)->isInMemory());
+    }
+
+    public function test_flush_clears_the_default_driver(): void
+    {
+        config()->set('excel.cache.driver', 'memory');
+
+        $manager = app(CacheManager::class);
+        $driver  = $manager->driver();
+        $driver->set('A1', 'value');
+
+        $this->assertTrue($driver->has('A1'));
+
+        $manager->flush();
+
+        $this->assertFalse($driver->has('A1'));
+    }
+}

--- a/tests/CellTest.php
+++ b/tests/CellTest.php
@@ -7,6 +7,11 @@ namespace Maatwebsite\Excel\Tests;
 use Maatwebsite\Excel\Cell;
 use Maatwebsite\Excel\Middleware\ConvertEmptyCellValuesToNull;
 use Maatwebsite\Excel\Middleware\TrimCellValue;
+use Mockery;
+use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
+use PhpOffice\PhpSpreadsheet\Cell\Cell as SpreadsheetCell;
+use PhpOffice\PhpSpreadsheet\RichText\RichText;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 final class CellTest extends TestCase
 {
@@ -47,5 +52,57 @@ final class CellTest extends TestCase
         $this->assertNull(Cell::make($worksheet->getActiveSheet(), 'A2')->getValue());
 
         config()->set('excel.imports.cells.middleware', []);
+    }
+
+    public function test_trim_passes_non_string_values_through_unchanged(): void
+    {
+        $middleware = new TrimCellValue;
+
+        $this->assertSame(42, $middleware(42, fn ($v) => $v));
+        $this->assertNull($middleware(null, fn ($v) => $v));
+    }
+
+    public function test_trim_removes_bom_characters(): void
+    {
+        $middleware = new TrimCellValue;
+
+        $this->assertSame('test', $middleware("\xEF\xBB\xBFtest", fn ($v) => $v));
+    }
+
+    public function test_trim_removes_zero_width_spaces(): void
+    {
+        $middleware = new TrimCellValue;
+
+        $this->assertSame('test', $middleware("\u{200B}test\u{200B}", fn ($v) => $v));
+    }
+
+    public function test_get_delegate_returns_the_underlying_spreadsheet_cell(): void
+    {
+        $worksheet       = (new Spreadsheet)->getActiveSheet();
+        $spreadsheetCell = $worksheet->getCell('A1');
+
+        $this->assertSame($spreadsheetCell, Cell::make($worksheet, 'A1')->getDelegate());
+    }
+
+    public function test_get_value_returns_plain_text_for_rich_text_value(): void
+    {
+        $worksheet = (new Spreadsheet)->getActiveSheet();
+        $richText  = new RichText;
+        $richText->createText('hello world');
+        $worksheet->getCell('A1')->setValue($richText);
+
+        $this->assertSame('hello world', Cell::make($worksheet, 'A1')->getValue());
+    }
+
+    public function test_get_value_falls_back_to_old_calculated_value_when_calculation_throws(): void
+    {
+        $spreadsheetCell = Mockery::mock(SpreadsheetCell::class);
+        $spreadsheetCell->shouldReceive('getValue')->andReturn('=INVALID()');
+        $spreadsheetCell->shouldReceive('getCalculatedValue')->andThrow(new CalculationException('bad formula'));
+        $spreadsheetCell->shouldReceive('getOldCalculatedValue')->andReturn('cached-value');
+
+        $cell = new Cell($spreadsheetCell);
+
+        $this->assertSame('cached-value', $cell->getValue(null, true, false));
     }
 }

--- a/tests/Columns/ColumnApiTest.php
+++ b/tests/Columns/ColumnApiTest.php
@@ -13,6 +13,7 @@ use Maatwebsite\Excel\Columns\Text;
 use Maatwebsite\Excel\ImageContent;
 use Maatwebsite\Excel\Tests\TestCase;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter\Column as FilterColumn;
 use PhpOffice\PhpSpreadsheet\Worksheet\MemoryDrawing;
@@ -235,6 +236,33 @@ final class ColumnApiTest extends TestCase
         $column = Column::make('Rate')->index(1)->formatted();
 
         $this->assertSame('50.00%', $column->read($sheet->getCell('A1')));
+    }
+
+    public function test_type_forces_an_explicit_data_type_when_writing(): void
+    {
+        $sheet = $this->givenSheet();
+
+        $column = Column::make('Attribute')->index(1)->type(DataType::TYPE_STRING);
+        $cell   = $column->write($sheet, 1, ['attribute' => 10]);
+
+        $this->assertSame(DataType::TYPE_STRING, $cell->getDataType());
+        $this->assertSame('10', $cell->getValue());
+    }
+
+    public function test_format_sets_the_column_number_format(): void
+    {
+        $sheet = $this->givenSheet();
+
+        $column = Column::make('Attribute')->index(1)->format('0.00%');
+        $column->write($sheet, 1, ['attribute' => 0.5]);
+        $column->afterWriting($sheet, 1);
+
+        $this->assertSame('0.00%', $sheet->getCell('A1')->getStyle()->getNumberFormat()->getFormatCode());
+    }
+
+    public function test_title_returns_the_column_title(): void
+    {
+        $this->assertSame('Full Name', Column::make('Full Name')->title());
     }
 
     public function test_text_columns_expose_their_key(): void

--- a/tests/Columns/PriceColumnTest.php
+++ b/tests/Columns/PriceColumnTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Columns;
+
+use Maatwebsite\Excel\Columns\Price;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
+
+final class PriceColumnTest extends BaseColumnTestCase
+{
+    public function test_writes_with_the_default_number_format(): void
+    {
+        $this->write(Price::make('Price'), [
+            'price' => 10.5,
+        ]);
+
+        $this->assertCellDataType(DataType::TYPE_NUMERIC);
+        $this->assertNumberFormat(NumberFormat::FORMAT_NUMBER);
+    }
+
+    public function test_currency_sets_a_custom_number_format(): void
+    {
+        $this->write(Price::make('Price')->currency('#,##0.00 "USD"'), [
+            'price' => 10.5,
+        ]);
+
+        $this->assertNumberFormat('#,##0.00 "USD"');
+    }
+
+    public function test_in_euros_uses_the_accounting_eur_format(): void
+    {
+        $this->write(Price::make('Price')->inEuros(), [
+            'price' => 10.5,
+        ]);
+
+        $this->assertNumberFormat(NumberFormat::FORMAT_ACCOUNTING_EUR);
+    }
+
+    public function test_in_dollars_uses_the_accounting_usd_format(): void
+    {
+        $this->write(Price::make('Price')->inDollars(), [
+            'price' => 10.5,
+        ]);
+
+        $this->assertNumberFormat(NumberFormat::FORMAT_ACCOUNTING_USD);
+    }
+}

--- a/tests/Concerns/ImportableTest.php
+++ b/tests/Concerns/ImportableTest.php
@@ -9,6 +9,7 @@ use Maatwebsite\Excel\Concerns\Import;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ToArray;
 use Maatwebsite\Excel\Excel;
+use Maatwebsite\Excel\Exceptions\NoFilePathGivenException;
 use Maatwebsite\Excel\Importer;
 use Maatwebsite\Excel\Tests\TestCase;
 use PHPUnit\Framework\Assert;
@@ -132,6 +133,43 @@ final class ImportableTest extends TestCase
         };
 
         $import->import('doesnotexistanywhere.xlsx');
+    }
+
+    public function test_needs_to_have_a_file_path_when_importing(): void
+    {
+        $this->expectException(NoFilePathGivenException::class);
+        $this->expectExceptionMessage('A filepath or UploadedFile needs to be passed to start the import.');
+
+        $import = new class implements Import
+        {
+            use Importable;
+        };
+
+        $import->import();
+    }
+
+    public function test_needs_to_have_a_file_path_when_converting_to_array(): void
+    {
+        $this->expectException(NoFilePathGivenException::class);
+
+        $import = new class implements Import
+        {
+            use Importable;
+        };
+
+        $import->toArray();
+    }
+
+    public function test_needs_to_have_a_file_path_when_converting_to_collection(): void
+    {
+        $this->expectException(NoFilePathGivenException::class);
+
+        $import = new class implements Import
+        {
+            use Importable;
+        };
+
+        $import->toCollection();
     }
 
     public function test_default_output_style_is_set(): void

--- a/tests/Concerns/WithChunkReadingTest.php
+++ b/tests/Concerns/WithChunkReadingTest.php
@@ -6,6 +6,7 @@ namespace Maatwebsite\Excel\Tests\Concerns;
 
 use DateTime;
 use Exception;
+use Illuminate\Console\OutputStyle;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Maatwebsite\Excel\Concerns\Import;
@@ -17,7 +18,9 @@ use Maatwebsite\Excel\Concerns\WithChunkReading;
 use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Concerns\WithFormatData;
 use Maatwebsite\Excel\Concerns\WithHeadingRow;
+use Maatwebsite\Excel\Concerns\WithLimit;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+use Maatwebsite\Excel\Concerns\WithProgressBar;
 use Maatwebsite\Excel\Events\AfterImport;
 use Maatwebsite\Excel\Events\BeforeImport;
 use Maatwebsite\Excel\Events\ImportFailed;
@@ -25,6 +28,7 @@ use Maatwebsite\Excel\Reader;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\Group;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
 use Maatwebsite\Excel\Tests\TestCase;
+use Mockery;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PHPUnit\Framework\Assert;
 use Throwable;
@@ -455,5 +459,70 @@ final class WithChunkReadingTest extends TestCase
         };
 
         $import->import('import-batches-with-date.xlsx');
+    }
+
+    public function test_reports_progress_when_importing_in_chunks(): void
+    {
+        $import = new class implements ToModel, WithChunkReading, WithProgressBar
+        {
+            use Importable;
+
+            public function model(array $row): User
+            {
+                return new User([
+                    'name'     => $row[0],
+                    'email'    => $row[1],
+                    'password' => 'secret',
+                ]);
+            }
+
+            public function chunkSize(): int
+            {
+                return 1;
+            }
+        };
+
+        $output = Mockery::mock(OutputStyle::class);
+        $output->shouldReceive('progressStart')->once()->with(2)->andReturnSelf();
+        $output->shouldReceive('progressAdvance')->twice()->andReturnSelf();
+        $output->shouldReceive('progressFinish')->once()->andReturnSelf();
+
+        $import->withOutput($output);
+        $import->import('import-users.xlsx');
+
+        $this->assertSame(2, User::count());
+    }
+
+    public function test_can_limit_rows_when_importing_in_chunks(): void
+    {
+        $import = new class implements ToArray, WithChunkReading, WithLimit
+        {
+            use Importable;
+
+            public int $called = 0;
+
+            public function array(array $array): void
+            {
+                $this->called++;
+
+                Assert::assertSame([
+                    ['Patrick Brouwers', 'patrick@maatwebsite.nl'],
+                ], $array);
+            }
+
+            public function chunkSize(): int
+            {
+                return 1;
+            }
+
+            public function limit(): int
+            {
+                return 1;
+            }
+        };
+
+        $import->import('import-users.xlsx');
+
+        $this->assertSame(1, $import->called, 'Row count was not limited during chunked reading.');
     }
 }

--- a/tests/Concerns/WithMappedCellsTest.php
+++ b/tests/Concerns/WithMappedCellsTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\ToArray;
+use Maatwebsite\Excel\Concerns\ToCollection;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithMappedCells;
 use Maatwebsite\Excel\Tests\Data\Stubs\Database\User;
@@ -83,6 +85,32 @@ final class WithMappedCellsTest extends TestCase
                         'email' => 'typingbeaver@mailbox.org',
                     ],
                 ], $array);
+            }
+        };
+
+        $import->import('mapped-import.xlsx');
+    }
+
+    public function test_can_import_with_references_to_cells_to_collection(): void
+    {
+        $import = new class implements ToCollection, WithMappedCells
+        {
+            use Importable;
+
+            public function mapping(): array
+            {
+                return [
+                    'name'  => 'B1',
+                    'email' => 'B2',
+                ];
+            }
+
+            public function collection(Collection $collection): void
+            {
+                Assert::assertSame([
+                    'name'  => 'Patrick Brouwers',
+                    'email' => 'patrick@maatwebsite.nl',
+                ], $collection->toArray());
             }
         };
 

--- a/tests/Events/EventsTest.php
+++ b/tests/Events/EventsTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Events;
+
+use Maatwebsite\Excel\Concerns\Export;
+use Maatwebsite\Excel\Concerns\Import;
+use Maatwebsite\Excel\Events\AfterBatch;
+use Maatwebsite\Excel\Events\AfterChunk;
+use Maatwebsite\Excel\Events\AfterImport;
+use Maatwebsite\Excel\Events\BeforeExport;
+use Maatwebsite\Excel\Events\BeforeImport;
+use Maatwebsite\Excel\Events\BeforeSheet;
+use Maatwebsite\Excel\Imports\ModelManager;
+use Maatwebsite\Excel\Reader;
+use Maatwebsite\Excel\Sheet;
+use Maatwebsite\Excel\Tests\TestCase;
+use Maatwebsite\Excel\Writer;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+
+final class EventsTest extends TestCase
+{
+    public function test_after_batch_getters_return_the_given_values(): void
+    {
+        $manager    = app(ModelManager::class);
+        $importable = new class implements Import
+        {
+        };
+
+        $event = new AfterBatch($manager, $importable, 50, 10);
+
+        $this->assertSame($manager, $event->manager);
+        $this->assertSame($manager, $event->getManager());
+        $this->assertSame($manager, $event->getDelegate());
+        $this->assertSame(50, $event->getBatchSize());
+        $this->assertSame(10, $event->getStartRow());
+        $this->assertSame($importable, $event->getConcernable());
+    }
+
+    public function test_before_export_getters_return_the_given_writer(): void
+    {
+        $writer     = app(Writer::class);
+        $exportable = new class implements Export
+        {
+        };
+
+        $event = new BeforeExport($writer, $exportable);
+
+        $this->assertSame($writer, $event->writer);
+        $this->assertSame($writer, $event->getWriter());
+        $this->assertSame($writer, $event->getDelegate());
+        $this->assertSame($exportable, $event->getConcernable());
+    }
+
+    public function test_before_import_getters_return_the_given_reader(): void
+    {
+        $reader     = app(Reader::class);
+        $importable = new class implements Import
+        {
+        };
+
+        $event = new BeforeImport($reader, $importable);
+
+        $this->assertSame($reader, $event->reader);
+        $this->assertSame($reader, $event->getReader());
+        $this->assertSame($reader, $event->getDelegate());
+        $this->assertSame($importable, $event->getConcernable());
+    }
+
+    public function test_after_import_getters_return_the_given_reader(): void
+    {
+        $reader     = app(Reader::class);
+        $importable = new class implements Import
+        {
+        };
+
+        $event = new AfterImport($reader, $importable);
+
+        $this->assertSame($reader, $event->reader);
+        $this->assertSame($reader, $event->getReader());
+        $this->assertSame($reader, $event->getDelegate());
+        $this->assertSame($importable, $event->getConcernable());
+    }
+
+    public function test_before_sheet_getters_return_the_given_sheet(): void
+    {
+        $sheet       = new Sheet((new Spreadsheet)->getActiveSheet());
+        $concernable = new class implements Export
+        {
+        };
+
+        $event = new BeforeSheet($sheet, $concernable);
+
+        $this->assertSame($sheet, $event->sheet);
+        $this->assertSame($sheet, $event->getSheet());
+        $this->assertSame($sheet, $event->getDelegate());
+        $this->assertSame($concernable, $event->getConcernable());
+    }
+
+    public function test_after_chunk_getters_return_the_given_values(): void
+    {
+        $sheet       = new Sheet((new Spreadsheet)->getActiveSheet());
+        $concernable = new class implements Import
+        {
+        };
+
+        $event = new AfterChunk($sheet, $concernable, 25);
+
+        $this->assertSame($sheet, $event->getSheet());
+        $this->assertSame($sheet, $event->getDelegate());
+        $this->assertSame(25, $event->getStartRow());
+        $this->assertSame($concernable, $event->getConcernable());
+    }
+
+    public function test_applies_to_concern_checks_the_concernable_type(): void
+    {
+        $sheet       = new Sheet((new Spreadsheet)->getActiveSheet());
+        $concernable = new class implements Export
+        {
+        };
+
+        $event = new BeforeSheet($sheet, $concernable);
+
+        $this->assertTrue($event->appliesToConcern($concernable::class));
+        $this->assertFalse($event->appliesToConcern(Import::class));
+    }
+}

--- a/tests/HeadingRowImportTest.php
+++ b/tests/HeadingRowImportTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Maatwebsite\Excel\Tests;
 
+use InvalidArgumentException;
 use Maatwebsite\Excel\HeadingRowImport;
 use Maatwebsite\Excel\Imports\HeadingRowFormatter;
 
@@ -141,5 +142,28 @@ final class HeadingRowImportTest extends TestCase
                 ['custom2-name', 'custom2-email'],
             ],
         ], $headings);
+    }
+
+    public function test_formatter_none_returns_headings_unchanged(): void
+    {
+        HeadingRowFormatter::default(HeadingRowFormatter::FORMATTER_NONE);
+
+        $import = new HeadingRowImport;
+
+        $headings = $import->toArray('import-users-with-headings.xlsx');
+
+        $this->assertSame([
+            [
+                ['name', 'email'],
+            ],
+        ], $headings);
+    }
+
+    public function test_default_throws_for_unknown_formatter_name(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Formatter "nonexistent" does not exist');
+
+        HeadingRowFormatter::default('nonexistent');
     }
 }

--- a/tests/Helpers/FileTypeDetectorTest.php
+++ b/tests/Helpers/FileTypeDetectorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Helpers;
+
+use Maatwebsite\Excel\Exceptions\NoTypeDetectedException;
+use Maatwebsite\Excel\Helpers\FileTypeDetector;
+use Maatwebsite\Excel\Tests\TestCase;
+
+final class FileTypeDetectorTest extends TestCase
+{
+    public function test_detect_returns_explicitly_passed_type_without_extension_lookup(): void
+    {
+        $this->assertSame('Xlsx', FileTypeDetector::detect('anything.csv', 'Xlsx'));
+    }
+
+    public function test_detect_resolves_type_from_file_path_extension(): void
+    {
+        $this->assertSame('Xlsx', FileTypeDetector::detect('test.xlsx'));
+    }
+
+    public function test_detect_resolves_type_from_uploaded_file_extension(): void
+    {
+        $file = $this->givenUploadedFile(
+            __DIR__ . '/../Data/Disks/Local/import-users.xlsx',
+            'upload.xlsx'
+        );
+
+        $this->assertSame('Xlsx', FileTypeDetector::detect($file));
+    }
+
+    public function test_detect_throws_when_file_path_has_no_extension(): void
+    {
+        $this->expectException(NoTypeDetectedException::class);
+
+        FileTypeDetector::detect('filename-without-extension');
+    }
+
+    public function test_detect_strict_returns_type_for_known_extension(): void
+    {
+        $this->assertSame('Xlsx', FileTypeDetector::detectStrict('test.xlsx'));
+    }
+
+    public function test_detect_strict_throws_for_extension_not_in_config(): void
+    {
+        $this->expectException(NoTypeDetectedException::class);
+
+        FileTypeDetector::detectStrict('test.unknown_format_xyz');
+    }
+}

--- a/tests/Helpers/RichTextReaderTest.php
+++ b/tests/Helpers/RichTextReaderTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Helpers;
+
+use Maatwebsite\Excel\Helpers\RichTextReader;
+use Maatwebsite\Excel\Tests\TestCase;
+use PhpOffice\PhpSpreadsheet\RichText\RichText;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Font;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+final class RichTextReaderTest extends TestCase
+{
+    private Worksheet $sheet;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sheet = (new Spreadsheet)->getActiveSheet();
+    }
+
+    public function test_returns_plain_string_value_as_string(): void
+    {
+        $this->sheet->getCell('A1')->setValue('hello world');
+
+        $this->assertSame('hello world', RichTextReader::toHtml($this->sheet->getCell('A1')));
+    }
+
+    public function test_plain_text_element_is_returned_without_span(): void
+    {
+        $richText = new RichText;
+        $richText->createText('plain text');
+        $this->sheet->getCell('A1')->setValue($richText);
+
+        $result = RichTextReader::toHtml($this->sheet->getCell('A1'));
+
+        $this->assertSame('plain text', $result);
+        $this->assertStringNotContainsString('<span', $result);
+    }
+
+    public function test_html_special_chars_are_escaped_in_plain_text_element(): void
+    {
+        $richText = new RichText;
+        $richText->createText('<b>not bold</b>');
+        $this->sheet->getCell('A1')->setValue($richText);
+
+        $result = RichTextReader::toHtml($this->sheet->getCell('A1'));
+
+        $this->assertStringContainsString('&lt;b&gt;not bold&lt;/b&gt;', $result);
+    }
+
+    public function test_run_element_is_wrapped_in_span(): void
+    {
+        $richText = new RichText;
+        $richText->createTextRun('styled text');
+        $this->sheet->getCell('A1')->setValue($richText);
+
+        $result = RichTextReader::toHtml($this->sheet->getCell('A1'));
+
+        $this->assertStringContainsString('<span', $result);
+        $this->assertStringContainsString('styled text', $result);
+        $this->assertStringContainsString('</span>', $result);
+    }
+
+    public function test_bold_font_adds_font_weight_css(): void
+    {
+        $richText = new RichText;
+        $run      = $richText->createTextRun('bold text');
+        $run->getFont()->setBold(true);
+        $this->sheet->getCell('A1')->setValue($richText);
+
+        $this->assertStringContainsString('font-weight:bold', RichTextReader::toHtml($this->sheet->getCell('A1')));
+    }
+
+    public function test_italic_font_adds_font_style_css(): void
+    {
+        $richText = new RichText;
+        $run      = $richText->createTextRun('italic text');
+        $run->getFont()->setItalic(true);
+        $this->sheet->getCell('A1')->setValue($richText);
+
+        $this->assertStringContainsString('font-style:italic', RichTextReader::toHtml($this->sheet->getCell('A1')));
+    }
+
+    public function test_underline_adds_underline_text_decoration(): void
+    {
+        $richText = new RichText;
+        $run      = $richText->createTextRun('underlined text');
+        $run->getFont()->setUnderline(Font::UNDERLINE_SINGLE);
+        $this->sheet->getCell('A1')->setValue($richText);
+
+        $this->assertStringContainsString('text-decoration:underline', RichTextReader::toHtml($this->sheet->getCell('A1')));
+    }
+
+    public function test_strikethrough_adds_line_through_text_decoration(): void
+    {
+        $richText = new RichText;
+        $run      = $richText->createTextRun('struck text');
+        $run->getFont()->setStrikethrough(true);
+        $this->sheet->getCell('A1')->setValue($richText);
+
+        $this->assertStringContainsString('text-decoration:line-through', RichTextReader::toHtml($this->sheet->getCell('A1')));
+    }
+
+    public function test_underline_and_strikethrough_are_combined_in_text_decoration(): void
+    {
+        $richText = new RichText;
+        $run      = $richText->createTextRun('combined');
+        $run->getFont()->setUnderline(Font::UNDERLINE_SINGLE);
+        $run->getFont()->setStrikethrough(true);
+        $this->sheet->getCell('A1')->setValue($richText);
+
+        $this->assertStringContainsString('text-decoration:underline line-through', RichTextReader::toHtml($this->sheet->getCell('A1')));
+    }
+
+    public function test_superscript_wraps_text_in_sup_tag(): void
+    {
+        $richText = new RichText;
+        $run      = $richText->createTextRun('sup');
+        $run->getFont()->setSuperscript(true);
+        $this->sheet->getCell('A1')->setValue($richText);
+
+        $result = RichTextReader::toHtml($this->sheet->getCell('A1'));
+
+        $this->assertStringContainsString('<sup>sup</sup>', $result);
+    }
+
+    public function test_subscript_wraps_text_in_sub_tag(): void
+    {
+        $richText = new RichText;
+        $run      = $richText->createTextRun('sub');
+        $run->getFont()->setSubscript(true);
+        $this->sheet->getCell('A1')->setValue($richText);
+
+        $result = RichTextReader::toHtml($this->sheet->getCell('A1'));
+
+        $this->assertStringContainsString('<sub>sub</sub>', $result);
+    }
+
+    public function test_multiple_elements_are_concatenated(): void
+    {
+        $richText = new RichText;
+        $richText->createText('plain ');
+        $run = $richText->createTextRun('bold');
+        $run->getFont()->setBold(true);
+        $this->sheet->getCell('A1')->setValue($richText);
+
+        $result = RichTextReader::toHtml($this->sheet->getCell('A1'));
+
+        $this->assertStringContainsString('plain ', $result);
+        $this->assertStringContainsString('font-weight:bold', $result);
+    }
+}

--- a/tests/Jobs/AfterImportJobTest.php
+++ b/tests/Jobs/AfterImportJobTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Jobs;
+
+use Carbon\CarbonImmutable;
+use Exception;
+use Maatwebsite\Excel\Concerns\Import;
+use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\RegistersEventListeners;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Events\ImportFailed;
+use Maatwebsite\Excel\Jobs\AfterImportJob;
+use Maatwebsite\Excel\Reader;
+use Maatwebsite\Excel\Tests\TestCase;
+use Mockery;
+use Throwable;
+
+final class AfterImportJobTest extends TestCase
+{
+    public function test_handle_returns_early_when_batch_is_cancelled(): void
+    {
+        $import = new class implements Import
+        {
+            use Importable;
+        };
+
+        // A full mock without any stubbed methods: if handle() proceeds past
+        // the cancellation check, any call to $reader will fail the test.
+        $reader = Mockery::mock(Reader::class);
+
+        $job           = new AfterImportJob($import, $reader);
+        [$job, $batch] = $job->withFakeBatch(cancelledAt: CarbonImmutable::now());
+
+        $job->handle();
+
+        $this->assertTrue($batch->cancelled());
+    }
+
+    public function test_failed_raises_import_failed_event_when_import_uses_events(): void
+    {
+        $exception = new Exception('boom');
+
+        $import = new class implements Import, WithEvents
+        {
+            use Importable, RegistersEventListeners;
+
+            public bool $eventRaised = false;
+
+            public ?Throwable $failedException = null;
+
+            public function importFailed(ImportFailed $event): void
+            {
+                $this->eventRaised = true;
+            }
+
+            public function failed(Throwable $e): void
+            {
+                $this->failedException = $e;
+            }
+        };
+
+        $job = new AfterImportJob($import, Mockery::mock(Reader::class));
+        $job->failed($exception);
+
+        $this->assertTrue($import->eventRaised);
+        $this->assertSame($exception, $import->failedException);
+    }
+
+    public function test_failed_does_nothing_when_import_does_not_use_events(): void
+    {
+        $import = new class implements Import
+        {
+            use Importable;
+
+            public ?Throwable $failedException = null;
+
+            public function failed(Throwable $e): void
+            {
+                $this->failedException = $e;
+            }
+        };
+
+        $job = new AfterImportJob($import, Mockery::mock(Reader::class));
+        $job->failed(new Exception('boom'));
+
+        $this->assertNotInstanceOf(Throwable::class, $import->failedException);
+    }
+}


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?

The test suite was strong on integration-level coverage of concerns, but several utility, cache, event, and column classes had thin or zero direct coverage — meaning regressions in that logic could slip through even though line-level tools flagged them as gaps. This PR closes the most impactful of those gaps with focused unit tests, without chasing 100% coverage for its own sake.

Total line coverage:
Before: 88.16%
After: 90.56%


Highlights:

- **`Cell`, `RichTextReader`, `FileTypeDetector`** - previously untested branches: rich-text plain-text extraction, the calculated-formula exception fallback (`getOldCalculatedValue`), BOM/zero-width-space trimming, and the `detectStrict()` failure path.
- **`Jobs\AfterImportJob`** - the cancelled-batch early return and the `failed()` handler (which should raise `ImportFailed` and call the import's own `failed()` method when it uses `WithEvents`) were both completely unexercised.
- **`Events\*` getters** - these used to be verified with `assertInstanceOf()`, which became redundant once the properties got native types. Replaced/added with `assertSame()` identity checks so the getters themselves are actually exercised.
- **`ChunkReader`** - progress bar reporting (`progressStart`/`progressFinish`) and `WithLimit` capping were untested when combined with `WithChunkReading`.
- **`MappedReader`** - the `ToCollection` branch of `WithMappedCells` had no test (only `ToArray`/`ToModel` did).
- **`Cache\BatchCache` / `CacheManager`** - `delete()`, `clear()`, `has()`, the serialization round-trip (`__sleep`/`__wakeup`), and both the default-TTL and memory-limit branches were untested. `CacheManager::flush()` and `isInMemory()` had no tests at all. Deprecated PSR cache adapters were deliberately left untouched.
- **`Columns\Price`** and **`Columns\Column::type()/format()/title()`** - these were exercised only from inside a PHPUnit static data-provider (`yield`), a pattern Xdebug doesn't attribute to coverage even though the code runs. Added direct, non-data-provider tests so the coverage tooling reflects reality.
- **`Concerns\Importable::getFilePath()`** - the `NoFilePathGivenException` throw path was covered for `Exportable` but not for `Importable`; added the missing `import()`/`toArray()`/`toCollection()` cases.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

Only tests were added

3️⃣  Does it include tests, if possible?

Yes - this PR is tests only. No production code changed.

4️⃣  Any drawbacks? Possible breaking changes?

None. No `src/` changes; purely additive test coverage.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.