### PR TITLE
Fix infinite recursion when WithMultipleSheets references itself in sheets()

### DIFF
--- a/src/Columns/ColumnCollection.php
+++ b/src/Columns/ColumnCollection.php
@@ -9,9 +9,9 @@ use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\WithColumns;
 use Maatwebsite\Excel\Concerns\WithFormatData;
 use Maatwebsite\Excel\Concerns\WithHeadingRow;
-use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 use Maatwebsite\Excel\Concerns\WithStrictNullComparison;
 use Maatwebsite\Excel\Exceptions\ColumnCollisionException;
+use Maatwebsite\Excel\Helpers\ConcernTree;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Exception;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
@@ -101,22 +101,16 @@ class ColumnCollection extends Collection
      */
     public static function requiresStyleInformation(?object $concernable): bool
     {
-        if ($concernable instanceof WithMultipleSheets) {
-            foreach ($concernable->sheets() as $sheetConcernable) {
-                if (static::requiresStyleInformation($sheetConcernable)) {
-                    return true;
-                }
+        foreach (ConcernTree::flatten($concernable) as $node) {
+            if (!$node instanceof WithColumns) {
+                continue;
             }
-        }
 
-        if (!$concernable instanceof WithColumns) {
-            return false;
-        }
-
-        foreach ($concernable->columns() as $column) {
-            foreach (Arr::wrap($column) as $definition) {
-                if ($definition->needsStyleInformation()) {
-                    return true;
+            foreach ($node->columns() as $column) {
+                foreach (Arr::wrap($column) as $definition) {
+                    if ($definition->needsStyleInformation()) {
+                        return true;
+                    }
                 }
             }
         }

--- a/src/Factories/WriterFactory.php
+++ b/src/Factories/WriterFactory.php
@@ -9,6 +9,7 @@ use Maatwebsite\Excel\Concerns\WithCharts;
 use Maatwebsite\Excel\Concerns\WithCustomCsvSettings;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 use Maatwebsite\Excel\Concerns\WithPreCalculateFormulas;
+use Maatwebsite\Excel\Helpers\ConcernTree;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Csv;
@@ -73,15 +74,9 @@ class WriterFactory
 
     private static function includesCharts(Export $export): bool
     {
-        if ($export instanceof WithCharts) {
-            return true;
-        }
-
-        if ($export instanceof WithMultipleSheets) {
-            foreach ($export->sheets() as $sheet) {
-                if ($sheet instanceof WithCharts) {
-                    return true;
-                }
+        foreach (ConcernTree::flatten($export) as $node) {
+            if ($node instanceof WithCharts) {
+                return true;
             }
         }
 

--- a/src/Helpers/ConcernTree.php
+++ b/src/Helpers/ConcernTree.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Helpers;
+
+use Maatwebsite\Excel\Concerns\Export;
+use Maatwebsite\Excel\Concerns\Import;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+use SplObjectStorage;
+
+/**
+ * @internal
+ */
+final class ConcernTree
+{
+    /**
+     * Returns a flat SplObjectStorage of every unique node in the concernable
+     * tree (root + all sheet descendants), safe against cycles.
+     *
+     * Two cycle patterns are handled:
+     *  - Identity cycles ($this returned from sheets()): caught by the shared
+     *    SplObjectStorage visited set.
+     *  - Class-level cycles (new self() or A->B->new A()): caught by tracking
+     *    class names along the current ancestry path (array passed by value so
+     *    sibling branches are not affected).
+     *
+     * @return SplObjectStorage<Export|Import, mixed>
+     */
+    public static function flatten(Export|Import|null $root): SplObjectStorage
+    {
+        /** @var SplObjectStorage<Export|Import, mixed> $storage */
+        $storage = new SplObjectStorage;
+        self::collect($root, $storage, []);
+
+        return $storage;
+    }
+
+    /**
+     * @param  SplObjectStorage<Export|Import, mixed>  $visited
+     * @param  array<class-string<Export|Import>, true>  $ancestorClasses
+     */
+    private static function collect(Export|Import|null $node, SplObjectStorage $visited, array $ancestorClasses): void
+    {
+        if ($node === null || $visited->contains($node)) {
+            return;
+        }
+
+        if ($node instanceof WithMultipleSheets) {
+            $class = $node::class;
+
+            if (isset($ancestorClasses[$class])) {
+                return; // class-level cycle — skip entirely, do not attach
+            }
+
+            $visited->attach($node);
+            $ancestorClasses[$class] = true;
+
+            foreach ($node->sheets() as $sheet) {
+                self::collect($sheet, $visited, $ancestorClasses);
+            }
+        } else {
+            $visited->attach($node);
+        }
+    }
+}

--- a/tests/Columns/ColumnApiTest.php
+++ b/tests/Columns/ColumnApiTest.php
@@ -10,6 +10,9 @@ use Maatwebsite\Excel\Columns\ColumnCollection;
 use Maatwebsite\Excel\Columns\Hyperlink;
 use Maatwebsite\Excel\Columns\Percentage;
 use Maatwebsite\Excel\Columns\Text;
+use Maatwebsite\Excel\Concerns\Import;
+use Maatwebsite\Excel\Concerns\WithColumns;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 use Maatwebsite\Excel\ImageContent;
 use Maatwebsite\Excel\Tests\TestCase;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
@@ -273,6 +276,58 @@ final class ColumnApiTest extends TestCase
 
         // Renaming the key must not change which heading the column matches.
         $this->assertSame('full_name', Text::make('Full Name', 'full_name')->key('user_name')->headingKey());
+    }
+
+    public function test_requires_style_information_returns_false_for_self_referencing_import_without_style_columns(): void
+    {
+        $import = new class implements Import, WithMultipleSheets
+        {
+            /**
+             * @return \AnonymousClass42d46886f73874414c32315e647542c6[]
+             */
+            public function sheets(): array
+            {
+                return [$this];
+            }
+        };
+
+        $this->assertFalse(ColumnCollection::requiresStyleInformation($import));
+    }
+
+    public function test_requires_style_information_returns_false_for_new_self_cycle_without_style_columns(): void
+    {
+        $import = new class implements Import, WithMultipleSheets
+        {
+            /** @return array<int, static> */
+            public function sheets(): array
+            {
+                return [new self];
+            }
+        };
+
+        $this->assertFalse(ColumnCollection::requiresStyleInformation($import));
+    }
+
+    public function test_requires_style_information_returns_true_for_self_referencing_import_with_style_column(): void
+    {
+        $import = new class implements Import, WithColumns, WithMultipleSheets
+        {
+            /** @return array<int, static> */
+            public function sheets(): array
+            {
+                return [$this];
+            }
+
+            /**
+             * @return Hyperlink[]
+             */
+            public function columns(): array
+            {
+                return [Hyperlink::make('URL', 'url')->url()];
+            }
+        };
+
+        $this->assertTrue(ColumnCollection::requiresStyleInformation($import));
     }
 
     private function givenSheet(): Worksheet

--- a/tests/Helpers/ConcernTreeTest.php
+++ b/tests/Helpers/ConcernTreeTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Helpers;
+
+use Maatwebsite\Excel\Concerns\Import;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+use Maatwebsite\Excel\Helpers\ConcernTree;
+use Maatwebsite\Excel\Tests\TestCase;
+
+final class ConcernTreeTest extends TestCase
+{
+    public function test_flatten_null_returns_empty_storage(): void
+    {
+        $result = ConcernTree::flatten(null);
+
+        $this->assertCount(0, $result);
+    }
+
+    public function test_flatten_leaf_without_multiple_sheets_returns_just_the_leaf(): void
+    {
+        $leaf = new class implements Import
+        {
+        };
+
+        $result = ConcernTree::flatten($leaf);
+
+        $this->assertCount(1, $result);
+        $this->assertTrue($result->contains($leaf));
+    }
+
+    public function test_flatten_normal_tree_returns_all_unique_nodes(): void
+    {
+        $child1 = new class implements Import
+        {
+        };
+        $child2 = new class implements Import
+        {
+        };
+        $root = new readonly class($child1, $child2) implements Import, WithMultipleSheets
+        {
+            public function __construct(private Import $a, private Import $b)
+            {
+            }
+
+            /**
+             * @return Import[]
+             */
+            public function sheets(): array
+            {
+                return [$this->a, $this->b];
+            }
+        };
+
+        $result = ConcernTree::flatten($root);
+
+        $this->assertCount(3, $result);
+        $this->assertTrue($result->contains($root));
+        $this->assertTrue($result->contains($child1));
+        $this->assertTrue($result->contains($child2));
+    }
+
+    public function test_flatten_identity_cycle_does_not_loop(): void
+    {
+        $root = new class implements Import, WithMultipleSheets
+        {
+            /** @return array<int, static> */
+            public function sheets(): array
+            {
+                return [$this];
+            }
+        };
+
+        $result = ConcernTree::flatten($root);
+
+        $this->assertCount(1, $result);
+        $this->assertTrue($result->contains($root));
+    }
+
+    public function test_flatten_new_self_cycle_does_not_loop(): void
+    {
+        $root = new class implements Import, WithMultipleSheets
+        {
+            /** @return array<int, static> */
+            public function sheets(): array
+            {
+                return [new self];
+            }
+        };
+
+        $result = ConcernTree::flatten($root);
+
+        // Root is collected; the new instance is stopped by the class-ancestry guard.
+        $this->assertCount(1, $result);
+        $this->assertTrue($result->contains($root));
+    }
+
+    public function test_flatten_indirect_identity_cycle_does_not_loop(): void
+    {
+        $b = new class implements Import, WithMultipleSheets
+        {
+            public ?Import $parent = null;
+
+            public function sheets(): array
+            {
+                return [$this->parent];
+            }
+        };
+        $root = new readonly class($b) implements Import, WithMultipleSheets
+        {
+            public function __construct(private Import $child)
+            {
+            }
+
+            /**
+             * @return Import[]
+             */
+            public function sheets(): array
+            {
+                return [$this->child];
+            }
+        };
+        $b->parent = $root;
+
+        $result = ConcernTree::flatten($root);
+
+        $this->assertCount(2, $result);
+        $this->assertTrue($result->contains($root));
+        $this->assertTrue($result->contains($b));
+    }
+
+    public function test_flatten_indirect_class_cycle_does_not_loop(): void
+    {
+        // Use two named classes so that get_class() returns different names,
+        // but ClassB instantiates ClassA — an indirect class cycle.
+        $root = new ClassA;
+
+        $result = ConcernTree::flatten($root);
+
+        // ClassA and ClassB are both collected; the second ClassA instance is stopped.
+        $this->assertCount(2, $result);
+    }
+
+    public function test_flatten_sibling_sheets_of_same_class_are_both_collected(): void
+    {
+        $sheet1 = new class implements Import
+        {
+        };
+        $sheet2 = new class implements Import
+        {
+        };
+
+        // Same anonymous class, different instances — use a concrete wrapper.
+        $root = new readonly class($sheet1, $sheet2) implements Import, WithMultipleSheets
+        {
+            public function __construct(private Import $a, private Import $b)
+            {
+            }
+
+            /**
+             * @return Import[]
+             */
+            public function sheets(): array
+            {
+                return [$this->a, $this->b];
+            }
+        };
+
+        $result = ConcernTree::flatten($root);
+
+        $this->assertCount(3, $result);
+        $this->assertTrue($result->contains($sheet1));
+        $this->assertTrue($result->contains($sheet2));
+    }
+}
+
+// Named concrete classes so that get_class() returns stable, distinct names.
+
+class ClassA implements Import, WithMultipleSheets
+{
+    /**
+     * @return ClassB[]
+     */
+    public function sheets(): array
+    {
+        return [new ClassB];
+    }
+}
+
+class ClassB implements Import, WithMultipleSheets
+{
+    /**
+     * @return ClassA[]
+     */
+    public function sheets(): array
+    {
+        return [new ClassA];
+    }
+}


### PR DESCRIPTION
1️⃣  **Why should it be added? What are the benefits of this change?**

When a class implements `WithMultipleSheets` and returns `$this` from `sheets()` (a common pattern when you want the same object to handle a specific named sheet), Laravel Excel 4.x enters infinite recursion inside `ColumnCollection::requiresStyleInformation()`, exhausting available memory and causing a fatal error.

This was a regression introduced in 4.x. The same pattern worked fine in 3.1 because the recursive concern resolution did not exist there.

The fix introduces a `ConcernTree` helper that flattens the `WithMultipleSheets` hierarchy into a flat list while guarding against two cycle patterns:

- **Identity cycles** (`return [$this]`) -- detected via a shared `SplObjectStorage` visited set
- **Class-level cycles** (`return [new self()]` or indirect cycles like `A -> B -> new A()`) -- detected by tracking class names along the current ancestry path

Both `ColumnCollection::requiresStyleInformation()` and `WriterFactory::includesCharts()` now use this shared utility instead of rolling their own traversal, so any future concern that needs to walk the sheet tree has a safe, reusable starting point.

Fixes #4428.

2️⃣  **Does it contain multiple, unrelated changes? Please separate the PRs out.**

No, all changes are related to the same root cause.

3️⃣  **Does it include tests, if possible?**

Yes. Unit tests cover: null input, a plain leaf node, a normal multi-node tree, identity cycles, `new self()` cycles, indirect identity cycles, indirect class cycles, and sibling sheets of the same class (to guard against false positives). Regression tests verify the correct return value of `requiresStyleInformation()` for self-referencing imports.

4️⃣  **Any drawbacks? Possible breaking changes?**

No breaking changes. The public API of `ColumnCollection::requiresStyleInformation()` is unchanged. The `ConcernTree` helper is internal.

The behavior of `WriterFactory::includesCharts()` is now slightly broader: it traverses the full sheet tree rather than just one level deep. This means charts nested inside sheets-of-sheets are now correctly detected, which is a bug fix rather than a breaking change.

5️⃣  **Mark the following tasks as done:**

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌