### PR TITLE
Refactor BatchCache and add tests

### DIFF
--- a/src/Cache/BatchCache.php
+++ b/src/Cache/BatchCache.php
@@ -93,6 +93,8 @@ class BatchCache implements CacheInterface
      */
     public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
+        $keys = is_array($keys) ? $keys : iterator_to_array($keys);
+
         // Check if all keys are still in memory
         $memory = $this->memory->getMultiple($keys, $default);
         if (is_array($memory)) {

--- a/src/Cache/BatchCache.php
+++ b/src/Cache/BatchCache.php
@@ -1,17 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Maatwebsite\Excel\Cache;
 
 use DateInterval;
-use Illuminate\Support\Facades\Cache;
+use Maatwebsite\Excel\Cache\Concerns\BatchCacheBehavior;
 use Psr\SimpleCache\CacheInterface;
 
 class BatchCache implements CacheInterface
 {
-    /**
-     * @var null|int|DateInterval|callable
-     */
-    protected $defaultTTL;
+    use BatchCacheBehavior;
 
     public function __construct(
         protected CacheInterface $cache,
@@ -22,30 +21,11 @@ class BatchCache implements CacheInterface
     }
 
     /**
-     * @return list<string>
-     */
-    public function __sleep(): array
-    {
-        return ['memory'];
-    }
-
-    public function __wakeup(): void
-    {
-        $this->cache = Cache::driver(
-            config('excel.cache.illuminate.store')
-        );
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function get(string $key, mixed $default = null): mixed
     {
-        if ($this->memory->has($key)) {
-            return $this->memory->get($key);
-        }
-
-        return $this->cache->get($key, $default);
+        return $this->doGet($key, $default);
     }
 
     /**
@@ -53,17 +33,7 @@ class BatchCache implements CacheInterface
      */
     public function set(string $key, mixed $value, null|int|DateInterval $ttl = null): bool
     {
-        if (func_num_args() === 2) {
-            $ttl = value($this->defaultTTL);
-        }
-
-        $this->memory->set($key, $value, $ttl);
-
-        if ($this->memory->reachedMemoryLimit()) {
-            return $this->cache->setMultiple($this->memory->flush(), $ttl);
-        }
-
-        return true;
+        return $this->doSet($key, $value, $ttl, func_num_args() === 3);
     }
 
     /**
@@ -71,11 +41,7 @@ class BatchCache implements CacheInterface
      */
     public function delete(string $key): bool
     {
-        if ($this->memory->has($key)) {
-            return $this->memory->delete($key);
-        }
-
-        return $this->cache->delete($key);
+        return $this->doDelete($key);
     }
 
     /**
@@ -83,9 +49,7 @@ class BatchCache implements CacheInterface
      */
     public function clear(): bool
     {
-        $this->memory->clear();
-
-        return $this->cache->clear();
+        return $this->doClear();
     }
 
     /**
@@ -93,38 +57,7 @@ class BatchCache implements CacheInterface
      */
     public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
-        $keys = is_array($keys) ? $keys : iterator_to_array($keys);
-
-        // Check if all keys are still in memory
-        $memory = $this->memory->getMultiple($keys, $default);
-        if (is_array($memory)) {
-            $actualItemsInMemory = count(array_filter($memory));
-        } else {
-            $actualItemsInMemory = 0;
-            foreach ($memory as $value) {
-                if ($value) {
-                    $actualItemsInMemory++;
-                }
-            }
-        }
-
-        if ($actualItemsInMemory === count($keys)) {
-            return $memory;
-        }
-
-        // Get all rows from cache if none is hold in memory.
-        if ($actualItemsInMemory === 0) {
-            return $this->cache->getMultiple($keys, $default);
-        }
-
-        // Add missing values from cache.
-        foreach ($this->cache->getMultiple($keys, $default) as $key => $value) {
-            if ($value !== null) {
-                $memory[$key] = $value;
-            }
-        }
-
-        return $memory;
+        return $this->doGetMultiple($keys, $default);
     }
 
     /**
@@ -134,17 +67,7 @@ class BatchCache implements CacheInterface
      */
     public function setMultiple(iterable $values, null|int|DateInterval $ttl = null): bool
     {
-        if (func_num_args() === 1) {
-            $ttl = value($this->defaultTTL);
-        }
-
-        $this->memory->setMultiple($values, $ttl);
-
-        if ($this->memory->reachedMemoryLimit()) {
-            return $this->cache->setMultiple($this->memory->flush(), $ttl);
-        }
-
-        return true;
+        return $this->doSetMultiple($values, $ttl, func_num_args() === 2);
     }
 
     /**
@@ -152,11 +75,7 @@ class BatchCache implements CacheInterface
      */
     public function deleteMultiple(iterable $keys): bool
     {
-        $keys = is_array($keys) ? $keys : iterator_to_array($keys);
-
-        $this->memory->deleteMultiple($keys);
-
-        return $this->cache->deleteMultiple($keys);
+        return $this->doDeleteMultiple($keys);
     }
 
     /**
@@ -164,10 +83,6 @@ class BatchCache implements CacheInterface
      */
     public function has(string $key): bool
     {
-        if ($this->memory->has($key)) {
-            return true;
-        }
-
-        return $this->cache->has($key);
+        return $this->doHas($key);
     }
 }

--- a/src/Cache/BatchCacheDeprecated.php
+++ b/src/Cache/BatchCacheDeprecated.php
@@ -100,6 +100,8 @@ class BatchCacheDeprecated implements CacheInterface
      */
     public function getMultiple($keys, $default = null)
     {
+        $keys = is_array($keys) ? $keys : iterator_to_array($keys);
+
         // Check if all keys are still in memory
         $memory = $this->memory->getMultiple($keys, $default);
         if (is_array($memory)) {

--- a/src/Cache/BatchCacheDeprecated.php
+++ b/src/Cache/BatchCacheDeprecated.php
@@ -2,7 +2,7 @@
 
 namespace Maatwebsite\Excel\Cache;
 
-use Illuminate\Support\Facades\Cache;
+use Maatwebsite\Excel\Cache\Concerns\BatchCacheBehavior;
 use Psr\SimpleCache\CacheInterface;
 
 /**
@@ -13,10 +13,7 @@ use Psr\SimpleCache\CacheInterface;
  */
 class BatchCacheDeprecated implements CacheInterface
 {
-    /**
-     * @var null|int|\DateInterval|\DateTimeInterface|callable
-     */
-    protected $defaultTTL = null;
+    use BatchCacheBehavior;
 
     public function __construct(
         protected CacheInterface $cache,
@@ -26,28 +23,12 @@ class BatchCacheDeprecated implements CacheInterface
         $this->defaultTTL = $defaultTTL;
     }
 
-    public function __sleep(): array
-    {
-        return ['memory'];
-    }
-
-    public function __wakeup(): void
-    {
-        $this->cache = Cache::driver(
-            config('excel.cache.illuminate.store')
-        );
-    }
-
     /**
      * {@inheritdoc}
      */
     public function get($key, $default = null)
     {
-        if ($this->memory->has($key)) {
-            return $this->memory->get($key);
-        }
-
-        return $this->cache->get($key, $default);
+        return $this->doGet($key, $default);
     }
 
     /**
@@ -57,17 +38,7 @@ class BatchCacheDeprecated implements CacheInterface
      */
     public function set($key, $value, $ttl = null)
     {
-        if (func_num_args() === 2) {
-            $ttl = value($this->defaultTTL);
-        }
-
-        $this->memory->set($key, $value, $ttl);
-
-        if ($this->memory->reachedMemoryLimit()) {
-            return $this->cache->setMultiple($this->memory->flush(), $ttl);
-        }
-
-        return true;
+        return $this->doSet($key, $value, $ttl, func_num_args() === 3);
     }
 
     /**
@@ -75,11 +46,7 @@ class BatchCacheDeprecated implements CacheInterface
      */
     public function delete($key)
     {
-        if ($this->memory->has($key)) {
-            return $this->memory->delete($key);
-        }
-
-        return $this->cache->delete($key);
+        return $this->doDelete($key);
     }
 
     /**
@@ -87,9 +54,7 @@ class BatchCacheDeprecated implements CacheInterface
      */
     public function clear()
     {
-        $this->memory->clear();
-
-        return $this->cache->clear();
+        return $this->doClear();
     }
 
     /**
@@ -100,38 +65,7 @@ class BatchCacheDeprecated implements CacheInterface
      */
     public function getMultiple($keys, $default = null)
     {
-        $keys = is_array($keys) ? $keys : iterator_to_array($keys);
-
-        // Check if all keys are still in memory
-        $memory = $this->memory->getMultiple($keys, $default);
-        if (is_array($memory)) {
-            $actualItemsInMemory = count(array_filter($memory));
-        } else {
-            $actualItemsInMemory = 0;
-            foreach ($memory as $value) {
-                if ($value) {
-                    $actualItemsInMemory++;
-                }
-            }
-        }
-
-        if ($actualItemsInMemory === count($keys)) {
-            return $memory;
-        }
-
-        // Get all rows from cache if none is hold in memory.
-        if ($actualItemsInMemory === 0) {
-            return $this->cache->getMultiple($keys, $default);
-        }
-
-        // Add missing values from cache.
-        foreach ($this->cache->getMultiple($keys, $default) as $key => $value) {
-            if ($value !== null) {
-                $memory[$key] = $value;
-            }
-        }
-
-        return $memory;
+        return $this->doGetMultiple($keys, $default);
     }
 
     /**
@@ -140,17 +74,7 @@ class BatchCacheDeprecated implements CacheInterface
      */
     public function setMultiple($values, $ttl = null)
     {
-        if (func_num_args() === 1) {
-            $ttl = value($this->defaultTTL);
-        }
-
-        $this->memory->setMultiple($values, $ttl);
-
-        if ($this->memory->reachedMemoryLimit()) {
-            return $this->cache->setMultiple($this->memory->flush(), $ttl);
-        }
-
-        return true;
+        return $this->doSetMultiple($values, $ttl, func_num_args() === 2);
     }
 
     /**
@@ -160,11 +84,7 @@ class BatchCacheDeprecated implements CacheInterface
      */
     public function deleteMultiple($keys)
     {
-        $keys = is_array($keys) ? $keys : iterator_to_array($keys);
-
-        $this->memory->deleteMultiple($keys);
-
-        return $this->cache->deleteMultiple($keys);
+        return $this->doDeleteMultiple($keys);
     }
 
     /**
@@ -172,10 +92,6 @@ class BatchCacheDeprecated implements CacheInterface
      */
     public function has($key)
     {
-        if ($this->memory->has($key)) {
-            return true;
-        }
-
-        return $this->cache->has($key);
+        return $this->doHas($key);
     }
 }

--- a/src/Cache/Concerns/BatchCacheBehavior.php
+++ b/src/Cache/Concerns/BatchCacheBehavior.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Maatwebsite\Excel\Cache\Concerns;
+
+use DateInterval;
+use DateTimeInterface;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * @internal
+ */
+trait BatchCacheBehavior
+{
+    /**
+     * @var null|int|DateInterval|DateTimeInterface|callable
+     */
+    protected $defaultTTL;
+
+    /**
+     * @return array<int, string>
+     */
+    public function __sleep(): array
+    {
+        return ['memory'];
+    }
+
+    public function __wakeup(): void
+    {
+        $this->cache = Cache::driver(
+            config('excel.cache.illuminate.store')
+        );
+    }
+
+    /**
+     * @param  mixed  $default
+     * @return mixed
+     */
+    protected function doGet(string $key, $default = null)
+    {
+        if ($this->memory->has($key)) {
+            return $this->memory->get($key);
+        }
+
+        return $this->cache->get($key, $default);
+    }
+
+    /**
+     * @param  mixed  $value
+     * @param  null|int|DateInterval  $ttl
+     */
+    protected function doSet(string $key, $value, $ttl, bool $ttlProvided): bool
+    {
+        if (!$ttlProvided) {
+            $ttl = value($this->defaultTTL);
+        }
+
+        $this->memory->set($key, $value, $ttl);
+
+        if ($this->memory->reachedMemoryLimit()) {
+            return $this->cache->setMultiple($this->memory->flush(), $ttl);
+        }
+
+        return true;
+    }
+
+    protected function doDelete(string $key): bool
+    {
+        if ($this->memory->has($key)) {
+            return $this->memory->delete($key);
+        }
+
+        return $this->cache->delete($key);
+    }
+
+    protected function doClear(): bool
+    {
+        $this->memory->clear();
+
+        return $this->cache->clear();
+    }
+
+    /**
+     * @param  iterable<string>  $keys
+     * @param  mixed  $default
+     * @return iterable<string, mixed>
+     */
+    protected function doGetMultiple(iterable $keys, $default = null): iterable
+    {
+        $keys = [...$keys];
+
+        // Check if all keys are still in memory
+        $memory = $this->memory->getMultiple($keys, $default);
+        if (!is_array($memory)) {
+            $memory = iterator_to_array($memory);
+        }
+        $actualItemsInMemory = count(array_filter($memory));
+
+        if ($actualItemsInMemory === count($keys)) {
+            return $memory;
+        }
+
+        // Get all rows from cache if none is hold in memory.
+        if ($actualItemsInMemory === 0) {
+            return $this->cache->getMultiple($keys, $default);
+        }
+
+        // Add missing values from cache.
+        foreach ($this->cache->getMultiple($keys, $default) as $key => $value) {
+            if ($value !== null) {
+                $memory[$key] = $value;
+            }
+        }
+
+        return $memory;
+    }
+
+    /**
+     * @param  iterable<string, mixed>  $values
+     * @param  null|int|DateInterval  $ttl
+     */
+    protected function doSetMultiple(iterable $values, $ttl, bool $ttlProvided): bool
+    {
+        if (!$ttlProvided) {
+            $ttl = value($this->defaultTTL);
+        }
+
+        $this->memory->setMultiple($values, $ttl);
+
+        if ($this->memory->reachedMemoryLimit()) {
+            return $this->cache->setMultiple($this->memory->flush(), $ttl);
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  iterable<string>  $keys
+     */
+    protected function doDeleteMultiple(iterable $keys): bool
+    {
+        $keys = [...$keys];
+
+        $this->memory->deleteMultiple($keys);
+
+        return $this->cache->deleteMultiple($keys);
+    }
+
+    protected function doHas(string $key): bool
+    {
+        if ($this->memory->has($key)) {
+            return true;
+        }
+
+        return $this->cache->has($key);
+    }
+}

--- a/src/Cache/Concerns/MemoryCacheBehavior.php
+++ b/src/Cache/Concerns/MemoryCacheBehavior.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Maatwebsite\Excel\Cache\Concerns;
+
+use DateInterval;
+use PhpOffice\PhpSpreadsheet\Cell\Cell;
+
+/**
+ * @internal
+ */
+trait MemoryCacheBehavior
+{
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $cache = [];
+
+    public function __construct(
+        protected ?int $memoryLimit = null,
+    ) {
+    }
+
+    public function reachedMemoryLimit(): bool
+    {
+        // When no limit is given, we'll never reach any limit.
+        if ($this->memoryLimit === null) {
+            return false;
+        }
+
+        return count($this->cache) >= $this->memoryLimit;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function flush(): array
+    {
+        $memory = $this->cache;
+
+        foreach ($memory as $cell) {
+            if ($cell instanceof Cell) {
+                $cell->detach();
+            }
+        }
+
+        $this->doClear();
+
+        return $memory;
+    }
+
+    protected function doClear(): bool
+    {
+        $this->cache = [];
+
+        return true;
+    }
+
+    protected function doDelete(string $key): bool
+    {
+        unset($this->cache[$key]);
+
+        return true;
+    }
+
+    /**
+     * @param  iterable<string>  $keys
+     */
+    protected function doDeleteMultiple(iterable $keys): bool
+    {
+        foreach ($keys as $key) {
+            $this->doDelete($key);
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  mixed  $default
+     * @return mixed
+     */
+    protected function doGet(string $key, $default = null)
+    {
+        if ($this->doHas($key)) {
+            return $this->cache[$key];
+        }
+
+        return $default;
+    }
+
+    /**
+     * @param  iterable<string>  $keys
+     * @param  mixed  $default
+     * @return array<string, mixed>
+     */
+    protected function doGetMultiple(iterable $keys, $default = null): array
+    {
+        $results = [];
+        foreach ($keys as $key) {
+            $results[$key] = $this->doGet($key, $default);
+        }
+
+        return $results;
+    }
+
+    protected function doHas(string $key): bool
+    {
+        return isset($this->cache[$key]);
+    }
+
+    /**
+     * @param  mixed  $value
+     * @param  null|int|DateInterval  $ttl
+     */
+    protected function doSet(string $key, $value, $ttl = null): bool
+    {
+        $this->cache[$key] = $value;
+
+        return true;
+    }
+
+    /**
+     * @param  iterable<string, mixed>  $values
+     * @param  null|int|DateInterval  $ttl
+     */
+    protected function doSetMultiple(iterable $values, $ttl = null): bool
+    {
+        foreach ($values as $key => $value) {
+            $this->doSet($key, $value);
+        }
+
+        return true;
+    }
+}

--- a/src/Cache/MemoryCache.php
+++ b/src/Cache/MemoryCache.php
@@ -1,30 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Maatwebsite\Excel\Cache;
 
 use DateInterval;
-use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use Maatwebsite\Excel\Cache\Concerns\MemoryCacheBehavior;
 
 class MemoryCache implements MemoryInterface
 {
-    /**
-     * @var array<string, mixed>
-     */
-    protected array $cache = [];
-
-    public function __construct(
-        protected ?int $memoryLimit = null,
-    ) {
-    }
+    use MemoryCacheBehavior;
 
     /**
      * {@inheritdoc}
      */
     public function clear(): bool
     {
-        $this->cache = [];
-
-        return true;
+        return $this->doClear();
     }
 
     /**
@@ -32,9 +24,7 @@ class MemoryCache implements MemoryInterface
      */
     public function delete(string $key): bool
     {
-        unset($this->cache[$key]);
-
-        return true;
+        return $this->doDelete($key);
     }
 
     /**
@@ -42,11 +32,7 @@ class MemoryCache implements MemoryInterface
      */
     public function deleteMultiple($keys): bool
     {
-        foreach ($keys as $key) {
-            $this->delete($key);
-        }
-
-        return true;
+        return $this->doDeleteMultiple($keys);
     }
 
     /**
@@ -54,11 +40,7 @@ class MemoryCache implements MemoryInterface
      */
     public function get(string $key, mixed $default = null): mixed
     {
-        if ($this->has($key)) {
-            return $this->cache[$key];
-        }
-
-        return $default;
+        return $this->doGet($key, $default);
     }
 
     /**
@@ -66,12 +48,7 @@ class MemoryCache implements MemoryInterface
      */
     public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
-        $results = [];
-        foreach ($keys as $key) {
-            $results[$key] = $this->get($key, $default);
-        }
-
-        return $results;
+        return $this->doGetMultiple($keys, $default);
     }
 
     /**
@@ -79,7 +56,7 @@ class MemoryCache implements MemoryInterface
      */
     public function has($key): bool
     {
-        return isset($this->cache[$key]);
+        return $this->doHas($key);
     }
 
     /**
@@ -87,9 +64,7 @@ class MemoryCache implements MemoryInterface
      */
     public function set(string $key, mixed $value, null|int|DateInterval $ttl = null): bool
     {
-        $this->cache[$key] = $value;
-
-        return true;
+        return $this->doSet($key, $value, $ttl);
     }
 
     /**
@@ -99,38 +74,6 @@ class MemoryCache implements MemoryInterface
      */
     public function setMultiple($values, $ttl = null): bool
     {
-        foreach ($values as $key => $value) {
-            $this->set($key, $value);
-        }
-
-        return true;
-    }
-
-    public function reachedMemoryLimit(): bool
-    {
-        // When no limit is given, we'll never reach any limit.
-        if ($this->memoryLimit === null) {
-            return false;
-        }
-
-        return count($this->cache) >= $this->memoryLimit;
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    public function flush(): array
-    {
-        $memory = $this->cache;
-
-        foreach ($memory as $cell) {
-            if ($cell instanceof Cell) {
-                $cell->detach();
-            }
-        }
-
-        $this->clear();
-
-        return $memory;
+        return $this->doSetMultiple($values, $ttl);
     }
 }

--- a/src/Cache/MemoryCacheDeprecated.php
+++ b/src/Cache/MemoryCacheDeprecated.php
@@ -2,7 +2,7 @@
 
 namespace Maatwebsite\Excel\Cache;
 
-use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use Maatwebsite\Excel\Cache\Concerns\MemoryCacheBehavior;
 
 /**
  * Used when psr/simple-cache is ^1.0 or ^2.0.
@@ -12,24 +12,14 @@ use PhpOffice\PhpSpreadsheet\Cell\Cell;
  */
 class MemoryCacheDeprecated implements MemoryInterface
 {
-    /**
-     * @var array<string, mixed>
-     */
-    protected array $cache = [];
-
-    public function __construct(
-        protected ?int $memoryLimit = null,
-    ) {
-    }
+    use MemoryCacheBehavior;
 
     /**
      * {@inheritdoc}
      */
     public function clear()
     {
-        $this->cache = [];
-
-        return true;
+        return $this->doClear();
     }
 
     /**
@@ -37,9 +27,7 @@ class MemoryCacheDeprecated implements MemoryInterface
      */
     public function delete($key)
     {
-        unset($this->cache[$key]);
-
-        return true;
+        return $this->doDelete($key);
     }
 
     /**
@@ -49,11 +37,7 @@ class MemoryCacheDeprecated implements MemoryInterface
      */
     public function deleteMultiple($keys)
     {
-        foreach ($keys as $key) {
-            $this->delete($key);
-        }
-
-        return true;
+        return $this->doDeleteMultiple($keys);
     }
 
     /**
@@ -61,11 +45,7 @@ class MemoryCacheDeprecated implements MemoryInterface
      */
     public function get($key, $default = null)
     {
-        if ($this->has($key)) {
-            return $this->cache[$key];
-        }
-
-        return $default;
+        return $this->doGet($key, $default);
     }
 
     /**
@@ -76,12 +56,7 @@ class MemoryCacheDeprecated implements MemoryInterface
      */
     public function getMultiple($keys, $default = null)
     {
-        $results = [];
-        foreach ($keys as $key) {
-            $results[$key] = $this->get($key, $default);
-        }
-
-        return $results;
+        return $this->doGetMultiple($keys, $default);
     }
 
     /**
@@ -89,7 +64,7 @@ class MemoryCacheDeprecated implements MemoryInterface
      */
     public function has($key)
     {
-        return isset($this->cache[$key]);
+        return $this->doHas($key);
     }
 
     /**
@@ -99,9 +74,7 @@ class MemoryCacheDeprecated implements MemoryInterface
      */
     public function set($key, $value, $ttl = null)
     {
-        $this->cache[$key] = $value;
-
-        return true;
+        return $this->doSet($key, $value, $ttl);
     }
 
     /**
@@ -110,35 +83,6 @@ class MemoryCacheDeprecated implements MemoryInterface
      */
     public function setMultiple($values, $ttl = null)
     {
-        foreach ($values as $key => $value) {
-            $this->set($key, $value);
-        }
-
-        return true;
-    }
-
-    public function reachedMemoryLimit(): bool
-    {
-        // When no limit is given, we'll never reach any limit.
-        if ($this->memoryLimit === null) {
-            return false;
-        }
-
-        return count($this->cache) >= $this->memoryLimit;
-    }
-
-    public function flush(): array
-    {
-        $memory = $this->cache;
-
-        foreach ($memory as $cell) {
-            if ($cell instanceof Cell) {
-                $cell->detach();
-            }
-        }
-
-        $this->clear();
-
-        return $memory;
+        return $this->doSetMultiple($values, $ttl);
     }
 }

--- a/tests/Cache/BatchCacheTest.php
+++ b/tests/Cache/BatchCacheTest.php
@@ -18,6 +18,7 @@ use Maatwebsite\Excel\Cache\BatchCacheDeprecated;
 use Maatwebsite\Excel\Cache\CacheManager;
 use Maatwebsite\Excel\Cache\MemoryInterface;
 use Maatwebsite\Excel\Tests\TestCase;
+use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\SimpleCache\CacheInterface;
 use Psr\SimpleCache\InvalidArgumentException;
@@ -117,6 +118,28 @@ final class BatchCacheTest extends TestCase
         $this->assertSame(
             array_merge($inMemory, $persisted),
             $cache->getMultiple($keys)
+        );
+    }
+
+    public function test_will_get_multiple_when_memory_reports_items_via_a_non_array_iterable(): void
+    {
+        $memory = Mockery::mock(MemoryInterface::class);
+        $memory->shouldReceive('getMultiple')
+            ->once()
+            ->with(['A1', 'A2', 'A3'], null)
+            ->andReturnUsing(function () {
+                yield 'A1' => 'A1-value';
+                yield 'A2' => 'A2-value';
+                yield 'A3' => null;
+            });
+
+        $store = new ArrayStore;
+        $store->putMany(['A3' => 'A3-value'], 10000);
+        $cache = $this->makeBatchCache(new Repository($store), $memory);
+
+        $this->assertSame(
+            ['A1' => 'A1-value', 'A2' => 'A2-value', 'A3' => 'A3-value'],
+            $cache->getMultiple(['A1', 'A2', 'A3'])
         );
     }
 
@@ -342,9 +365,6 @@ final class BatchCacheTest extends TestCase
     }
 
     /**
-     * Construct a BatchCache with a in memory store
-     * and an array cache, pretending to be a persistence store.
-     *
      * @param  array<string, mixed>  $memory
      * @param  array<string, mixed>  $persisted
      *
@@ -363,17 +383,22 @@ final class BatchCacheTest extends TestCase
 
         $this->cache = new Repository($store);
 
+        return $this->makeBatchCache($this->cache, $this->memory);
+    }
+
+    private function makeBatchCache(CacheInterface $cache, MemoryInterface $memory): CacheInterface
+    {
         if (!InstalledVersions::satisfies(new VersionParser, 'psr/simple-cache', '^3.0')) {
             return new BatchCacheDeprecated(
-                $this->cache,
-                $this->memory,
+                $cache,
+                $memory,
                 config('excel.cache.default_ttl')
             );
         }
 
         return new BatchCache(
-            $this->cache,
-            $this->memory,
+            $cache,
+            $memory,
             config('excel.cache.default_ttl')
         );
     }

--- a/tests/Cache/BatchCacheTest.php
+++ b/tests/Cache/BatchCacheTest.php
@@ -90,6 +90,36 @@ final class BatchCacheTest extends TestCase
         $this->assertSame('A6-value', $cache->get('A6'));
     }
 
+    public function test_will_get_multiple_when_keys_is_a_generator(): void
+    {
+        $inMemory = [
+            'A1' => 'A1-value',
+            'A2' => 'A2-value',
+            'A3' => 'A3-value',
+        ];
+        $persisted = [
+            'A4' => 'A4-value',
+            'A5' => 'A5-value',
+            'A6' => 'A6-value',
+        ];
+
+        $cache = $this->givenCache($inMemory, $persisted);
+
+        $keys = (function () {
+            yield 'A1';
+            yield 'A2';
+            yield 'A3';
+            yield 'A4';
+            yield 'A5';
+            yield 'A6';
+        })();
+
+        $this->assertSame(
+            array_merge($inMemory, $persisted),
+            $cache->getMultiple($keys)
+        );
+    }
+
     public function test_it_persists_to_cache_when_memory_limit_reached_on_setting_a_value(): void
     {
         $memoryLimit = 3;

--- a/tests/Cache/MemoryCacheTest.php
+++ b/tests/Cache/MemoryCacheTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maatwebsite\Excel\Tests\Cache;
+
+use Maatwebsite\Excel\Cache\CacheManager;
+use Maatwebsite\Excel\Cache\MemoryInterface;
+use Maatwebsite\Excel\Tests\TestCase;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+final class MemoryCacheTest extends TestCase
+{
+    public function test_get_returns_default_when_key_is_absent(): void
+    {
+        $memory = $this->givenMemory();
+
+        $this->assertNull($memory->get('A1'));
+        $this->assertSame('default', $memory->get('A1', 'default'));
+    }
+
+    public function test_set_and_get_roundtrip(): void
+    {
+        $memory = $this->givenMemory();
+
+        $this->assertTrue($memory->set('A1', 'A1-value'));
+        $this->assertSame('A1-value', $memory->get('A1'));
+    }
+
+    public function test_has_returns_true_when_present_and_false_when_absent(): void
+    {
+        $memory = $this->givenMemory();
+        $memory->set('A1', 'A1-value');
+
+        $this->assertTrue($memory->has('A1'));
+        $this->assertFalse($memory->has('A2'));
+    }
+
+    public function test_delete_removes_a_value(): void
+    {
+        $memory = $this->givenMemory();
+        $memory->set('A1', 'A1-value');
+
+        $this->assertTrue($memory->delete('A1'));
+        $this->assertFalse($memory->has('A1'));
+    }
+
+    public function test_delete_multiple_removes_several_values(): void
+    {
+        $memory = $this->givenMemory();
+        $memory->setMultiple(['A1' => 'A1-value', 'A2' => 'A2-value', 'A3' => 'A3-value']);
+
+        $this->assertTrue($memory->deleteMultiple(['A1', 'A2']));
+        $this->assertFalse($memory->has('A1'));
+        $this->assertFalse($memory->has('A2'));
+        $this->assertTrue($memory->has('A3'));
+    }
+
+    public function test_set_multiple_and_get_multiple_roundtrip(): void
+    {
+        $memory = $this->givenMemory();
+
+        $this->assertTrue($memory->setMultiple(['A1' => 'A1-value', 'A2' => 'A2-value']));
+        $this->assertSame(
+            ['A1' => 'A1-value', 'A2' => 'A2-value', 'A3' => null],
+            $memory->getMultiple(['A1', 'A2', 'A3'])
+        );
+    }
+
+    public function test_clear_empties_the_cache(): void
+    {
+        $memory = $this->givenMemory();
+        $memory->setMultiple(['A1' => 'A1-value', 'A2' => 'A2-value']);
+
+        $this->assertTrue($memory->clear());
+        $this->assertFalse($memory->has('A1'));
+        $this->assertFalse($memory->has('A2'));
+    }
+
+    public function test_reached_memory_limit_is_always_false_without_a_configured_limit(): void
+    {
+        $memory = $this->givenMemory();
+
+        for ($i = 0; $i < 10; $i++) {
+            $memory->set("A{$i}", "A{$i}-value");
+        }
+
+        $this->assertFalse($memory->reachedMemoryLimit());
+    }
+
+    public function test_reached_memory_limit_becomes_true_once_the_limit_is_hit(): void
+    {
+        $memory = $this->givenMemory(2);
+
+        $this->assertFalse($memory->reachedMemoryLimit());
+
+        $memory->set('A1', 'A1-value');
+        $this->assertFalse($memory->reachedMemoryLimit());
+
+        $memory->set('A2', 'A2-value');
+        $this->assertTrue($memory->reachedMemoryLimit());
+    }
+
+    public function test_flush_returns_all_values_and_empties_the_cache(): void
+    {
+        $memory = $this->givenMemory();
+        $memory->setMultiple(['A1' => 'A1-value', 'A2' => 'A2-value']);
+
+        $this->assertSame(
+            ['A1' => 'A1-value', 'A2' => 'A2-value'],
+            $memory->flush()
+        );
+        $this->assertFalse($memory->has('A1'));
+        $this->assertFalse($memory->has('A2'));
+    }
+
+    public function test_flush_detaches_any_cached_spreadsheet_cells(): void
+    {
+        $spreadsheet = new Spreadsheet;
+        $sheet       = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', 'A1-value');
+        $cell = $sheet->getCell('A1');
+
+        $this->assertInstanceOf(Worksheet::class, $cell->getWorksheetOrNull());
+
+        $memory = $this->givenMemory();
+        $memory->set('A1', $cell);
+
+        $flushed = $memory->flush();
+
+        $this->assertSame($cell, $flushed['A1']);
+        $this->assertNotInstanceOf(Worksheet::class, $cell->getWorksheetOrNull());
+    }
+
+    private function givenMemory(?int $memoryLimit = null): MemoryInterface
+    {
+        config()->set('excel.cache.batch.memory_limit', $memoryLimit ?: 60000);
+
+        return $this->app->make(CacheManager::class)->createMemoryDriver();
+    }
+}


### PR DESCRIPTION
**1️⃣ Why should it be added? What are the benefits of this change?**

`BatchCache`/`MemoryCache` and their `BatchCacheDeprecated`/`MemoryCacheDeprecated` counterparts (kept around so we still support `psr/simple-cache` ^1.0 and ^2.0, whose `CacheInterface` predates native PHP types) had grown into four files carrying almost the exact same logic, just with typed vs untyped method signatures. Any bug fix or behavior change had to be applied twice by hand, and it was easy to let the two drift.

This PR moves the shared logic into two internal traits, `Concerns/BatchCacheBehavior` and `Concerns/MemoryCacheBehavior`. Each of the four classes keeps its own public `CacheInterface` method signatures (typed or untyped, whichever it needs), but the bodies now delegate to untyped `do*` helper methods that live in one place. No more copy-pasting a fix across four files.

While adding coverage for this, I ran into a real bug: when a custom `MemoryInterface` implementation returns a non-array iterable from `getMultiple()`, the partial-match branch wrote into it as if it were always an array, which blows up with "Cannot use object of type Generator as array". Fixed by normalizing that value to an array up front.

This branch also includes #4432 from @zigzagdev, cherry-picked as its own commit so the original authorship stays intact. That PR fixes a related but distinct issue: `$keys` itself being a non-array iterable (rather than the memory driver's return value). Both fixes now live in the shared trait.

**2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.**

It's one cohesive change (deduplicating the cache classes), but it does carry a few pieces that come along with that:

- The trait extraction itself, with both `Concerns` traits marked `@internal`.
- The `getMultiple()` non-array `$memory` fix, found via the new tests.
- @zigzagdev's `$keys` normalization fix from #4432, cherry-picked with credit intact.
- A follow-up simplification: both `$keys` normalizations now use the spread operator (`[...$keys]`) instead of an `is_array()` check plus `iterator_to_array()`, which handles arrays and Traversables in one expression.

I kept these together because the trait extraction is what made the `$memory` bug visible in the first place, and separating them out would mean re-splitting logic that only exists as one diff right now.

**3️⃣ Does it include tests, if possible?**

Yes. Added `tests/Cache/MemoryCacheTest.php`, which didn't exist before, covering `MemoryCache`/`MemoryCacheDeprecated` directly: get/set/has/delete/deleteMultiple/clear/setMultiple/getMultiple, `reachedMemoryLimit()`, and `flush()` including its `Cell::detach()` cleanup. Also added a `BatchCacheTest` case for a `MemoryInterface` returning a non-array iterable from `getMultiple()`, which is what caught the bug above.


**4️⃣ Any drawbacks? Possible breaking changes?**

None intended. All four classes keep their existing public signatures and behavior, so this should be invisible to anyone using the cache drivers. `__sleep`/`__wakeup` and the untyped `Deprecated` signatures are carried over unchanged (see #4372 for why those stay untyped).

**5️⃣ Mark the following tasks as done:**

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.

**6️⃣ Thanks for contributing! 🙌**