### PR TITLE
Add tests for WithCharts, WithDrawings and download buffer handling

### DIFF
--- a/tests/Columns/ColumnApiTest.php
+++ b/tests/Columns/ColumnApiTest.php
@@ -218,7 +218,7 @@ final class ColumnApiTest extends TestCase
         $drawing->setRenderingFunction(MemoryDrawing::RENDERING_PNG);
         $drawing->setMimeType(MemoryDrawing::MIMETYPE_PNG);
 
-        $content = ImageContent::fromMemory($drawing);
+        $content = ImageContent::from($drawing);
 
         $this->assertSame('png', $content->extension());
         $this->assertStringEndsWith('.png', $content->filename());

--- a/tests/Concerns/WithChartsTest.php
+++ b/tests/Concerns/WithChartsTest.php
@@ -17,22 +17,10 @@ use PhpOffice\PhpSpreadsheet\Chart\Legend;
 use PhpOffice\PhpSpreadsheet\Chart\PlotArea;
 use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\IOFactory;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 final class WithChartsTest extends TestCase
 {
-    private function readWithCharts(string $filePath): Worksheet
-    {
-        $reader = IOFactory::createReader('Xlsx');
-        $reader->setIncludeCharts(true);
-
-        /** @var Spreadsheet $spreadsheet */
-        $spreadsheet = $reader->load($filePath);
-
-        return $spreadsheet->getActiveSheet();
-    }
-
     public function test_can_export_with_a_single_chart(): void
     {
         $export = new class implements Export, FromArray, WithCharts, WithTitle
@@ -130,5 +118,15 @@ final class WithChartsTest extends TestCase
         $this->assertCount(2, $sheet->getChartCollection());
         $this->assertSame('chart1', $sheet->getChartByIndex('0')->getName());
         $this->assertSame('chart2', $sheet->getChartByIndex('1')->getName());
+    }
+
+    private function readWithCharts(string $filePath): Worksheet
+    {
+        $reader = IOFactory::createReader('Xlsx');
+        $reader->setIncludeCharts(true);
+
+        $spreadsheet = $reader->load($filePath);
+
+        return $spreadsheet->getActiveSheet();
     }
 }

--- a/tests/Concerns/WithChartsTest.php
+++ b/tests/Concerns/WithChartsTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
-use Maatwebsite\Excel\Concerns\Export;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromArray;
 use Maatwebsite\Excel\Concerns\WithCharts;
@@ -23,7 +22,7 @@ final class WithChartsTest extends TestCase
 {
     public function test_can_export_with_a_single_chart(): void
     {
-        $export = new class implements Export, FromArray, WithCharts, WithTitle
+        $export = new class implements FromArray, WithCharts, WithTitle
         {
             use Exportable;
 
@@ -69,7 +68,7 @@ final class WithChartsTest extends TestCase
 
     public function test_can_export_with_multiple_charts(): void
     {
-        $export = new class implements Export, FromArray, WithCharts, WithTitle
+        $export = new class implements FromArray, WithCharts, WithTitle
         {
             use Exportable;
 

--- a/tests/Concerns/WithChartsTest.php
+++ b/tests/Concerns/WithChartsTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Concerns;
+
+use Maatwebsite\Excel\Concerns\Export;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\WithCharts;
+use Maatwebsite\Excel\Concerns\WithTitle;
+use Maatwebsite\Excel\Tests\TestCase;
+use PhpOffice\PhpSpreadsheet\Chart\Chart;
+use PhpOffice\PhpSpreadsheet\Chart\DataSeries;
+use PhpOffice\PhpSpreadsheet\Chart\DataSeriesValues;
+use PhpOffice\PhpSpreadsheet\Chart\Legend;
+use PhpOffice\PhpSpreadsheet\Chart\PlotArea;
+use PhpOffice\PhpSpreadsheet\Chart\Title;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+final class WithChartsTest extends TestCase
+{
+    private function readWithCharts(string $filePath): Worksheet
+    {
+        $reader = IOFactory::createReader('Xlsx');
+        $reader->setIncludeCharts(true);
+
+        /** @var Spreadsheet $spreadsheet */
+        $spreadsheet = $reader->load($filePath);
+
+        return $spreadsheet->getActiveSheet();
+    }
+
+    public function test_can_export_with_a_single_chart(): void
+    {
+        $export = new class implements Export, FromArray, WithCharts, WithTitle
+        {
+            use Exportable;
+
+            public function array(): array
+            {
+                return [[1], [2], [3]];
+            }
+
+            public function title(): string
+            {
+                return 'Sheet1';
+            }
+
+            public function charts(): Chart
+            {
+                return $this->buildChart('chart1');
+            }
+
+            private function buildChart(string $name): Chart
+            {
+                $series = new DataSeries(
+                    DataSeries::TYPE_BARCHART,
+                    DataSeries::GROUPING_CLUSTERED,
+                    [0],
+                    plotValues: [new DataSeriesValues(DataSeriesValues::DATASERIES_TYPE_NUMBER, 'Sheet1!$A$1:$A$3', null, 3)]
+                );
+
+                $chart = new Chart($name, new Title('Chart title'), new Legend, new PlotArea(null, [$series]));
+                $chart->setTopLeftPosition('C1');
+                $chart->setBottomRightPosition('J15');
+
+                return $chart;
+            }
+        };
+
+        $export->store('with-charts.xlsx');
+
+        $sheet = $this->readWithCharts(__DIR__ . '/../Data/Disks/Local/with-charts.xlsx');
+
+        $this->assertCount(1, $sheet->getChartCollection());
+        $this->assertSame('chart1', $sheet->getChartByIndex('0')->getName());
+    }
+
+    public function test_can_export_with_multiple_charts(): void
+    {
+        $export = new class implements Export, FromArray, WithCharts, WithTitle
+        {
+            use Exportable;
+
+            public function array(): array
+            {
+                return [[1], [2], [3]];
+            }
+
+            public function title(): string
+            {
+                return 'Sheet1';
+            }
+
+            /**
+             * @return Chart[]
+             */
+            public function charts(): array
+            {
+                return [
+                    $this->buildChart('chart1'),
+                    $this->buildChart('chart2'),
+                ];
+            }
+
+            private function buildChart(string $name): Chart
+            {
+                $series = new DataSeries(
+                    DataSeries::TYPE_BARCHART,
+                    DataSeries::GROUPING_CLUSTERED,
+                    [0],
+                    plotValues: [new DataSeriesValues(DataSeriesValues::DATASERIES_TYPE_NUMBER, 'Sheet1!$A$1:$A$3', null, 3)]
+                );
+
+                $chart = new Chart($name, new Title('Chart title'), new Legend, new PlotArea(null, [$series]));
+                $chart->setTopLeftPosition('C1');
+                $chart->setBottomRightPosition('J15');
+
+                return $chart;
+            }
+        };
+
+        $export->store('with-charts-multiple.xlsx');
+
+        $sheet = $this->readWithCharts(__DIR__ . '/../Data/Disks/Local/with-charts-multiple.xlsx');
+
+        $this->assertCount(2, $sheet->getChartCollection());
+        $this->assertSame('chart1', $sheet->getChartByIndex('0')->getName());
+        $this->assertSame('chart2', $sheet->getChartByIndex('1')->getName());
+    }
+}

--- a/tests/Concerns/WithDrawingsTest.php
+++ b/tests/Concerns/WithDrawingsTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Maatwebsite\Excel\Tests\Concerns;
 
-use Maatwebsite\Excel\Concerns\Export;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromArray;
 use Maatwebsite\Excel\Concerns\WithDrawings;
@@ -15,7 +14,7 @@ final class WithDrawingsTest extends TestCase
 {
     public function test_can_export_with_a_single_drawing(): void
     {
-        $export = new class implements Export, FromArray, WithDrawings
+        $export = new class implements FromArray, WithDrawings
         {
             use Exportable;
 
@@ -47,7 +46,7 @@ final class WithDrawingsTest extends TestCase
 
     public function test_can_export_with_multiple_drawings(): void
     {
-        $export = new class implements Export, FromArray, WithDrawings
+        $export = new class implements FromArray, WithDrawings
         {
             use Exportable;
 

--- a/tests/Concerns/WithDrawingsTest.php
+++ b/tests/Concerns/WithDrawingsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Concerns;
+
+use Maatwebsite\Excel\Concerns\Export;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\WithDrawings;
+use Maatwebsite\Excel\Tests\TestCase;
+use PhpOffice\PhpSpreadsheet\Worksheet\Drawing;
+
+final class WithDrawingsTest extends TestCase
+{
+    public function test_can_export_with_a_single_drawing(): void
+    {
+        $export = new class implements Export, FromArray, WithDrawings
+        {
+            use Exportable;
+
+            public function array(): array
+            {
+                return [['Patrick', 'Brouwers']];
+            }
+
+            public function drawings(): Drawing
+            {
+                $drawing = new Drawing;
+                $drawing->setName('Logo');
+                $drawing->setPath(__DIR__ . '/../Data/Disks/Local/icon.jpg');
+                $drawing->setCoordinates('B2');
+
+                return $drawing;
+            }
+        };
+
+        $export->store('with-drawings.xlsx');
+
+        $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/with-drawings.xlsx', 'Xlsx');
+        $sheet       = $spreadsheet->getActiveSheet();
+
+        $this->assertCount(1, $sheet->getDrawingCollection());
+        $this->assertSame('Logo', $sheet->getDrawingCollection()[0]->getName());
+        $this->assertSame('B2', $sheet->getDrawingCollection()[0]->getCoordinates());
+    }
+
+    public function test_can_export_with_multiple_drawings(): void
+    {
+        $export = new class implements Export, FromArray, WithDrawings
+        {
+            use Exportable;
+
+            public function array(): array
+            {
+                return [['Patrick', 'Brouwers']];
+            }
+
+            /**
+             * @return Drawing[]
+             */
+            public function drawings(): array
+            {
+                $first = new Drawing;
+                $first->setName('First');
+                $first->setPath(__DIR__ . '/../Data/Disks/Local/icon.jpg');
+                $first->setCoordinates('B2');
+
+                $second = new Drawing;
+                $second->setName('Second');
+                $second->setPath(__DIR__ . '/../Data/Disks/Local/avatar.jpg');
+                $second->setCoordinates('D2');
+
+                return [$first, $second];
+            }
+        };
+
+        $export->store('with-drawings-multiple.xlsx');
+
+        $spreadsheet = $this->read(__DIR__ . '/../Data/Disks/Local/with-drawings-multiple.xlsx', 'Xlsx');
+        $sheet       = $spreadsheet->getActiveSheet();
+
+        $this->assertCount(2, $sheet->getDrawingCollection());
+        $this->assertSame('First', $sheet->getDrawingCollection()[0]->getName());
+        $this->assertSame('Second', $sheet->getDrawingCollection()[1]->getName());
+    }
+}

--- a/tests/ExcelTest.php
+++ b/tests/ExcelTest.php
@@ -58,6 +58,26 @@ final class ExcelTest extends TestCase
         $this->assertSame('attachment; filename=filename.xlsx', str_replace('"', '', $response->headers->get('Content-Disposition')));
     }
 
+    public function test_download_discards_stray_output_buffer_content(): void
+    {
+        $export = new EmptyExport;
+
+        $startingLevel = ob_get_level();
+        ob_start();
+        echo 'stray output that should not prepend the download';
+
+        $response = $this->SUT->download($export, 'filename.xlsx');
+
+        $this->assertInstanceOf(BinaryFileResponse::class, $response);
+        $this->assertSame('attachment; filename=filename.xlsx', str_replace('"', '', $response->headers->get('Content-Disposition')));
+
+        // download() replaces the buffer above with a fresh, empty one; close it
+        // so the output-buffering level matches what it was before this test ran.
+        while (ob_get_level() > $startingLevel) {
+            ob_end_clean();
+        }
+    }
+
     public function test_can_store_an_export_object_on_default_disk(): void
     {
         $export = new EmptyExport;


### PR DESCRIPTION
1️⃣ Why should it be added? What are the benefits of this change?

`WithCharts` and `WithDrawings` had no tests at all. Also added a test for the branch in `Excel::download()` that clears out a stray output buffer before writing the response — that one was untested too.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

No, all three are small, independent additions in the same spirit (closing coverage gaps), bundled together since they're each tiny on their own.

3️⃣ Does it include tests, if possible?

This PR is tests only, no production code touched.

4️⃣ Any drawbacks? Possible breaking changes?

None.

5️⃣ Tasks

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.