### PR TITLE
fix: normalize `Generator/Traversable` $keys to array in `BatchCache::getMultiple()`

### DIFF
--- a/src/Cache/BatchCache.php
+++ b/src/Cache/BatchCache.php
@@ -93,6 +93,8 @@ class BatchCache implements CacheInterface
      */
     public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
+        $keys = is_array($keys) ? $keys : iterator_to_array($keys);
+
         // Check if all keys are still in memory
         $memory = $this->memory->getMultiple($keys, $default);
         if (is_array($memory)) {

--- a/src/Cache/BatchCacheDeprecated.php
+++ b/src/Cache/BatchCacheDeprecated.php
@@ -100,6 +100,8 @@ class BatchCacheDeprecated implements CacheInterface
      */
     public function getMultiple($keys, $default = null)
     {
+        $keys = is_array($keys) ? $keys : iterator_to_array($keys);
+
         // Check if all keys are still in memory
         $memory = $this->memory->getMultiple($keys, $default);
         if (is_array($memory)) {

--- a/tests/Cache/BatchCacheTest.php
+++ b/tests/Cache/BatchCacheTest.php
@@ -90,6 +90,36 @@ final class BatchCacheTest extends TestCase
         $this->assertSame('A6-value', $cache->get('A6'));
     }
 
+    public function test_will_get_multiple_when_keys_is_a_generator(): void
+    {
+        $inMemory = [
+            'A1' => 'A1-value',
+            'A2' => 'A2-value',
+            'A3' => 'A3-value',
+        ];
+        $persisted = [
+            'A4' => 'A4-value',
+            'A5' => 'A5-value',
+            'A6' => 'A6-value',
+        ];
+
+        $cache = $this->givenCache($inMemory, $persisted);
+
+        $keys = (function () {
+            yield 'A1';
+            yield 'A2';
+            yield 'A3';
+            yield 'A4';
+            yield 'A5';
+            yield 'A6';
+        })();
+
+        $this->assertSame(
+            array_merge($inMemory, $persisted),
+            $cache->getMultiple($keys)
+        );
+    }
+
     public function test_it_persists_to_cache_when_memory_limit_reached_on_setting_a_value(): void
     {
         $memoryLimit = 3;


### PR DESCRIPTION
1️⃣  Why should it be added? What are the benefits of this change?

`Psr\SimpleCache\CacheInterface::getMultiple()` declares its `$keys` parameter as `iterable`, which per the PSR-16 spec includes any `Traversable` (e.g. a `Generator`), not just arrays.
`BatchCache::getMultiple()` (and its `BatchCacheDeprecated` counterpart) did not respect this contract:

- It called `count($keys)` to check whether all keys were found in memory. `count()` requires a `Countable` or `array`, so passing a `Generator` throws:

  ```text
  TypeError: count(): Argument #1 ($value) must be of type Countable|array, Generator given
  ```

- Even if that were fixed, `$keys` is iterated twice — once via `$this->memory->getMultiple($keys, ...)` and again via `$this->cache->getMultiple($keys, ...)` for the cache fallback. A `Generator` is consumed after the first pass, so the second iteration silently yields nothing, producing incomplete results instead of an error.

Therefore, this PR normalizes `$keys` to a plain array at the top of the method, mirroring the pattern already used by `deleteMultiple()` in the same class:

```php
$keys = is_array($keys) ? $keys : iterator_to_array($keys);
```

that is why, the method actually honors the `iterable` type it declares.

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

No.

3️⃣  Does it include tests, if possible?

Yes. 
Added `test_will_get_multiple_when_keys_is_a_generator()` to `BatchCacheTest`, which passes a `Generator` covering both the "some values in memory, some in persisted cache" case.

4️⃣  Any drawbacks? Possible breaking changes?

None expected.

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
