### PR TITLE
fix: initialize Remembers `ChunkOffset/RemembersRowNumber` properties to null

### DIFF
--- a/src/Concerns/RemembersChunkOffset.php
+++ b/src/Concerns/RemembersChunkOffset.php
@@ -4,7 +4,7 @@ namespace Maatwebsite\Excel\Concerns;
 
 trait RemembersChunkOffset
 {
-    protected ?int $chunkOffset;
+    protected ?int $chunkOffset = null;
 
     public function setChunkOffset(int $chunkOffset): void
     {

--- a/src/Concerns/RemembersRowNumber.php
+++ b/src/Concerns/RemembersRowNumber.php
@@ -4,7 +4,7 @@ namespace Maatwebsite\Excel\Concerns;
 
 trait RemembersRowNumber
 {
-    protected int $rowNumber;
+    protected ?int $rowNumber = null;
 
     public function rememberRowNumber(int $rowNumber): void
     {

--- a/tests/Concerns/RemembersChunkOffsetTest.php
+++ b/tests/Concerns/RemembersChunkOffsetTest.php
@@ -13,6 +13,17 @@ use Maatwebsite\Excel\Tests\TestCase;
 
 final class RemembersChunkOffsetTest extends TestCase
 {
+    public function test_get_chunk_offset_returns_null_before_it_is_set(): void
+    {
+        $import = new class implements Import
+        {
+            use Importable;
+            use RemembersChunkOffset;
+        };
+
+        $this->assertNull($import->getChunkOffset());
+    }
+
     public function test_can_set_and_get_chunk_offset(): void
     {
         $import = new class implements Import

--- a/tests/Concerns/RemembersRowNumberTest.php
+++ b/tests/Concerns/RemembersRowNumberTest.php
@@ -14,6 +14,17 @@ use Maatwebsite\Excel\Tests\TestCase;
 
 final class RemembersRowNumberTest extends TestCase
 {
+    public function test_get_row_number_returns_null_before_it_is_remembered(): void
+    {
+        $import = new class implements Import
+        {
+            use Importable;
+            use RemembersRowNumber;
+        };
+
+        $this->assertNull($import->getRowNumber());
+    }
+
     public function test_can_set_and_get_row_number(): void
     {
         $import = new class implements Import


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?

`RemembersChunkOffset::$chunkOffset` and `RemembersRowNumber::$rowNumber` are typed properties declared without a default value. 
In PHP, a typed property without a default is left "uninitialized" rather than `null`, even when the type itself is nullable.
Both traits expose a getter (`getChunkOffset(): ?int`, `getRowNumber(): ?int`) whose return type promises `null` when no value has been set yet. 
In practice, calling either getter before the corresponding setter (`setChunkOffset()` / `rememberRowNumber()`) throws:

```php
Error: Typed property ...::$chunkOffset must not be accessed before initialization
```

instead of returning `null` as the declared type implies. This can be hit by any import class that uses these public traits and calls the getter early (e.g. in a constructor or before the first row is processed).

`RemembersRowNumber::$rowNumber` also had a non-nullable `int` type despite its getter declaring `?int`, which was itself an inconsistency independent of the initialization bug.

Therefore, this PR fixes both traits by giving the properties a `null` default (and aligning `$rowNumber`'s type with its getter), so the getters behave as their signatures promise.

2️⃣  Does it contain multiple, unrelated changes?

No, both changes are the same fix applied to two sibling traits that share the exact same bug pattern.

3️⃣  Does it include tests, if possible?

Yes.
Added a regression test to each trait's test file that calls the getter before the setter and asserts it returns `null`. 
Both new tests fail with the "must not be accessed before initialization" error against the old code and pass after the fix.

4️⃣  Any drawbacks? Possible breaking changes?

None. 
This only makes the properties behave as their existing nullable return types already promised; no public API signatures changed.

5️⃣  Tasks

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌